### PR TITLE
Set ALTERNATE_FROM_CLASS for Command::V2 when running `genome`.

### DIFF
--- a/lib/perl/Genome/Command.pm
+++ b/lib/perl/Genome/Command.pm
@@ -41,4 +41,10 @@ my %command_map = (
 
 $Genome::Command::SUB_COMMAND_MAPPING = \%command_map;
 
+use Genome::Command::Base;
+%Command::V2::ALTERNATE_FROM_CLASS = (
+    %Command::V2::ALTERNATE_FROM_CLASS,
+    %Genome::Command::Base::ALTERNATE_FROM_CLASS,
+);
+
 1;


### PR DESCRIPTION
This makes the object resolution more consistent between `Genome::Command::Base` and `Command::V2` commands in the tree.
