### PR TITLE
Reference-Sequence Conversion Improvements for Merging

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/Merge.pm
+++ b/lib/perl/Genome/FeatureList/Command/Merge.pm
@@ -92,7 +92,6 @@ sub execute {
         $merged_list = $cmd->new_feature_list;
     }
 
-    say $merged_list->id;
     return 1;
 }
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -84,6 +84,7 @@ class Genome::Model::Build::ReferenceSequence {
         combines => {
             is => 'Genome::Model::Build::ReferenceSequence',
             doc => 'If specified, merges several other references into one.', 
+            is_many => 1,
         },
     ],
     has_many_optional => [

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/Converter.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/Converter.pm
@@ -79,6 +79,11 @@ sub convert_bed {
         while(my $line = <$source_fh>) {
             chomp $line;
             my ($chrom, $start, $stop, @extra) = split("\t", $line);
+            unless($chrom && $start && $stop) {
+                $self->debug_message('Not converting non-entry line %s', $line);
+                $destination_fh->say($line);
+                next;
+            }
             my ($new_chrom, $new_start, $new_stop) = $self->convert_position($chrom, $start, $stop);
             my $new_line = join("\t", $new_chrom, $new_start, $new_stop, @extra) . "\n";
             print $destination_fh $new_line;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/Converter.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/Converter.pm
@@ -75,7 +75,7 @@ sub convert_bed {
     if($self->is_per_position_algorithm) {
         my $source_fh = Genome::Sys->open_file_for_reading($source_bed);
         my $destination_fh = Genome::Sys->open_file_for_writing($destination_bed);
-    
+
         while(my $line = <$source_fh>) {
             chomp $line;
             my ($chrom, $start, $stop, @extra) = split("\t", $line);
@@ -83,7 +83,7 @@ sub convert_bed {
             my $new_line = join("\t", $new_chrom, $new_start, $new_stop, @extra) . "\n";
             print $destination_fh $new_line;
         }
-    
+
        $source_fh->close;
        $destination_fh->close;
     } else {


### PR DESCRIPTION
* Pass BED "track", "browser", etc. lines unmodified.
* A reference can now indicate it is a combination of multiple other references.
* Remove redundant print in `genome feature-list merge` since it will be printed by the import command.