### PR TITLE
Add unique_results method

### DIFF
--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -9,6 +9,7 @@ use Data::Dump qw(pp);
 use Scalar::Util qw();
 use Try::Tiny qw(try catch);
 use JSON qw(to_json);
+use List::MoreUtils qw(uniq);
 
 class Genome::Process {
     is => [
@@ -567,6 +568,12 @@ sub delete {
     }
 
     return $self->SUPER::delete(@_);
+}
+
+sub unique_results {
+    my $self = shift;
+    my @results = $self->results;
+    return uniq @results;
 }
 
 

--- a/lib/perl/Genome/Process/Command/View.pm
+++ b/lib/perl/Genome/Process/Command/View.pm
@@ -115,7 +115,7 @@ EOS
         $self->_color_pair('Process Class', $process->class),
         $self->_color_pair('Software Revision', $process->software_revision),
         $self->_color_pair('SoftwareResult Test Name(s)',
-            $self->_software_result_test_names($process->results)),
+            $self->_software_result_test_names($process->unique_results)),
         $self->_color_pair('MetaData Directory', $process->metadata_directory));
 }
 


### PR DESCRIPTION
This is useful for when there are more than one SoftwareResult::User
relationships between the process and the results.
