### PR TITLE
Allow for create to return undef

### DIFF
--- a/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Result.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Result.pm
@@ -37,6 +37,7 @@ sub output_file_path {
 sub create {
     my $class = shift;
     my $self = $class->SUPER::create(@_);
+    return unless $self;
 
     $self->_prepare_staging_directory;
     $self->_run;


### PR DESCRIPTION
This happens when SoftwareResult::create fails to create the result
because another process has already created it.  Then
SoftwareResult::get_or_create will look for and find the already created
result.
