### PR TITLE
Respect the active flag when deciding if it's safe to delete children.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -537,7 +537,7 @@ sub delete {
 
     # find child objects for which there are no more users.
     for my $child (@child_objects) {
-        my @users = Genome::SoftwareResult::User->get(software_result => $child);
+        my @users = Genome::SoftwareResult::User->get(software_result => $child, active => 1);
         $child->delete if !@users;
     }
 


### PR DESCRIPTION
The upcoming automatically-added users will typically never be deleted.  It should be sufficient that they're flagged as inactive.
