### PR TITLE
owner on GMSchema is optional

### DIFF
--- a/lib/perl/Genome/DataSource/GMSchema.pm
+++ b/lib/perl/Genome/DataSource/GMSchema.pm
@@ -14,7 +14,7 @@ class Genome::DataSource::GMSchema {
         server  => { default_value  => $ENV{GENOME_DS_GMSCHEMA_SERVER} },
         login   => { default_value  => $ENV{GENOME_DS_GMSCHEMA_LOGIN} },
         auth    => { default_value  => $ENV{GENOME_DS_GMSCHEMA_AUTH} },
-        owner   => { default_value => undef },
+        owner   => { default_value => undef, is_optional => 1 },
     ],
 };
 


### PR DESCRIPTION
When using the GENOME_TEST_FILLDB feature this object fails error checking due
to `owner` being `undef`.  To correct this the `owner` should be labeled as
optional.
