### PR TITLE
change query_tcga_barcode timeout, sleep, and attempts

### DIFF
--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.pm
@@ -393,9 +393,12 @@ sub query_tcga_barcode {
     my %argv = @_;
 
     my $url = delete $argv{url} || 'https://tcga-data.nci.nih.gov/uuid/uuidws/mapping/json/barcode/batch';
-    my $sleep = delete $argv{sleep} || 60;
+    my $sleep = delete $argv{sleep} || 10;
 
     my $agent = LWP::UserAgent->new();
+
+    # based on instrumentation the upper bound on response times is 700 ms
+    $agent->timeout(5);
 
     my $request = HTTP::Request->new(POST => $url);
     $request->content_type('text/plain');
@@ -412,7 +415,7 @@ sub query_tcga_barcode {
             }
         );
         return $rv;
-    }, sleep => $sleep, attempts => 5);
+    }, sleep => $sleep, attempts => 8);
     if ($attempts) {
         Genome::Utility::Instrumentation::gauge(
             join('.', @prefix, 'retry_attempts'), $attempts,


### PR DESCRIPTION
Previous, default timeout was 180s, sleep was 60s, and attempts was 5. This
mean query_tcga_barcode would hang for 20 minutes is the TCGA UUID Browser was
down.  Instrumentation so far shows that so far it has always either succeeded
on the first attempt or failed and that the upper bound on average successful
response times was 700 ms.

Now the default timeout is 5s (much greater than 700ms), sleep is 10s, and
attempts is 8 which means query_tcga_barcode will hang for 2 minutes if the
TCGA UUID Browser is down.

This will prevent tests from failing and should, presumably, not cause an
increase in failure rates (due to the first attempt succeeds or it fails). 
Future instrumentation values will allow us to verify.
