### PR TITLE
Only need to lock once.  After that it's ours to modify.

### DIFF
--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -674,10 +674,13 @@ sub build_requested {
 
 sub _lock {
     my $self = shift;
+
+    return 1 if $self->{_lock};
+
     my $model_id = $self->id;
     unless ($ENV{UR_DBI_NO_COMMIT}) {
         my $lock_var = File::Spec->join($ENV{GENOME_LOCK_DIR}, 'build_requested', $model_id);
-        my $lock = Genome::Sys->lock_resource(resource_lock => $lock_var, max_try => 30, block_sleep => 30);
+        my $lock = $self->{_lock} = Genome::Sys->lock_resource(resource_lock => $lock_var, max_try => 30, block_sleep => 30);
 
         die("Unable to acquire the lock to request $model_id. Is something already running or did it exit uncleanly?")
             unless $lock;


### PR DESCRIPTION
This should address the problems with multiple instrument data in CQID triggering a build request on the same model.
