### PR TITLE
Disable fillmd/BamQc for bsmap

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
@@ -348,7 +348,7 @@ sub prepare_reference_sequence_index {
 }
 
 sub fillmd_for_sam {
-    return 1;
+    return 0;
 }
 
 sub requires_read_group_addition {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
@@ -355,6 +355,10 @@ sub requires_read_group_addition {
     return 1;
 }
 
+sub _use_alignment_summary_cpp {
+    return 0;
+}
+
 # only accept bam input if we're not running in force fragment mode
 sub accepts_bam_input {
     my $self = shift;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.t
@@ -51,7 +51,7 @@ $aligner_label =~ s/\./\_/g;
 
 #was the path for BSMAP2.1 - new path is in the more canonical location
 #my $expected_shortcut_path = "/gscmnt/sata828/info/alignment_data/$aligner_label/TEST-human/test_run_name/4_-123456",
-my $expected_shortcut_path = $ENV{GENOME_TEST_INPUTS} . "/Genome-InstrumentData-AlignmentResult-Bsmap/v2.74/2013-11-27";
+my $expected_shortcut_path = $ENV{GENOME_TEST_INPUTS} . "/Genome-InstrumentData-AlignmentResult-Bsmap/v2.74/2014-12-18";
 print STDERR $expected_shortcut_path . "\n";
 
 my $FAKE_INSTRUMENT_DATA_ID=-123456;

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/BamQc.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/BamQc.pm
@@ -167,7 +167,7 @@ sub _should_skip_bam_qc {
     if ($pp->can('read_aligner_name')) {
         my $aligner = $pp->read_aligner_name;
         if ($self->_aligner_blacklist->has($aligner)) {
-            $self->warning_message("Skipping BamQc because aligner is '$_'");
+            $self->warning_message("Skipping BamQc because aligner is '$aligner'");
             return 1;
         }
     }

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/BamQc.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/BamQc.pm
@@ -43,8 +43,7 @@ sub execute {
     my $build = $self->build;
     my $pp    = $build->processing_profile;
 
-    if ($pp->read_aligner_name eq 'imported') {
-        $self->warning_message('Skip BamQc step for imported alignment bam');
+    if ($self->_should_skip_bam_qc($pp)) {
         return 1;
     }
 
@@ -90,7 +89,6 @@ sub params_for_result {
     my $read_length = $instr_data->sequencing_platform =~ /^solexa$/i ? 0 : 1;
 
     my $error_rate_version = $self->_select_error_rate_version_for_pp($pp);
-    my $should_run_error_rate = $self->_should_run_error_rate_for_pp($pp);
 
     return (
         alignment_result_id => $self->_alignment_result->id,
@@ -99,7 +97,7 @@ sub params_for_result {
         fastqc_version      => Genome::Model::Tools::Fastqc->default_fastqc_version,
         samstat_version     => Genome::Model::Tools::SamStat::Base->default_samstat_version,
         error_rate_version  => $error_rate_version,
-        error_rate          => $should_run_error_rate,
+        error_rate          => 1,
         read_length         => $read_length,
         test_name           => $ENV{GENOME_SOFTWARE_RESULT_TEST_NAME} || undef,
     );
@@ -163,17 +161,21 @@ sub _select_error_rate_version_for_pp {
     return $error_rate_version;
 }
 
-sub _should_run_error_rate_for_pp {
+sub _should_skip_bam_qc {
     my ($self, $pp) = @_;
 
-    my $aligner_black_listed = ($pp->can('read_aligner_name')
-        and $self->_aligner_blacklist->has($pp->read_aligner_name));
-
-    return $aligner_black_listed ? 0 : 1;
+    if ($pp->can('read_aligner_name')) {
+        my $aligner = $pp->read_aligner_name;
+        if ($self->_aligner_blacklist->has($aligner)) {
+            $self->warning_message("Skipping BamQc because aligner is '$_'");
+            return 1;
+        }
+    }
+    return 0;
 }
 
 sub _aligner_blacklist {
-    return Set::Scalar->new(qw(bsmap));
+    return Set::Scalar->new(qw(imported bsmap));
 }
 
 sub _bwa_mem_version_object {

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/BamQc.t
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/BamQc.t
@@ -6,7 +6,7 @@ use warnings;
 use version 0.77;
 use above 'Genome';
 use Genome::Test::Factory::ProcessingProfile::ReferenceAlignment;
-use Test::More tests => 11;
+use Test::More tests => 12;
 
 my $bamqc_class = 'Genome::Model::Event::Build::ReferenceAlignment::BamQc';
 
@@ -63,15 +63,22 @@ is($bamqc_class->_select_error_rate_version_for_pp($test_pp),
     'New ErrorRate version chosen correctly'
 );
 
-is($bamqc_class->_should_run_error_rate_for_pp($test_pp),
-    1,
-    'ErrorRate correctly chosen to run'
+is($bamqc_class->_should_skip_bam_qc($test_pp),
+    0,
+    'BamQc correctly chosen to run'
 );
 
 $test_pp->read_aligner_version();
 $test_pp->read_aligner_name('bsmap');
 
-is($bamqc_class->_should_run_error_rate_for_pp($test_pp),
-    0,
-    'ErrorRate correctly skipped for bsmap'
+is($bamqc_class->_should_skip_bam_qc($test_pp),
+    1,
+    'BamQc correctly skipped for bsmap'
+);
+
+$test_pp->read_aligner_name('imported');
+
+is($bamqc_class->_should_skip_bam_qc($test_pp),
+    1,
+    'BamQc correctly skipped for imported'
 );


### PR DESCRIPTION
We were having trouble running `fillmd` on `bsmap` alignments. This disables `fillmd` and BamQc when the aligner is set to `bsmap`.

Would like input from @jasonwalker80 before merging.