### PR TITLE
Picard "Standard" SamToFastq Updates

### DIFF
--- a/lib/perl/Genome/Model/Tools/Picard/StandardSamToFastq.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/StandardSamToFastq.pm
@@ -24,7 +24,7 @@ class Genome::Model::Tools::Picard::StandardSamToFastq {
         },
         re_reverse => {
             is          => 'Boolean',
-            default     => 0,
+            default     => 1,
             doc         => 'Whether or not to re-reverse reads and qualities reported as negative strand.',
         },
         output_per_rg => {
@@ -88,7 +88,7 @@ sub execute {
     my @args;
 
     push @args,
-        map { $make_arg->($self, $_, 0) } ('input', 'fastq', 'second_end_fastq', 'output_dir');
+        map { $make_arg->($self, $_, 0) } ('input', 'fastq', 'second_end_fastq', 'output_dir','max_records_in_ram');
     push @args,
         map { $make_arg->($self, $_, 1) } ('re_reverse', 'output_per_rg', 'include_non_pf_reads', 'include_non_primary_alignments');
 

--- a/lib/perl/Genome/Model/Tools/Picard/StandardSamToFastq.t
+++ b/lib/perl/Genome/Model/Tools/Picard/StandardSamToFastq.t
@@ -17,7 +17,7 @@ BEGIN {
        plan skip_all => 'requires 64-bit machine';
     }
     else {
-       plan tests => 9;
+       plan tests => 13;
     }
 };
 
@@ -49,7 +49,6 @@ isa_ok($cmd_1, 'Genome::Model::Tools::Picard::StandardSamToFastq');
 ok( $cmd_1->execute, 'execute' );
 ok( -s $fq1,         'output file is non-zero' );
 ok( -s $fq2,         'output file is non-zero' );
-
 unlink($fq1->stringify, $fq2->stringify);
 
 my $cmd_2  = Genome::Model::Tools::Picard::StandardSamToFastq->create(
@@ -64,5 +63,20 @@ isa_ok($cmd_2, 'Genome::Model::Tools::Picard::StandardSamToFastq');
 ok( $cmd_2->execute, 'execute' );
 ok( -s $fq1,         'output file is non-zero' );
 ok( -s $fq2,         'output file is non-zero' );
+unlink($fq1->stringify, $fq2->stringify);
+
+my $cmd_3  = Genome::Model::Tools::Picard::StandardSamToFastq->create(
+    input  => $bam . '',
+    fastq  => $fq1 . '',
+    second_end_fastq => $fq2 . '',
+    re_reverse => 1,
+    use_version => '1.113'
+);
+isa_ok($cmd_3, 'Genome::Model::Tools::Picard::StandardSamToFastq');
+ok( $cmd_3->execute, 'execute' );
+ok( -s $fq1,         'output file is non-zero' );
+ok( -s $fq2,         'output file is non-zero' );
+unlink($fq1->stringify, $fq2->stringify);
+
 
 $tmpdir->rmtree;


### PR DESCRIPTION
- Respect the max_records_in_ram property by passing along to picard command.  
- Set re_reverse default to true to match Picard default behaviour.
