### PR TITLE
+ account for breakdancer version 1.4.5

### DIFF
--- a/lib/perl/Genome/Model/Tools/Breakdancer.pm
+++ b/lib/perl/Genome/Model/Tools/Breakdancer.pm
@@ -81,6 +81,11 @@ my %BREAKDANCER_VERSIONS = (
         cfg => 'usr/lib/breakdancer-max1.4.2/bam2cfg.pl',
         max => 'usr/bin/breakdancer-max1.4.2',
     },
+    '1.4.5' => {
+        dir => '/',
+        cfg => 'usr/lib/breakdancer-max1.4.5/bam2cfg.pl',
+        max => 'usr/bin/breakdancer-max1.4.5',
+    },
 );
 
 


### PR DESCRIPTION
- add breakdancer version 1.4.5 to the BREAKDANCER_VERSIONS hash
