### PR TITLE
Use regex directly in Genome::ModelGroup::Command::Copy.

### DIFF
--- a/lib/perl/Genome/ModelGroup/Command/Copy.pm
+++ b/lib/perl/Genome/ModelGroup/Command/Copy.pm
@@ -132,7 +132,7 @@ $DB::single = 1;
     my @model_changes;
     my @param_changes;
     my @input_changes;
-    my $rx = UR::BoolExpr->_old_filter_regex_for_string();
+    my $rx = '^\s*([\w\.\-]+)\s*(\@|\=|!=|=|\>|\<|~|!~|!\:|\:|\blike\b|\bbetween\b|\bin\b)\s*[\'"]?([^\'"]*)[\'"]?\s*$';
     my $meta = $from_models[0]->__meta__;
     my $changes_pp = 0;
     for my $change (@changes) {


### PR DESCRIPTION
This regex isn't used by `UR` any more, so it was removed in master. (See genome/UR#51.)
