### PR TITLE
Somatic Validation profiles now have bam_readcount_version. 

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation.pm
@@ -7,6 +7,12 @@ use Genome;
 
 class Genome::Model::SomaticValidation {
     is  => 'Genome::Model::Detail::RunsVariantReporting',
+    has_param => [
+        bam_readcount_version => {
+            is => 'Text',
+            doc => 'The bam readcount version to use',
+        },
+    ],
     has_param_optional => [
         alignment_strategy => {
             is => 'Text',

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ReviewVariants.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ReviewVariants.pm
@@ -935,6 +935,7 @@ sub gather_new_sites {
             variant_file => "$snv_file",
             reference => $ref_seq_fasta,
             filtered_file => "$snv_file.failuhc",
+            bam_readcount_version => $build->processing_profile->bam_readcount_version,
         );
         unless ($uhc_cmd->execute) {
             die $self->error_message("Failed to run UHC filter.");

--- a/lib/perl/Genome/Test/Factory/ProcessingProfile/SomaticValidation.pm
+++ b/lib/perl/Genome/Test/Factory/ProcessingProfile/SomaticValidation.pm
@@ -2,4 +2,13 @@ package Genome::Test::Factory::ProcessingProfile::SomaticValidation;
 use Genome::Test::Factory::ProcessingProfile;
 @ISA = (Genome::Test::Factory::ProcessingProfile);
 
+use strict;
+use warnings;
+
+our @required_params = qw(bam_readcount_version);
+
+sub create_bam_readcount_version {
+    return Genome::Model::Tools::Sam::Readcount->default_version;
+}
+
 1;


### PR DESCRIPTION
This is causing somatic validation model tests to fail. I've backfilled the bam_readcount_version in all somatic validation processing profiles to 0.4 which is the old default.
