### PR TITLE
Add `genome disk allocation purge` CLI

### DIFF
--- a/lib/perl/Genome/Disk/Command/Allocation/Deallocate.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/Deallocate.pm
@@ -19,7 +19,7 @@ class Genome::Disk::Command::Allocation::Deallocate {
 };
 
 sub help_brief {
-    return 'removes the target allocation and deletes its directories';
+    return 'PERMANENTLY DELETES files and database records';
 }
 
 sub help_synopsis {
@@ -27,7 +27,8 @@ sub help_synopsis {
 }
 
 sub help_detail {
-    return 'removes the target allocation and deletes its directories';
+    return "PERMANENTLY DELETES the allocation's files and removes its "
+        . 'database records. The files and records are unrecoverable.';
 }
 
 sub execute { 

--- a/lib/perl/Genome/Disk/Command/Allocation/Purge.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/Purge.pm
@@ -23,11 +23,13 @@ class Genome::Disk::Command::Allocation::Purge {
 };
 
 sub help_detail {
-    return 'purges the given allocations, moving its files to a trash folder';
+    return "PERMANENTLY DELETES the allocation's files. The files are "
+        . 'temporarily stored in a trash folder for short-term recovery. '
+        . 'Database records of this allocation will be kept.';
 }
 
 sub help_brief {
-    return 'purges the given allocations';
+    return 'PERMANENTLY DELETES files';
 }
 
 sub execute {


### PR DESCRIPTION
It requires a `reason` and a list of `Genome::Disk::Allocation` objects.

I'm just adding this for convenience.
