### PR TITLE
Remove unused 'completed' allocation status

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -71,7 +71,7 @@ class Genome::Disk::Allocation {
         },
         status => {
             is => 'Text',
-            valid_values => ['active', 'completed', 'purged', 'archived', 'invalid'],
+            valid_values => ['active', 'purged', 'archived', 'invalid'],
             doc => 'The current status of this allocation',
             default_value => 'active',
         },


### PR DESCRIPTION
I feel silly making a pull request for a one-line change...

See also: https://github.com/genome/genome/pull/8

```
$ psql -U genome -c "SELECT status, COUNT(allocation) FROM disk.allocation GROUP BY status"
  status  |  count
----------+---------
 invalid  |    2713
 purged   |  975666
 archived |  293582
 active   | 9689992
```
