### PR TITLE
Replace calculated "sample_type" property with an alias

### DIFF
--- a/lib/perl/Genome/Sample.pm
+++ b/lib/perl/Genome/Sample.pm
@@ -53,13 +53,9 @@ class Genome::Sample {
             doc => 'Either "genomic dna" or "rna" in most cases',
         },
         sample_type => {
-            calculate_from => 'extraction_type',
-            calculate => q{
-                $self = shift;
-                my $new_type = shift;
-                if ($new_type) { $self->extraction_type($new_type); }
-                return $extraction_type;
-            },
+            is => 'Text',
+            via => '__self__',
+            to => 'extraction_type',
         },
         is_rna => {
             calculate_from => [qw/ extraction_type /],


### PR DESCRIPTION
The calculated property implementation was returning the old value when
running updates.  Rather than fix it, just stop using it altogether.
