### PR TITLE
Update expected case to account for new seq-grind version.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeBam.t
@@ -11,7 +11,7 @@ require File::Compare;
 use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::SanitizeBam') or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'bam/v1') or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'bam/v5') or die;
 
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
 my $dirty_bam_path = $tmp_dir.'/input.bam';


### PR DESCRIPTION
The deployed seq-grind version changed locally, which handles the sam headers slightly differently.  Assuming that's okay, this commit updates our expected case for the SanitizeBam test.
