### PR TITLE
use xlim limits if they are provided

### DIFF
--- a/lib/perl/Genome/Model/Tools/CopyNumber/CnView.pm.R
+++ b/lib/perl/Genome/Model/Tools/CopyNumber/CnView.pm.R
@@ -118,8 +118,8 @@ plotChrCNV = function(target_chr, direction){
   #Get the limits for the X axis
   x_ideo_chr = c(ideo_thischr[,"chromStart"], ideo_thischr[,"chromEnd"])
   if (chr_start > 0){
-    x_lower = chr_start
-    x_upper = chr_end
+    xlim_lower = chr_start
+    xlim_upper = chr_end
   } else {
     xlim_lower = min(x_ideo_chr)
     xlim_upper = max(x_ideo_chr)
@@ -280,8 +280,8 @@ plotChrCNV_Compact = function(target_chr, type){
   #Get the limits for the X axis
   x_ideo_chr = c(ideo_thischr[,"chromStart"], ideo_thischr[,"chromEnd"])
   if (chr_start > 0){
-    x_lower = chr_start
-    x_upper = chr_end
+    xlim_lower = chr_start
+    xlim_upper = chr_end
   } else {
     xlim_lower = min(x_ideo_chr)
     xlim_upper = max(x_ideo_chr)


### PR DESCRIPTION
If chromosome start and stop are provided as arguments to CnView use them in the plots instead of the ideogram limits.
