### PR TITLE
Fix vaf calculations

### DIFF
--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/ManySamplesVafInterpreter.t
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/ManySamplesVafInterpreter.t
@@ -33,19 +33,19 @@ subtest "one alt allele" => sub {
             S1_var_count => 341,
             S1_per_library_var_count => 'Solexa-135852:155,Solexa-135853:186',
             S1_per_library_ref_count => 'Solexa-135852:2,Solexa-135853:1',
-            S1_per_library_vaf => 'Solexa-135852:45.0581395348837,Solexa-135853:54.0697674418605',
+            S1_per_library_vaf => 'Solexa-135852:87.0786516853933,Solexa-135853:99.4652406417112',
             S2_vaf => 99.1279069767442,
             S2_ref_count => 3,
             S2_var_count => 341,
             S2_per_library_var_count => 'Solexa-135852:155,Solexa-135853:186',
             S2_per_library_ref_count => 'Solexa-135852:2,Solexa-135853:1',
-            S2_per_library_vaf => 'Solexa-135852:45.0581395348837,Solexa-135853:54.0697674418605',
+            S2_per_library_vaf => 'Solexa-135852:87.0786516853933,Solexa-135853:99.4652406417112',
             S3_vaf => 99.1279069767442,
             S3_ref_count => 3,
             S3_var_count => 341,
             S3_per_library_var_count => 'Solexa-135852:155,Solexa-135853:186',
             S3_per_library_ref_count => 'Solexa-135852:2,Solexa-135853:1',
-            S3_per_library_vaf => 'Solexa-135852:45.0581395348837,Solexa-135853:54.0697674418605',
+            S3_per_library_vaf => 'Solexa-135852:87.0786516853933,Solexa-135853:99.4652406417112',
         }
     );
 

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/VafInterpreter.t
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/VafInterpreter.t
@@ -31,7 +31,7 @@ subtest "one alt allele" => sub {
             var_count => 341,
             per_library_var_count => 'Solexa-135852:155,Solexa-135853:186',
             per_library_ref_count => 'Solexa-135852:2,Solexa-135853:1',
-            per_library_vaf => 'Solexa-135852:45.0581395348837,Solexa-135853:54.0697674418605',
+            per_library_vaf => 'Solexa-135852:87.0786516853933,Solexa-135853:99.4652406417112',
         }
     );
 
@@ -56,7 +56,7 @@ subtest "insertion" => sub {
             var_count => 20,
             per_library_var_count => 'Solexa-135852:20,Solexa-135853:0',
             per_library_ref_count => 'Solexa-135852:2,Solexa-135853:1',
-            per_library_vaf => 'Solexa-135852:5.81395348837209,Solexa-135853:0',
+            per_library_vaf => 'Solexa-135852:11.2359550561798,Solexa-135853:0',
         }
     );
 
@@ -81,7 +81,7 @@ subtest "deletion" => sub {
             var_count => 20,
             per_library_var_count => 'Solexa-135852:20,Solexa-135853:0',
             per_library_ref_count => 'Solexa-135852:3,Solexa-135853:2',
-            per_library_vaf => 'Solexa-135852:5.81395348837209,Solexa-135853:0',
+            per_library_vaf => 'Solexa-135852:11.0497237569061,Solexa-135853:0',
         }
     );
 


### PR DESCRIPTION
For per-library vaf: Instead of dividing by the total depth (across all libraries) we need to
divide by the depth in just that one library.

For total vaf: Instead of summing up per-library vaf we need to
calculate the coverage and depth directly.
