### PR TITLE
Remove width restriction on size_in_bytes

### DIFF
--- a/lib/perl/Genome/Disk/Allocation/FileSummary.pm
+++ b/lib/perl/Genome/Disk/Allocation/FileSummary.pm
@@ -24,7 +24,7 @@ class Genome::Disk::Allocation::FileSummary {
             doc => 'relative path to file from the allocation root',
         },
         digest => { is => 'Text', is_optional => 1 },
-        size_in_bytes => { is => 'Integer', len => 8, is_optional => 1 },
+        size_in_bytes => { is => 'Integer', is_optional => 1 },
         is_symlink => { is => 'Boolean', len => 1 },
         destination => { is => 'Text', is_optional => 1 },
     ],


### PR DESCRIPTION
The UR update classes from db command (PR #52) appears to have added a standard integer width restriction to this column even though the underlying column type is bigint.

This removes that.
