### PR TITLE
Bless new test build

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
@@ -15,5 +15,5 @@ apipe-test-rnaseq: d43e5b2f2e2f496aa9329a160d3833e1
 apipe-test-somatic-validation-sv: fca9bd3a029d48099f07092c19989d16
 apipe-test-somatic-validation: 750be33ae59f4a588b87a587d9df22bb
 apipe-test-somatic-variation-short: f3d6a8e349404994a1cb0816e7a0b06d
-apipe-test-somatic-variation-sv-detection: fc750038993f45ca98c7cf94af566594
+apipe-test-somatic-variation-sv-detection: 2a046f43a086479b9d6c957b9d977312
 apipe-test-somatic-variation: b89dc737d7d045f4be9b64489fa14e46 


### PR DESCRIPTION
Model tests failed again, this time it looks like unarchiving changed the paths to certain files which is what's causing the diffs (sigh).

The failed test in question is here: https://apipe-ci.gsc.wustl.edu/job/2-Genome-Model-Tests-2-Run-Models/TEST_SPEC=5.10-somatic-variation-sv-detection/1310/console if someone would be so kind as to verify my change and that the diffs are OK.
