### PR TITLE
get_alignments() defers to existing method to get each alignment.

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
@@ -415,8 +415,7 @@ sub compare_snps_file {
 
 sub get_alignments {
     my $self = shift;
-    return map { $self->model->processing_profile->results_for_instrument_data_input($_) }
-        $self->instrument_data_inputs;
+    return map { $self->alignment_results_for_instrument_data($_) } $self->instrument_data;
 }
 
 sub get_alignment_bams {


### PR DESCRIPTION
The other method handles segment information, so it should work in more situations.