### PR TITLE
Command to Assign Model(s) to an AnalysisProject

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddInstrumentData.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddInstrumentData.pm
@@ -1,4 +1,4 @@
-package Genome::Config::AnalysisProject::Command::AddInstrumentDataToAnalysisProject;
+package Genome::Config::AnalysisProject::Command::AddInstrumentData;
 
 use strict;
 use warnings;
@@ -6,7 +6,7 @@ use warnings;
 use Genome;
 use Set::Scalar;
 
-class Genome::Config::AnalysisProject::Command::AddInstrumentDataToAnalysisProject {
+class Genome::Config::AnalysisProject::Command::AddInstrumentData {
     is => 'Command::V2',
     has_input => [
        analysis_project => {
@@ -28,7 +28,7 @@ sub help_brief {
 }
 
 sub help_synopsis {
-    return "genome config analysis-project add-instrument-data-to-analysis-project <analysis-project> <instrument-data>";
+    return "genome config analysis-project add-instrument-data <analysis-project> <instrument-data>";
 }
 
 sub help_detail {

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddInstrumentData.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddInstrumentData.t
@@ -10,7 +10,7 @@ BEGIN {
 use above 'Genome';
 use Test::More;
 
-my $class = 'Genome::Config::AnalysisProject::Command::AddInstrumentDataToAnalysisProject';
+my $class = 'Genome::Config::AnalysisProject::Command::AddInstrumentData';
 use_ok($class);
 
 my $inst_data_1 = Genome::InstrumentData::Imported->create();

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.pm
@@ -1,11 +1,11 @@
-package Genome::Config::AnalysisProject::Command::AddModelToAnalysisProject;
+package Genome::Config::AnalysisProject::Command::AddModel;
 
 use strict;
 use warnings;
 
 use Genome;
 
-class Genome::Config::AnalysisProject::Command::AddModelToAnalysisProject {
+class Genome::Config::AnalysisProject::Command::AddModel {
     is => 'Command::V2',
     has_input => [
        profile_item => {
@@ -34,7 +34,7 @@ sub help_brief {
 }
 
 sub help_synopsis {
-    return 'genome config analysis-project add-model-to-analysis-project <profile-item> <model> [<model> ...]';
+    return 'genome config analysis-project add-model <profile-item> <model> [<model> ...]';
 }
 
 sub help_detail {

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.t
@@ -14,7 +14,7 @@ use Test::More tests => 35;
 use Genome::Test::Factory::AnalysisProject;
 use Genome::Test::Factory::Model::ReferenceAlignment;
 
-my $class = 'Genome::Config::AnalysisProject::Command::AddModelToAnalysisProject';
+my $class = 'Genome::Config::AnalysisProject::Command::AddModel';
 
 use_ok($class);
 


### PR DESCRIPTION
It has been requested that a command be created to manually attach a model to an analysis project.

For consolation the creation of the bridge entity triggers a Timeline::Event so it is possible to determine later that the model was not actually a creation of that analysis project.
