### PR TITLE
Override get_or_create not create

### DIFF
--- a/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Result.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Result.pm
@@ -34,9 +34,9 @@ sub output_file_path {
     return File::Spec->join($self->output_dir, $self->output_filename);
 }
 
-sub create {
+sub get_or_create {
     my $class = shift;
-    my $self = $class->SUPER::create(@_);
+    my $self = $class->SUPER::get_or_create(@_);
 
     $self->_prepare_staging_directory;
     $self->_run;


### PR DESCRIPTION
Overriding create is problematic since create will return undef if it
finds an existing SR (and this is done before locking).  When undef is
returned, the rest of our overridden create function is broken. Since we
need a guarantee that we will either get or create a $self, we need to
override get_or create instead.

One unappealing side-effect of this is that calling 'create' on our
class now doesn't actually fully create the software-result, only the
database entry for it.  So long as nobody expects that the work will be
done when calling 'create' directly, this is ok, but it seems
non-intuitive.
