### PR TITLE
Correct Inheritance for `genome model build status`.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Status.pm
+++ b/lib/perl/Genome/Model/Build/Command/Status.pm
@@ -6,7 +6,7 @@ use warnings;
 use Genome;
 
 class Genome::Model::Build::Command::Status {
-    is => 'Command::V2',
+    is => 'Genome::Command::WithColor',
     doc => "prints status of non-succeeded builds and tallies all build statuses",
     has => [
         builds => {


### PR DESCRIPTION
This uses color, so it needs to inherit from `Genome::Command::WithColor`.
