### PR TITLE
Add accessors to configs and projects using the menu item.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisMenu/Item.pm
+++ b/lib/perl/Genome/Config/AnalysisMenu/Item.pm
@@ -25,6 +25,19 @@ class Genome::Config::AnalysisMenu::Item {
             is => 'Text',
         },
     ],
+    has_many => [
+        config_items => {
+            is => 'Genome::Config::Profile::Item',
+            reverse_as => 'analysis_menu_item',
+            doc => 'Config Items based on this menu item',
+        },
+        analysis_projects => {
+            is => 'Genome::Config::AnalysisProject',
+            via => 'config_items',
+            to => 'analysis_project',
+            doc => 'Analysis Projects using this menu item',
+        },
+    ],
 };
 
 sub __display_name__ {


### PR DESCRIPTION
This allows usage such as:
`genome analysis-project create --analysis-menu-items analysis_projects.id=12345`
to copy all menu items to a new project.
