### PR TITLE
Remove old subclassification methods from ReferenceAlignment.

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
@@ -1011,32 +1011,6 @@ sub eviscerate {
     }
 }
 
-sub _X_resolve_subclass_name { # only temporary, subclass will soon be stored
-    my $class = shift;
-    return __PACKAGE__->_resolve_subclass_name_by_sequencing_platform(@_);
-}
-
-
-sub _resolve_subclass_name_for_sequencing_platform {
-    my ($class,$sequencing_platform) = @_;
-    my @type_parts = split(' ',$sequencing_platform);
-
-    my @sub_parts = map { ucfirst } @type_parts;
-    my $subclass = join('',@sub_parts);
-
-    my $class_name = join('::', 'Genome::Model::Build::ReferenceAlignment' , $subclass);
-    return $class_name;
-}
-
-sub _resolve_sequencing_platform_for_subclass_name {
-    my ($class,$subclass_name) = @_;
-    my ($ext) = ($subclass_name =~ /Genome::Model::Build::ReferenceAlignment::(.*)/);
-    return unless ($ext);
-    my @words = $ext =~ /[a-z]+|[A-Z](?:[A-Z]+|[a-z]*)(?=$|[A-Z])/g;
-    my $sequencing_platform = lc(join(" ", @words));
-    return $sequencing_platform;
-}
-
 #This directory is used by both cDNA and now Capture models as well
 sub reference_coverage_directory {
     my $self = shift;

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -401,60 +401,6 @@ sub filter_ruleset_params {
 }
 
 
-#< SUBCLASSING >#
-#
-# This is called by the infrastructure to appropriately classify abstract processing profiles
-# according to their type name because of the "sub_classification_method_name" setting
-# in the class definiton...
-sub _X_resolve_subclass_name {
-    my $class = shift;
-
-    my $sequencing_platform;
-    if ( ref($_[0]) and $_[0]->can('params') ) {
-        my @params = $_[0]->params;
-        my @seq_plat_param = grep { $_->name eq 'sequencing_platform' } @params;
-        if (scalar(@seq_plat_param) == 1) {
-            $sequencing_platform = $seq_plat_param[0]->value;
-        }
-
-    }  else {
-        my %params = @_;
-        $sequencing_platform = $params{sequencing_platform};
-    }
-
-    unless ( $sequencing_platform ) {
-        my $rule = $class->define_boolexpr(@_);
-        $sequencing_platform = $rule->value_for('sequencing_platform');
-    }
-
-    return ( defined $sequencing_platform )
-    ? $class->_resolve_subclass_name_for_sequencing_platform($sequencing_platform)
-    : undef;
-}
-
-sub _resolve_subclass_name_for_sequencing_platform {
-    my ($class,$sequencing_platform) = @_;
-    my @type_parts = split(' ',$sequencing_platform);
-
-    my @sub_parts = map { ucfirst } @type_parts;
-    my $subclass = join('',@sub_parts);
-
-    my $class_name = join('::', 'Genome::ProcessingProfile::ReferenceAlignment' , $subclass);
-    return $class_name;
-}
-
-sub _resolve_sequencing_platform_for_class {
-    my $class = shift;
-
-    my ($subclass) = $class =~ /^Genome::ProcessingProfile::ReferenceAlignment::([\w\d]+)$/;
-    return unless $subclass;
-
-    return lc join(" ", ($subclass =~ /[a-z\d]+|[A-Z\d](?:[A-Z\d]+|[a-z]*)(?=$|[A-Z\d])/gx));
-
-    my @words = $subclass =~ /[a-z\d]+|[A-Z\d](?:[A-Z\d]+|[a-z]*)(?=$|[A-Z\d])/gx;
-    return lc(join(" ", @words));
-}
-
 #### IMPLEMENTATION #####
 
 sub stages {


### PR DESCRIPTION
These were replaced by the calculated+immutable version in 35a703b98545aca94785442a997a95fc2b9178ae (from before the redaction).