### PR TITLE
Create the bridge entities more explicitly.

### DIFF
--- a/lib/perl/Genome/Model/Command/Define/ImportedReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Command/Define/ImportedReferenceSequence.pm
@@ -310,8 +310,10 @@ sub _get_or_create_model {
             'processing_profile_id' => $irs_pp->id,
             'name' => $self->model_name,
             'is_rederivable' => $self->is_rederivable,
-            'analysis_projects' => [$self->analysis_projects],
         );
+        if($self->analysis_projects) {
+            $model->add_analysis_project_bridge(analysis_project => $self->analysis_projects);
+        }
 
         if($model) {
             if(my @problems = $model->__errors__){


### PR DESCRIPTION
UR tries to find an "add_analysis_project" subroutine, which does not exist.  So call something that does exist instead.

[There is currently a fiction in some of our code that a model might have multiple analysis projects.  A database constraint enforces the one-to-one mapping, so there will be only one.]
