### PR TITLE
Deprecate `genome disk allocation deallocate`

### DIFF
--- a/lib/perl/Genome/Disk/Command/Allocation/Deallocate.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/Deallocate.pm
@@ -18,6 +18,8 @@ class Genome::Disk::Command::Allocation::Deallocate {
     doc => 'removes target allocation and deletes its directories',
 };
 
+sub _is_hidden_in_docs { !Genome::Sys->current_user_is_admin }
+
 sub help_brief {
     return 'removes the target allocation and deletes its directories';
 }


### PR DESCRIPTION
Users probably want `genome disk allocation purge` instead.  For now we
are simply hiding this command from non-admin users.

Based on logs, it appears there is at least one user who uses this interface regularly.
