### PR TITLE
Remove check for useless, deleted default database

### DIFF
--- a/lib/perl/Genome/Model/Tools/ViromeEvent/BlastHumanGenome/InnerCheckOutput.t
+++ b/lib/perl/Genome/Model/Tools/ViromeEvent/BlastHumanGenome/InnerCheckOutput.t
@@ -7,8 +7,6 @@ use above 'Genome';
 use Test::More;
 
 use_ok('Genome::Model::Tools::ViromeEvent::BlastHumanGenome::InnerCheckOutput') or die;
-#check blast dir .. testing on already completed, no-run, blast data so tool won't know if blast db is missing
-ok( -s '/gscmnt/sata835/info/medseq/virome/blast_db/human_genomic/2009_07_09.humna_genomic', "Blast db exists");
 
 my $file_to_run = $ENV{GENOME_TEST_INPUTS} . '/Genome-Model-Tools-ViromeScreening/Titanium17/Titanium17_undecodable/Titanium17_undecodable.fa.cdhit_out.masked.goodSeq_HGblast/Titanium17_undecodable.fa.cdhit_out.masked.goodSeq_file0.fa';
 ok( -s $file_to_run, "Test fasta file exists" ) or die;


### PR DESCRIPTION
Despite evidence to the contrary, the user claims this is still in use.  Remove the offending line in the test that references data she claims is not in use so that tests pass.
