### PR TITLE
Set run_as for analysis-projects based on if it's for "production"

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
@@ -23,7 +23,7 @@ class Genome::Config::AnalysisProject::Command::Create {
             is => 'Boolean',
             is_optional => 1,
             default_value => 0,
-            doc => 'If specified, this will flag this analysis project as being production data. All models will be created accordingly.',
+            doc => 'If specified, this will flag this analysis project as being production data (and not CLIA-related). All models will be created accordingly.',
         },
         no_config => {
             is => 'Boolean',
@@ -58,6 +58,10 @@ EOS
 
 sub execute {
     my $self = shift;
+
+    if($self->is_cle and $self->is_production) {
+        die('The --is-cle and --is-production options are mutually exclusive.');
+    }
 
     $self->_validate_name($self->name);
     my @params = (

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Create.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Create.t
@@ -36,4 +36,16 @@ ok($res2, 'second command executed successfully');
 isa_ok($res2, 'Genome::Config::AnalysisProject', 'command returned a Genome::Config::AnalysisProject');
 is($res2->run_as, Genome::Sys->username, 'run_as set correctly');
 
+my $cmd3 = Genome::Config::AnalysisProject::Command::Create->create(
+    name => 'test bad create options',
+    is_production => 1,
+    is_cle => 1,
+);
+ok($cmd3, 'constructed third create command');
+isa_ok($cmd3, 'Genome::Config::AnalysisProject::Command::Create');
+my $res3 = eval { $cmd3->execute };
+my $err3 = $@;
+ok(!$res3, 'third command fails with bad options');
+ok($err3, 'error thrown with bad options');
+
 done_testing();


### PR DESCRIPTION
The idea behind this is so that users can create AnPs for imported (non-production) datasets where builds will run as them rather than the standard apipe-builder.
