### PR TITLE
Allow archived disk allocations to be deleted directly from tape

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -329,22 +329,12 @@ sub _delete {
     }
 
     my $self = $class->get($id);
-    my $path = $self->absolute_path;
 
     $self->_delete_timeline_events;
+    my @deletion_observers = $self->_get_deletion_observers;
     $self->SUPER::delete;
 
-    if ($self->is_archived) {
-        $class->_create_observer(sub {
-            $class->_cleanup_archive_directory($path);
-        });
-
-    } else {
-        $class->_create_observer(
-            $class->_mark_for_deletion_closure($path),
-            $class->_remove_directory_closure($path),
-        );
-    }
+    $class->_create_observer(@deletion_observers);
 
     return 1;
 }
@@ -355,6 +345,24 @@ sub _delete_timeline_events {
     for my $event ($self->timeline_events) {
         $event->delete();
     }
+}
+
+sub _get_deletion_observers {
+    my $self = shift;
+
+    my $class = $self->class;
+    my $path = $self->absolute_path;
+
+    if ($self->is_archived) {
+        return sub {$class->_cleanup_archive_directory($path)};
+
+    } else {
+        return (
+            $class->_mark_for_deletion_closure($path),
+            $class->_remove_directory_closure($path),
+        );
+    }
+
 }
 
 sub _reallocate {


### PR DESCRIPTION
This solves the issue with the sync cron.  The failure of the sync cron is blocking high priority data, so quick review is appreciated.
