### PR TITLE
Add migration to make model_group_id nullable

### DIFF
--- a/sqitch/gms/deploy/make_model_group_id_nullable.sql
+++ b/sqitch/gms/deploy/make_model_group_id_nullable.sql
@@ -1,0 +1,8 @@
+-- Deploy make_model_group_id_nullable
+-- requires: config_analysis_project
+
+BEGIN;
+
+  ALTER TABLE config.analysis_project ALTER COLUMN model_group_id DROP NOT NULL;
+
+COMMIT;

--- a/sqitch/gms/revert/make_model_group_id_nullable.sql
+++ b/sqitch/gms/revert/make_model_group_id_nullable.sql
@@ -1,0 +1,7 @@
+-- Revert make_model_group_id_nullable
+
+BEGIN;
+
+  ALTER TABLE config.analysis_project ALTER COLUMN model_group_id SET NOT NULL;
+
+COMMIT;

--- a/sqitch/gms/sqitch.plan
+++ b/sqitch/gms/sqitch.plan
@@ -345,3 +345,5 @@ process_status_event_permissions [process_status_event] 2014-11-12T01:52:40Z Dav
 
 process_input [process_process] 2014-11-12T02:18:57Z David Morton <dmorton@genome.wustl.edu> # Add process.input table
 @1416002215 2014-11-14T21:56:56Z David Morton <dmorton@genome.wustl.edu> # Add process.input table
+
+make_model_group_id_nullable [config_analysis_project] 2014-12-03T19:07:30Z Adam Coffman <acoffman@genome.wustl.edu> # make this column nullable to prepare for its removal

--- a/sqitch/gms/verify/make_model_group_id_nullable.sql
+++ b/sqitch/gms/verify/make_model_group_id_nullable.sql
@@ -1,0 +1,13 @@
+-- Verify make_model_group_id_nullable
+DO $$
+BEGIN
+
+  IF EXISTS(SELECT * from information_schema.columns
+      WHERE table_schema = 'config'
+      AND table_name = 'analysis_project'
+      AND column_name = 'model_group_id'
+      AND is_nullable = 'NO') THEN
+      RAISE EXCEPTION 'model_group_id is not nullable';
+  END IF;
+
+END $$;


### PR DESCRIPTION
This is prerequisite to merging PR #226. The deploy order will have to be:
- Merge this PR, run the migration
- Merge #226, wait for it it get out in a snapshot, and then run that migration.

(I can pull the migration from #226 into a different PR if needed, there will likely be a merge conflict with this one anyways)

This migration is applying cleanly (and reverting cleanly) against a test db (thanks test-db!). I would like someone(s) to review it before I merge and run the migration however.
