### PR TITLE
use version package so that version comparison works for 1.10 and up

### DIFF
--- a/lib/perl/Genome/Model/Tools/Joinx/VcfMerge.pm
+++ b/lib/perl/Genome/Model/Tools/Joinx/VcfMerge.pm
@@ -169,7 +169,7 @@ sub _resolve_flags {
         $flags .= " -s";
     }
     if ($self->exact_pos) {
-        if ( version->parse($self->use_version) < version->parse('1.7') ) {
+        if ( version->parse('v'.$self->use_version) < version->parse("v1.7") ) {
             die $self->error_message("Invalid option (--exact-pos) for joinx version (". $self->use_version .")");
         }
         $flags .= " -e";


### PR DESCRIPTION
I would like to merge this early, if possible, since this is causing failures in https://rt.gsc.wustl.edu/Ticket/Display.html?id=103180
