### PR TITLE
SeparatedValueReader dies when columns don't match

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/Manager.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Manager.t
@@ -16,6 +16,7 @@ use Data::Dumper;
 require Digest::MD5;
 require Genome::Utility::Test;
 use Test::More;
+use Test::Exception;
 
 use_ok('Genome::InstrumentData::Command::Import::Manager') or die;
 
@@ -169,8 +170,7 @@ $manager = Genome::InstrumentData::Command::Import::Manager->create(
     source_files_tsv => $test_dir.'/invalid-format.tsv',
 );
 ok($manager, 'create manager');
-ok(!$manager->execute, 'execute failed for invalid format file');
-like($manager->error_message, qr/Property 'source_files_tsv': Expected 3 values, got 4 on line 3 in/, 'correct error');
+throws_ok(sub {$manager->execute}, qr/Expected 3 values, got 4 on line 3 in/, 'execute failed for invalid format');
 
 # fail - source file does not exist
 $manager = Genome::InstrumentData::Command::Import::Manager->create(

--- a/lib/perl/Genome/Utility/IO/SeparatedValueReader.pm
+++ b/lib/perl/Genome/Utility/IO/SeparatedValueReader.pm
@@ -130,7 +130,7 @@ sub next {
         # If we dont care about extra columns, all is well... unless we dont at least have the minimum required
         if (!($self->allow_extra_columns)||(@{$self->headers} > @values)) {
             #  Bomb out if we dont want extra columns
-            $self->error_message(
+            die $self->error_message(
                sprintf(
                     'Expected %d values, got %d on line %d in %s',
                     scalar @{$self->headers},
@@ -139,7 +139,6 @@ sub next {
                     ( $self->get_original_input || ref $self->io ),
                 )
             );
-            return;
         } else {
             @extra_columns = splice @values, scalar(@{$self->headers});
         }

--- a/lib/perl/Genome/Utility/IO/SeparatedValueReaderWriter.t
+++ b/lib/perl/Genome/Utility/IO/SeparatedValueReaderWriter.t
@@ -8,6 +8,7 @@ use above 'Genome';
 require File::Compare;
 use Test::More;
 use Test::Deep qw(cmp_bag);
+use Test::Exception;
 
 use_ok('Genome::Utility::IO::SeparatedValueReader') or die;
 use_ok('Genome::Utility::IO::SeparatedValueWriter') or die;
@@ -96,7 +97,7 @@ $reader = Genome::Utility::IO::SeparatedValueReader->create(
     headers => [qw/ not the right number of headers /],
 );
 ok($reader, 'create reader');
-ok(!$reader->next, 'Failed as expected - next');
+dies_ok(sub {$reader->next}, "line with too many columns causes die");
 
 # This should fail because we ignore extra columns but we dont have the minimum
 $reader = Genome::Utility::IO::SeparatedValueReader->create(
@@ -105,7 +106,7 @@ $reader = Genome::Utility::IO::SeparatedValueReader->create(
     allow_extra_columns => 1,
 );
 ok($reader, 'Created SVR to test too few columns while ignoring extra columns');
-ok(!$reader->next, 'Failed as expected - next');
+dies_ok(sub {$reader->next}, 'Failed as expected - next');
 
 # This should succeed because we ignore extra columns
 $reader = Genome::Utility::IO::SeparatedValueReader->create(


### PR DESCRIPTION
otherwise when you are looping through a file using next,
it will just truncate the file and print an error message,
without any other clue that something is wrong.

NOTE: This is not cle-urgent.  Just noticed that it is a problem.
