### PR TITLE
Fix G:D:A _cleanup_archive_directory

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -883,7 +883,7 @@ sub _retrieve_mode {
 
 sub _cleanup_archive_directory {
     my ($class, $directory) = @_;
-    my $cmd = "if [ -d $directory ] ; then rm -rf $directory ; fi";
+    my $cmd = "if [ -d $directory ] ; then rm -rf $directory ; else exit 1; fi";
     unless ($ENV{UR_DBI_NO_COMMIT}) {
         my ($job_id, $status) = Genome::Sys->bsub_and_wait(
             queue => $ENV{GENOME_ARCHIVE_LSF_QUEUE},


### PR DESCRIPTION
@nnutter and I discovered some questionable behavior while looking into a question he raised in #39, resulting in these changes.

It appears that this code would never actually execute `rm -rf $directory`, since the lack of a space between `$directory` and `]` resulted in a syntax error that caused the if statement to not execute the true code path.  These changes make it possible for the test to succeed, and also notify us in the case of failure.

It might be the case that this function was intended to silently fail, though I'm not sure exactly why that would be needed right now.
