### PR TITLE
run sciclone even if cnv_file is empty

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/GenerateSciclonePlots.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/GenerateSciclonePlots.pm
@@ -271,8 +271,7 @@ sub run_sciclone {
         return;
     }
     if(-z $cnv_f) {
-        $self->warning_message("cnv file $cnv_f empty. skipping sciclone step.");
-        return;
+        $self->warning_message("cnv file $cnv_f empty. assuming all variants are CN2.");
     }
     my $number_of_variants = Genome::Sys->line_count($variant_f);
     my $do_clustering = $self->do_clustering;


### PR DESCRIPTION
Instead of skipping sciclone when there are no CNVs called assume all variants are CN-neutral and run SciClone. For e.g.: this is true in the case of some AML samples.
