### PR TITLE
_reload_allocation also gets called after allocations are deleted

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -620,7 +620,9 @@ sub _reload_allocation {
         $allocation = Genome::Disk::Allocation->get($id);
     } elsif ($mode eq 'load') {
         $allocation = UR::Context->current->reload($class, id => $id);
-        UR::Context->current->reload($allocation->owner_class_name, id => $allocation->owner_id);
+        if ($allocation) {
+            UR::Context->current->reload($allocation->owner_class_name, id => $allocation->owner_id);
+        }
     } else {
         die 'Unrecognized _retrieve_mode: ' . $class->_retrieve_mode;
     }


### PR DESCRIPTION
I think this should fix the model test failures.
