### PR TITLE
update tests to not write to GENOME_TEST_INPUTS

### DIFF
--- a/lib/perl/Genome/Model/Tools/CopyNumber/PlotSegments.t
+++ b/lib/perl/Genome/Model/Tools/CopyNumber/PlotSegments.t
@@ -6,15 +6,19 @@ use warnings;
 use above 'Genome';
 use Test::More tests => 4;
 
+use File::Temp qw();
+
 use_ok('Genome::Model::Tools::CopyNumber::PlotSegments');
 
 my $test_dir = $ENV{GENOME_TEST_INPUTS} . "/Genome-Model-Tools-CopyNumber-PlotSegments";
 my $output_file = Genome::Sys->create_temp_file_path;
 my $input_dir = "$test_dir";
 my $input_file = "$input_dir/input1.seg.cbs";
-my $output_pdf = "$input_dir/output.pdf";
 
-print $output_pdf."\n";
+my $output_fh = File::Temp->new();
+my $output_pdf = $output_fh->filename();
+$output_fh->close();
+diag $output_pdf;
 
 my $command= Genome::Model::Tools::CopyNumber::PlotSegments->create(
 	segment_files => $input_file,

--- a/lib/perl/Genome/Model/Tools/Validation/LongIndelsGenerateMergedAssemblies.t
+++ b/lib/perl/Genome/Model/Tools/Validation/LongIndelsGenerateMergedAssemblies.t
@@ -11,6 +11,7 @@ use warnings;
 use above "Genome";
 use Test::More;
 use File::Compare;
+use File::Copy qw(copy);
 
 use_ok("Genome::Model::Tools::Validation::LongIndelsGenerateMergedAssemblies");
 
@@ -18,8 +19,14 @@ my $version = 2;
 my $base_dir = $ENV{GENOME_TEST_INPUTS}."/Genome-Model-Tools-Validation-LongIndelsGenerateMergedAssemblies/v$version";
 my $temp_dir = Genome::Sys->create_temp_directory;
 
+# copy to temp because the tool appears to make a large_indels.bed.dedup next
+# to the original file and it doesn't seem good to have things writing in GENOME_TEST_INPUTS
+my $temp_large_indels = $temp_dir."/large_indels.bed";
+copy($base_dir."/large_indels.bed", $temp_large_indels)
+    or die "failed to copy large_indels.bed to temp_dir: $!";
+
 my $cmd = Genome::Model::Tools::Validation::LongIndelsGenerateMergedAssemblies->create(
-    long_indel_bed_file => $base_dir."/large_indels.bed",
+    long_indel_bed_file => $temp_large_indels,
     output_dir => $temp_dir,
     transcript_variant_annotator_version => 2,
     reference_transcripts => "NCBI-human.ensembl/67_37l_v2",


### PR DESCRIPTION
When GENOME_TEST_INPUTS was recently migrated it was noticed that a couple
files were repeatedly updating.  This updates two tests to prevent writes to
GENOME_TEST_INPUTS.
