### PR TITLE
Switch property to be "ARRAY" typed instead of is_many.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/SubjectMapping/Command/Import/SomaticValidation.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/SubjectMapping/Command/Import/SomaticValidation.pm
@@ -74,8 +74,8 @@ sub execute {
             $self->_create_input($mapping, $_, $value);
         }
 
-        my @tags = $reader->current_extra_columns;
-        for(@tags) {
+        my $tags = $reader->current_extra_columns;
+        for(@$tags) {
             $self->_link_to_tag($mapping, $_);
         }
 

--- a/lib/perl/Genome/Utility/IO/SeparatedValueReader.pm
+++ b/lib/perl/Genome/Utility/IO/SeparatedValueReader.pm
@@ -36,8 +36,7 @@ class Genome::Utility::IO::SeparatedValueReader {
             doc => 'The current original line of input from the file, pre splitting.'
         },
         current_extra_columns => {
-            type => 'Text',
-            is_many => 1,
+            type => 'ARRAY',
             doc => 'if "allow_extra_columns" is set, any additional columns for the current line',
         }
     ],

--- a/lib/perl/Genome/Utility/IO/SeparatedValueReaderWriter.t
+++ b/lib/perl/Genome/Utility/IO/SeparatedValueReaderWriter.t
@@ -115,9 +115,9 @@ $reader = Genome::Utility::IO::SeparatedValueReader->create(
 );
 ok($reader, 'Created SVR to test too many columns while ignoring extra columns');
 ok($reader->next, 'Succeeded as expected');
-my @extra = $reader->current_extra_columns;
-ok(scalar(@extra), 'extra columns set as expected');
-cmp_bag(\@extra, ['legend', 'reggae'], 'extra columns are the trailing ones in the file');
+my $extra = $reader->current_extra_columns;
+ok(scalar(@$extra), 'extra columns set as expected');
+cmp_bag($extra, ['legend', 'reggae'], 'extra columns are the trailing ones in the file');
 
 #print "$tmpdir\n"; <STDIN>;
 done_testing();


### PR DESCRIPTION
In #36 @brummett suggested that this should be an `ARRAY` property instead of `is_many`.  He's right! The `is_many` approach is not performant--NYTProf indicates it's spending most of its time inside `Carp` generating stacktraces after a doomed attempt to load a module called "Text" on every line.  This changes it to an `ARRAY`, which NYTProf shows has similar performance to the version of the module that pre-dated the prior PR.

(The new place that tops the list `_strip_quotes`.  It may be worth exploring a more efficient way to handle that case--maybe make it optional?  The current implementation doesn't handle a quoted string that contains the delimiter, anyway.)
