### PR TITLE
Remove ssmith from slow merge notifications.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Sam/Merge.pm
+++ b/lib/perl/Genome/Model/Tools/Sam/Merge.pm
@@ -102,7 +102,7 @@ sub merge_command {
             maximum_permgen_memory => $self->max_permgen_size,
             additional_jvm_options => '-Dcom.sun.management.jmxremote', #for monitoring
             _monitor_command => 1,
-            _monitor_mail_to => 'jeldred abrummet',
+            _monitor_mail_to => 'apipe-builder',
             _monitor_check_interval => 60, #seconds
             _monitor_stdout_interval => 900, #seconds
         );


### PR DESCRIPTION
This list probably shouldn't be hardcoded in this module at all, but this commit stops sending the mail to ssmith.
