### PR TITLE
Remove WithSavedResults from Genome::Db::Cosmic::Command::Import

### DIFF
--- a/lib/perl/Genome/Db/Cosmic/Command/Import.pm
+++ b/lib/perl/Genome/Db/Cosmic/Command/Import.pm
@@ -4,7 +4,7 @@ use warnings;
 use Genome;
 
 class  Genome::Db::Cosmic::Command::Import {
-    is => 'Genome::Command::WithSavedResults',
+    is => 'Command::V2',
     has_input => [
         source_name         => { is => 'Text', is_constant => 1, value => 'cosmic' },
         database_name       => { is => 'Text', is_constant => 1, value => '' },           
@@ -13,6 +13,12 @@ class  Genome::Db::Cosmic::Command::Import {
     ],
     has_param => [
         result_version      => { is => 'Integer', default_value => 1 },
+    ],
+    has_output => [
+        output_dir  => {
+            is => 'FilesystemPath',
+            doc => 'the output directory',
+        },
     ],
     #    source_directory    => { is => 'Text', is_constant => 1, value => undef },                       
     #    data_directory      => { is => 'Text', is_constant => 1, value => undef },           


### PR DESCRIPTION
As part of the ongoing SoftwareResult project `WithSavedResults` must be changed.  Since this importer is non-functional (`execute()` ends in `die()`), I propose to remove its inheritance instead of updating it to the new interface.

[My preferred course of action would be to merge PR #207, thus removing this module completely.]