### PR TITLE
Don't put array value in single quotes

### DIFF
--- a/lib/perl/Genome/ProcessingProfile.pm
+++ b/lib/perl/Genome/ProcessingProfile.pm
@@ -333,7 +333,7 @@ sub param_summary {
             $summary .= join(",",@values)
         } 
         elsif ($values[0] =~ /\s/) {
-            $summary .= '"$values[0]"'
+            $summary .= '"'.$values[0].'"'
         }
         else {
             $summary .= $values[0]


### PR DESCRIPTION
We are thinking of using this method for TCGA MAGE-TAB metadata and wanted to see what things would look like without the bungled output.
