### PR TITLE
Fix bitwise bug in G::Utility::File::Mode

### DIFF
--- a/lib/perl/Genome/Utility/File/Mode.pm
+++ b/lib/perl/Genome/Utility/File/Mode.pm
@@ -41,7 +41,7 @@ sub _bit_shift {
 
 sub _has_bit {
     my ($mode, $bit) = (shift, shift);
-    return ($mode & $bit) >> _bit_shift($bit);
+    return ($mode & $bit) == $bit;
 }
 
 sub new {


### PR DESCRIPTION
A test for a compound mode (e.g. group rwx) would return true if any 
individual bit was set (as opposed to all required bits being set).
