### PR TITLE
Only reload the Allocation's owner if there's an existing object.

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -641,7 +641,7 @@ sub _reload_allocation {
         $allocation = UR::Context->current->reload($class, id => $id);
         if ($allocation) {
             my $owner = $allocation->owner;
-            if($owner and exists $owner->{db_committed}) {
+            if($owner and UR::Context->current->object_exists_in_underlying_context($owner)) {
                 UR::Context->current->reload($owner);
             }
         }


### PR DESCRIPTION
Otherwise the new object gets dropped instead.

We noticed this when `genome analysis-project add-config-item` mysteriously stopped issuing SQL to save the new object, although it did save the timeline event and allocation.
