### PR TITLE
Remove old FIXMEs from G:C:Crud test

### DIFF
--- a/lib/perl/Genome/Command/Crud.t
+++ b/lib/perl/Genome/Command/Crud.t
@@ -51,60 +51,60 @@ class Person {
     has => [
         name => { is => 'Text', doc => 'Name of the person', },
         title => {
-            is => 'Text', 
+            is => 'Text',
             valid_values => [qw/ mr sir mrs ms miss dr /],
             default_value => 'mr',
             doc => 'Title',
         },
-        has_pets => { 
+        has_pets => {
             is => 'Text',
             is_optional => 1,
             valid_values => [qw/ yes no /],
             default_value => 'no',
-            doc => 'Does this person have pets?', 
+            doc => 'Does this person have pets?',
         },
-        job => { 
-            is => 'Person::Job', 
-            id_by => 'job_id', 
+        job => {
+            is => 'Person::Job',
+            id_by => 'job_id',
             is_optional => 1,
             doc => 'The person\'s job',
         },
-        relationships => { 
+        relationships => {
             is => 'Person::Relationship',
             is_many => 1,
             is_optional => 1,
             reverse_as => 'person',
-            doc => 'This person\'s relationships', 
+            doc => 'This person\'s relationships',
         },
-        friends => { 
+        friends => {
             is => 'Person',
             is_many => 1,
             is_optional => 1,
             is_mutable => 1,
-            via => 'relationships', 
+            via => 'relationships',
             to => 'related',
             where => [ name => 'friend' ],
-            doc => 'Friends of this person', 
+            doc => 'Friends of this person',
         },
        mom => {
            is => 'Person',
            is_optional => 1,
            is_mutable => 1,
            is_many => 0,
-           via => 'relationships', 
+           via => 'relationships',
            to => 'related',
            where => [ name => 'mom' ],
-           doc => 'The person\'s Mom', 
+           doc => 'The person\'s Mom',
        },
        best_friend => {
            is => 'Person',
            is_optional => 1,
            is_mutable => 1,
            is_many => 0,
-           via => 'relationships', 
+           via => 'relationships',
            to => 'related',
            where => [ name => 'best friend' ],
-           doc => 'Best friend of this person', 
+           doc => 'Best friend of this person',
        },
     ],
 };
@@ -146,7 +146,7 @@ ok($main_tree_meta, 'MAIN TREE meta');
 #print Person::Command->help_usage_complete_text;
 
 # CREATE
-# meta 
+# meta
 my $create_meta = Person::Command::Create->__meta__;
 ok($create_meta, 'CREATE meta');
 $help_text = strip_ansi( Person::Command::Create->help_usage_complete_text );
@@ -162,7 +162,7 @@ like($help_text,
 like($help_text,
     qr(DESCRIPTION\s+This command creates a person\.),
     'Person Create help description');
-    
+
 is(Person::Command::Create->_target_class, 'Person', 'CREATE: _target_class');
 is(Person::Command::Create->_target_name, 'person', 'CREATE: _target_name');
 
@@ -197,7 +197,7 @@ is_deeply($mom->job, $care_taker_of_earth, 'Mom is care taker of the earth');
 is_deeply([$mom->friends], [], 'Mom does not have friends');
 ok(!$mom->best_friend, 'Mom does not have a best friend');
 
-# Creater Ronnie 
+# Creater Ronnie
 my $create_ronnie = Person::Command::Create->create(
     name => 'Ronald Reagan',
     title => 'sir',
@@ -216,12 +216,12 @@ is_deeply($ronnie->mom, $mom, 'Ronnie has a mom!');
 is_deeply([$ronnie->friends], [], 'Ronnie does not have friends');
 ok(!$ronnie->best_friend, 'Ronnie  does not have a best friend');
 
-# Create George 
+# Create George
 my $create_george = Person::Command::Create->create(
     name =>  'George HW Bush',
     title => 'mr',
     job => $vice_president,
-    has_pets => 'yes', 
+    has_pets => 'yes',
     best_friend => $ronnie,
     friends => [ $ronnie ],
 );
@@ -285,7 +285,7 @@ like($help_text,
     'person update best-friend required args help');
 
 # update property
-# text 
+# text
 my $update_title = Person::Command::Update::Title->create(
     people => [$ronnie, $george],
     value => 'mr',
@@ -375,7 +375,7 @@ is_deeply($ronnie->best_friend, $george, "UPDATE PROPERTY best_friend: Ronnie st
 # fail: text only if null
 my $update_no_people_fail = Person::Command::Update::Name->create(
     value => 'Bob Robertson',
-); 
+);
 ok($update_no_people_fail, 'UPDATE PROPERTY name: create w/o people');
 $update_no_people_fail->dump_status_messages(0);
 $update_no_people_fail->dump_error_messages(0);


### PR DESCRIPTION
These couple of `#FIXME` comments have been there since 2011.  It looks to me like the code does what the FIXMEs suggest it should do, so I've removed them.  If that's not right, then I'd be happy to try to make them right, instead! :smiley:
