### PR TITLE
DV2 DetectionBase knows more about allocation statuses

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Result/DetectionBase.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Result/DetectionBase.pm
@@ -210,7 +210,7 @@ sub _extract_allocation_owner_id {
 sub _validate_found_allocation {
     my ($class, $allocation, $result, $instance_output) = @_;
 
-    if (grep {$allocation->status} ('purged', 'invalid')) {
+    if (grep {$_ eq $allocation->status} ('purged', 'invalid')) {
         $class->warning_message("Found link to %s allocation (%s).  "
             . "Removing symlink.", $allocation->status, $allocation->id);
         unlink $instance_output;


### PR DESCRIPTION
This PR was spawned from comments in #345.  It contains a chunk of refactoring, followed by a few feature adds:
- give a specific error message when an allocation is archived
- notice purged or invalid allocation links and continue seamlessly
- add a bit more instrumentation
