### PR TITLE
Replace confusing comments in DV2 result modules.

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Result.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Result.pm
@@ -10,6 +10,6 @@ class Genome::Model::Tools::DetectVariants2::Result {
     doc => 'This class represents the result of a variant detector.',
 };
 
-#Most detector-specific logic is in Detector.pm
+#This is a concrete subclass for "DetectionBase" that adds no additional functionality.
 
 1;

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Result/Filter.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Result/Filter.pm
@@ -31,8 +31,6 @@ class Genome::Model::Tools::DetectVariants2::Result::Filter {
     ],
 };
 
-#Most filter-specific logic is in Detector.pm
-
 sub previous_result {
     my $self = shift;
 


### PR DESCRIPTION
These comments have been a minor annoyance for a while.  It's unclear (to me) what "Detector.pm" might be referring to, even if it is one that still exists.

I wasn't sure whether to write a replacement comment in GMT:DV2::Result or to remove it.  Is it better with or without it?
