### PR TITLE
Improve responsiveness when encountering large log files

### DIFF
--- a/lib/perl/Genome/Command/WorkflowMixin.pm
+++ b/lib/perl/Genome/Command/WorkflowMixin.pm
@@ -506,8 +506,9 @@ sub _print_error_log_preview {
     # If the log is less than 5MB, try to find the error message
     my @error_lines;
     if ( (-s $log_path) < (5 * 1024 * 1024) ) {
-        my @lines = `grep 'ERROR' $log_path`;
-        @error_lines = grep {$_ =~ m/ERROR/} @lines;
+        @error_lines = `grep --max-count=1 'ERROR' $log_path`;
+    } else {
+        print $handle " Max file size exceeded, skipped error preview.\n";
     }
 
     my $preview;


### PR DESCRIPTION
When we hit large log files, the grep would take a long time and build view would hang.
