### PR TITLE
Re-add the column_name for the subclass_name property

### DIFF
--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -64,6 +64,7 @@ class Genome::Model {
         },
         subclass_name => {
             is => 'Text',
+            column_name => 'SUBCLASS_NAME',
             calculate_from => 'processing_profile_id',
             calculate => sub {
                 my $pp_id = shift;


### PR DESCRIPTION
This has the effect of putting NULLs in the subclass_name column in the DB when models are saved.

This was removed by mistake in commit 09688fd0.  The class writer (used by 'ur update classes-from-db') doesn't yet know how to write this kind of property out.
