### PR TITLE
Skip possible header lines less aggressively in G:M:T:A:Coverage:BamReadcount

### DIFF
--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/AddReadcounts.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/AddReadcounts.pm
@@ -248,7 +248,7 @@ sub execute {
             chomp($sline);
 
             if($count == 0){ #check for header
-                if($sline =~ /^(#|Hugo_Symbol|chr\s)/i){
+                if($sline =~ /^(#|Hugo_Symbol|Chrom|chromosome|chr\s)/i) {
                     #good header match
                     if(defined($header_prefixes[$prefix-1])){
                         my $pre = $header_prefixes[$prefix-1];

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
@@ -279,7 +279,8 @@ sub execute {
         chomp($sline);
 
         #skip header lines
-        next if ($on_first_line && ($sline =~ /^(#|Hugo_Symbol|chr\s)/i));
+        next if ($on_first_line
+            && ($sline =~ /^(#|Hugo_Symbol|Chrom|chromosome|chr\s)/i));
         $on_first_line = 0;
 
         my @fields = split("\t",$sline);


### PR DESCRIPTION
There are no tests for these tools.  I have manually run them (specifically `add-readcounts`) on user data that triggered the bug.

The `variant_file` input to BamReadcount was filtering every line as though it could be a header.  This PR makes it consider only the first line in the file.  It was also filtering too aggressively for one user's needs (see support queue).
