### PR TITLE
Remove character limit on name column for model.

### DIFF
--- a/sqitch/gms/deploy/unconstrain_model_name_length.sql
+++ b/sqitch/gms/deploy/unconstrain_model_name_length.sql
@@ -1,0 +1,8 @@
+-- Deploy unconstrain_model_name_length
+-- requires: model_model
+
+BEGIN;
+
+  ALTER TABLE model.model ALTER COLUMN name TYPE text;
+
+COMMIT;

--- a/sqitch/gms/revert/unconstrain_model_name_length.sql
+++ b/sqitch/gms/revert/unconstrain_model_name_length.sql
@@ -1,0 +1,7 @@
+-- Revert unconstrain_model_name_length
+
+BEGIN;
+
+  ALTER TABLE model.feature_list ALTER COLUMN name TYPE varchar(255);
+
+COMMIT;

--- a/sqitch/gms/sqitch.plan
+++ b/sqitch/gms/sqitch.plan
@@ -321,3 +321,6 @@ add_config_id_to_anp_model_bridges [config_analysis_project_model_bridge] 2014-0
 
 config.subject_mapping_subject_index [config.subject_mapping] 2014-08-14T19:33:06Z Thomas B. Mooney <tmooney@genome.wustl.edu> # add index to speed up query in CQID
 @1408045247 2014-08-14T19:40:48Z Thomas B. Mooney <tmooney@genome.wustl.edu># Added index on query frequently used by CQID
+
+unconstrain_model_name_length [model_model] 2014-09-04T13:19:39Z Thomas B. Mooney <tmooney@genome.wustl.edu> # remove 255 char limit on names
+@1409840677 2014-09-04T14:24:38Z Thomas B. Mooney <tmooney@genome.wustl.edu># Allow longer names for models.

--- a/sqitch/gms/verify/unconstrain_model_name_length.sql
+++ b/sqitch/gms/verify/unconstrain_model_name_length.sql
@@ -1,0 +1,9 @@
+-- Verify unconstrain_model_name_length
+
+BEGIN;
+
+  SELECT 1/(character_maximum_length IS NULL)::int b
+  FROM information_schema.columns
+  WHERE table_schema = 'model' AND table_name = 'model' AND column_name = 'name';
+
+ROLLBACK;


### PR DESCRIPTION
Our default model names for capture models include the FeatureList name.  Sometime back the limit on FL names was expanded from 200 characters so now we've encountered a FL name that overflows the maximum model name length.  This change permits any length model name (up to PG's limit for a "text" field).  The class definition in Model.pm already lacked a length specification.
