### PR TITLE
Samtools Idxstats version check

### DIFF
--- a/lib/perl/Genome/Model/Tools/Sam/Idxstats.pm
+++ b/lib/perl/Genome/Model/Tools/Sam/Idxstats.pm
@@ -19,11 +19,10 @@ sub execute {
 
     my $version = $self->use_version;
 
-    if ($version =~ /^r/) {
-        ($version) = $version =~ /(\d+)/;
-        if ($version < 613) {
-            $self->warning_message('samtools version: '.$self->use_version .' do not have idxstats option. Instead r783 will be used');
-            $self->use_version('r783');
+    if ( my ($version_num) = $version =~ m/^r(\d+)/) {
+        if ($version_num < 613) {
+            $self->error_message('samtools version: '. $self->use_version .' does not have idxstats option.  Please provide a more recent verison of samtools.');
+            die($self->error_message);
         }
     }
 


### PR DESCRIPTION
Only evaluate r### format samtools version numbers.  Newer versions contain Idxstats sub-command.

There might be better ways, but hoping this is a quick fix for this specific problem.
