### PR TITLE
Allow for builds without disk_allocations

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Unarchive.pm
+++ b/lib/perl/Genome/Model/Build/Command/Unarchive.pm
@@ -109,9 +109,11 @@ sub _execute {
 
         # Set the data directory to the absolute path of the main alloc
         my $main_allocation = $build->disk_allocation;
-        UR::Context->reload($main_allocation); # this may have been loaded and unarchived earlier
-        if ( $build->data_directory ne $main_allocation->absolute_path ) {
-            $build->data_directory($main_allocation->absolute_path);
+        if ($main_allocation) {
+            UR::Context->reload($main_allocation); # this may have been loaded and unarchived earlier
+            if ( $build->data_directory ne $main_allocation->absolute_path ) {
+                $build->data_directory($main_allocation->absolute_path);
+            }
         }
 
         if ( $num_allocations == 0 ) {


### PR DESCRIPTION
This will let the command not fail on builds who do not have a
disk_allocation.  One common reason for this is that the build was
unstartable, but other causes may exist.
