### PR TITLE
Picard 1.124 isn't packaged correctly and does not run

### DIFF
--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -166,6 +166,7 @@ sub installed_picard_versions {
     my @versions;
     for my $f (@files) {
         if($f =~ /picard-([\d\.]+).jar$/) {
+            next if $1 eq '1.124';
             push @versions, $1;
         }
     }


### PR DESCRIPTION
The Picard.t test fails unless we ignore it.
