### PR TITLE
Allow multiple metrics with the same timing code.

### DIFF
--- a/lib/perl/Genome/Utility/Instrumentation.pm
+++ b/lib/perl/Genome/Utility/Instrumentation.pm
@@ -63,7 +63,8 @@ sub increment {
 
 
 sub timer {
-    my ($name, $code) = @_;
+    my $code = pop @_;
+    my @names = @_;
 
     my $start_time = Time::HiRes::time();
 
@@ -73,17 +74,16 @@ sub timer {
     if ($@) {
         my $error = $@;
         my $stop_time = Time::HiRes::time();
-        eval {
-            my $error_name = "$name\_error";
-            Net::Statsd::timing($error_name, 1000 * ($stop_time - $start_time));
-        };
+        for (@names) {
+            timing("$_\_error", 1000 * ($stop_time - $start_time));
+        }
         die $error;
     }
 
     my $stop_time = Time::HiRes::time();
-    eval {
-        Net::Statsd::timing($name, 1000 * ($stop_time - $start_time));
-    };
+    for(@names) {
+        timing($_, 1000 * ($stop_time - $start_time));
+    }
 }
 
 sub timing {


### PR DESCRIPTION
`Genome::SoftwareResult::_faster_get` contains almost identical timing code to `Genome::Utilitiy:Instrumenttation::timing`. Unfortunately, in the current state it cannot be factored out because it uses the same timing information to record multiple metrics, which `timing` doesn't support.

This PR allows `Genome::Utilitiy:Instrumentation::timing` to take multiple metric names, while keeping the API the same for all current users.

Popping an item off `@_` doesn't seem particularly idiomatic to me, but I felt that preserving the current API (the coderef is the last argument) was more desirable in this case. Thoughts?
