### PR TITLE
fix build_requested locking so that it only locks if we modify the value

### DIFF
--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -657,9 +657,9 @@ sub builds_with_status {
 # Overriding build_requested to add a note to the model with information about who requested a build
 sub build_requested {
     my ($self, $value, $reason) = @_;
-    $self->_lock();
     # Writing the if like this allows someone to do build_requested(undef)
     if (@_ > 1) {
+        $self->_lock();
         my ($calling_package, $calling_subroutine) = (caller(1))[0,3];
         my $default_reason = 'no reason given';
         $default_reason .= ' called by ' . $calling_package . '::' . $calling_subroutine if $calling_package;


### PR DESCRIPTION
This breaks model tests because it is locking whenever someone inspects.  It should only lock on modification.  This fixes that...
