### PR TITLE
Cnview update

### DIFF
--- a/lib/perl/Genome/Model/Tools/CopyNumber/CnView.pm.R
+++ b/lib/perl/Genome/Model/Tools/CopyNumber/CnView.pm.R
@@ -426,7 +426,7 @@ cnvs=read.table(cnv_file, comment.char="#", header=TRUE)
 segments=read.table(segments_file, sep="\t", as.is=c(1,11), header=TRUE)
 
 if (nrow(cnvs) == 0){
-  print("CNV file or CNV-segments file empty. Skipping CnView.")
+  print("CNV file empty. Skipping CnView.")
   q();
 }
 


### PR DESCRIPTION
Run CnView with empty segments file. This helps with copy-neutral samples where there are no CNVs called. e.g microarray data from HGG1.
