### PR TITLE
updated genome-snapshot-deps URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -192,7 +192,7 @@
 	url = git@github.com:genome-vendor/bedtools.git
 [submodule "genome-snapshot-deps"]
 	path = genome-snapshot-deps
-	url = ssh://git/srv/git/genome-snapshot-deps.git
+	url = git@github.com:genome/genome-snapshot-deps.git
 [submodule "vendor/polymutt"]
 	path = vendor/polymutt
 	url = git@github.com:genome-vendor/polymutt.git


### PR DESCRIPTION
genome-snapshot-deps has been migrated to GitHub so this updated the URL to
point at the new location.
