### PR TITLE
Propagate the AnalysisProject on SomaticValidation to its subordinate RefSeq models

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
@@ -148,6 +148,7 @@ sub execute {
         prefix => $sample_id,
         server_dispatch => 'inline',
         is_rederivable => 1,
+        analysis_projects => [$self->build->model->analysis_projects],
     );
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.pm
@@ -111,6 +111,7 @@ sub execute {
         prefix => $prefix,
         server_dispatch => 'inline',
         is_rederivable => 1,
+        analysis_projects => [$build->model->analysis_projects],
     );
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');


### PR DESCRIPTION
This will help with tracking usage per project (and moves towards a goal of eventually requiring all models to have an analysis project).
