### PR TITLE
Also try finding models via Analysis Projects.

### DIFF
--- a/lib/perl/Genome/Command/Base.pm
+++ b/lib/perl/Genome/Command/Base.pm
@@ -56,6 +56,7 @@ our %ALTERNATE_FROM_CLASS = (
     'Genome::Model' => {
         'Genome::Model::Build' => ['model'],
         'Genome::ModelGroup' => ['models'],
+        'Genome::Config::AnalysisProject' => ['models'],
     },
     'Genome::Model::Build' => {
         'Genome::Model' => ['builds'],


### PR DESCRIPTION
This allows users to sometimes omit the `analysis_projects.id=` or `analysis_projects.name=` from their command lines.
