### PR TITLE
Add functionality to compare Genome::Process output files

### DIFF
--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -600,7 +600,7 @@ sub unique_results {
 sub result_with_label {
     my ($self, $label) = validate_pos(@_, 1, 1);
 
-    my @results = grep {$_->users(label => $label)} $self->unique_results;
+    my @results = grep {my @users = $_->users(label => $label); scalar(@users) > 0} $self->unique_results;
     if (scalar(@results) != 1) {
         die sprintf("Found (%d) results with label (%s), but expected only one, they are: %s",
             scalar(@results), $label, pp(map {$_->id} @results));

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -630,5 +630,31 @@ sub result_is_on_cle_disk_group {
     return Genome::Disk::Group::Validate::GenomeDiskGroups::is_cle_disk_group_name($disk_group_name);
 }
 
+sub compare_output {
+    my ($self, $other_process_id) = @_;
+    my $process_id = $self->id;
+
+    unless (defined ($other_process_id)) {
+        die $self->error_message('Require process ID argument!');
+    }
+    my $other_process = Genome::Process->get($other_process_id);
+    unless ($other_process) {
+        die $self->error_message('Could not get process for ID (%s)', $other_process_id);
+    }
+
+    unless ($self->class eq $other_process->class) {
+        die $self->error_message('Processes (%s) annd (%s) are not of the same type', $process_id, $other_process_id);
+    }
+
+    my %diffs = $self->_compare_output_files($other_process);
+
+    return %diffs;
+}
+
+sub _compare_output_files {
+    my ($self, $other_process) = @_;
+
+    die $self->error_message('Abstract method (_compare_output_files) must be defined in subclass (%s)', $self->class);
+}
 
 1;

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t
@@ -52,6 +52,44 @@ subtest 'working_command' => sub {
     my $expected_process_dir = File::Spec->join($test_dir, "expected_in_process");
     compare_dir_ok($p->metadata_directory, $expected_process_dir,
         'All metadata files are as expected');
+
+    subtest 'test compare_output subroutine - same inputs' => sub {
+        my $other_test_dir = Genome::Sys->create_temp_directory;
+        Genome::Sys->rsync_directory(
+            source_directory => $code_test_dir,
+            target_directory => $other_test_dir
+        );
+        my $other_input_vcf = File::Spec->join($other_test_dir, 'input.vcf');
+
+        my $other_cmd = $pkg->create(
+            input_vcf => $other_input_vcf,
+            variant_type => 'snvs',
+            plan_file => File::Spec->join($other_test_dir, 'plan.yaml'),
+            translations_file => get_translations_file($other_input_vcf),
+        );
+        my $other_p = $other_cmd->execute();
+        is($p->output_directory('__test__'), $other_p->output_directory('__test__'), 'Output directory is the same');
+        is_deeply({$p->compare_output($other_p->id)}, {}, 'Two identical process executions produce the same output');
+    };
+
+    subtest 'test compare_output subroutine - different inputs' => sub {
+        my $other_test_dir = Genome::Sys->create_temp_directory;
+        Genome::Sys->rsync_directory(
+            source_directory => $code_test_dir,
+            target_directory => $other_test_dir
+        );
+        my $other_input_vcf = File::Spec->join($other_test_dir, 'other_input.vcf');
+
+        my $other_cmd = $pkg->create(
+            input_vcf => $other_input_vcf,
+            variant_type => 'snvs',
+            plan_file => File::Spec->join($other_test_dir, 'plan.yaml'),
+            translations_file => get_translations_file($other_input_vcf),
+        );
+        my $other_p = $other_cmd->execute();
+        my %diffs = $p->compare_output($other_p->id);
+        is_deeply([keys %diffs], [File::Spec->join($other_p->output_directory('__test__'), 'report.txt')], 'Two process executions with different input files produce different reports');
+    };
 };
 
 subtest 'no_translations_file' => sub {

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/other_input.vcf
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/other_input.vcf
@@ -1,0 +1,51 @@
+##fileformat=VCFv4.1
+##source=Samtools
+##reference=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/BUILD.36.3/special_requests/assembly_variants/NCBI36_WUGSC_variant.fa.gz
+##phasing=none
+##center=genome.wustl.edu
+##FILTER=<ID=PASS,Description="Passed all filters">
+##FILTER=<ID=SnpFilter,Description="Filter description">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth at this position in the sample">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Depth of reads supporting alleles 0/1/2/3...">
+##FORMAT=<ID=DP4,Number=4,Type=Integer,Description="Number of high-quality ref-forward, ref-reverse, alt-forward and alt-reverse bases">
+##FORMAT=<ID=BQ,Number=.,Type=Integer,Description="Average base quality for reads supporting alleles">
+##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post-transcriptional modification,5=unknown">
+##FORMAT=<ID=GQ,Number=.,Type=Integer,Description="Conditional Phred-scaled genotype quality">
+##FORMAT=<ID=MQ,Number=1,Type=Integer,Description="Phred style probability score that the variant is novel with respect to the genome's ancestor">
+##FORMAT=<ID=FA,Number=1,Type=Float,Description="Fraction of reads supporting ALT">
+##FORMAT=<ID=VAQ,Number=1,Type=Integer,Description="Variant allele quality">
+##FORMAT=<ID=FT,Number=1,Type=String,Description="Sample genotype filter">
+##source=Sniper
+##FILTER=<ID=FalsePositive,Description="Filter description">
+##FILTER=<ID=SomaticScoreMappingQuality,Description="Filter description">
+##FORMAT=<ID=AMQ,Number=.,Type=Integer,Description="Average mapping quality for each allele present in the genotype">
+##FORMAT=<ID=IGT,Number=1,Type=String,Description="Genotype when called independently (only filled if called in joint prior mode)">
+##FORMAT=<ID=BCOUNT,Number=4,Type=Integer,Description="Occurrence count for each base at this site (A,C,G,T)">
+##FORMAT=<ID=JGQ,Number=1,Type=Integer,Description="Joint genotype quality (only filled if called in join prior mode)">
+##FORMAT=<ID=SSC,Number=1,Type=Integer,Description="Somatic score between 0 and 255">
+##FILTER=<ID=IntersectionFailure,Description="Variant callers do not agree on this position">
+##source=VarscanSomatic
+##FILTER=<ID=VarscanHighConfidence,Description="Filter description">
+##source=Strelka
+##FORMAT=<ID=FDP,Number=1,Type=Integer,Description="Number of basecalls filtered from original read depth for tier1">
+##FORMAT=<ID=SDP,Number=1,Type=Integer,Description="Number of reads with deletions spanning this site at tier1">
+##FORMAT=<ID=SUBDP,Number=1,Type=Integer,Description="Number of reads below tier1 mapping quality threshold aligned across this site">
+##FORMAT=<ID=AU,Number=2,Type=Integer,Description="Number of 'A' alleles used in tiers 1,2">
+##FORMAT=<ID=CU,Number=2,Type=Integer,Description="Number of 'C' alleles used in tiers 1,2">
+##FORMAT=<ID=GU,Number=2,Type=Integer,Description="Number of 'G' alleles used in tiers 1,2">
+##FORMAT=<ID=TU,Number=2,Type=Integer,Description="Number of 'T' alleles used in tiers 1,2">
+##INFO=<ID=QSS,Number=1,Type=Integer,Description="Quality score for any somatic snv, ie. for the ALT allele to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=TQSS,Number=1,Type=Integer,Description="Data tier used to compute QSS">
+##INFO=<ID=NT,Number=1,Type=String,Description="Genotype of the normal in all data tiers, as used to classify somatic variants. One of {ref,het,hom,conflict}.">
+##INFO=<ID=QSS_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=TQSS_NT,Number=1,Type=Integer,Description="Data tier used to compute QSS_NT">
+##INFO=<ID=SGT,Number=1,Type=String,Description="Most likely somatic genotype excluding normal noise states">
+##FILTER=<ID=BCNoise,Description="Fraction of basecalls filtered at this site in either sample is at or above 0.4">
+##FILTER=<ID=SpanDel,Description="Fraction of reads crossing site with spanning deletions in either sample exceeeds 0.75">
+##FILTER=<ID=QSS_ref,Description="Normal sample is not homozygous ref or ssnv Q-score < 15, ie calls with NT!=ref or QSS_NT < 15">
+##FILTER=<ID=DP,Description="Greater than 3x chromosomal mean depth in Normal sample">
+##fileDate=20140422
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TEST-patient1-somval_tumor1	TEST-patient1-somval_tumor1-[Samtools]	TEST-patient1-somval_normal1	TEST-patient1-somval_normal1-[Sniper]	TEST-patient1-somval_tumor1-[Sniper]	TEST-patient1-somval_normal1-[VarscanSomatic]	TEST-patient1-somval_tumor1-[VarscanSomatic]	TEST-patient1-somval_normal1-[Strelka]	TEST-patient1-somval_tumor1-[Strelka]
+1	511466	.	G	T	2	.	.	GT:GQ:DP:BQ:MQ:AD:FA:VAQ:SS:FT	1/1:0:1:0,37:32:0,1:1:2:.:IntersectionFailure;SnpFilter	1/1:0:1:0,37:32:0,1:1:2:.:SnpFilter	.	.	.	.	.	.	.
+1	558077	.	C	T	4	.	.	GT:GQ:DP:BQ:MQ:AD:FA:VAQ:SS:FT	0/1:0:1:0,34:46:0,1:1:4:.:IntersectionFailure;SnpFilter	0/1:0:1:0,34:46:0,1:1:4:.:SnpFilter	.	.	.	.	.	.	.

--- a/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
+++ b/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
@@ -104,7 +104,7 @@ sub _compare_output_files {
                 } elsif (! $other_file) {
                     $diffs{$file} = sprintf(
                         'no file %s found for process %s and report %s with output_directory %s',
-                        File::Spec->abs2rel($file, $output_dir), $other_process->id, $report, $output_dir
+                        File::Spec->abs2rel($file, $output_dir), $other_process->id, $report, $other_output_dir
                     );
                 } else {
                     $diffs{$other_file} = sprintf(

--- a/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
+++ b/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
@@ -97,9 +97,9 @@ sub _compare_output_files {
             sub {
                 my ($other_file, $file) = @_;
                 if (! $file) {
-                    $diffs{$other_file} = sprintf('no file %s from process %s', $other_file, $other_process->id);
+                    $diffs{$other_file} = sprintf('no file %s from process %s', $other_file, $self->id);
                 } elsif (! $other_file) {
-                    $diffs{$file} = sprintf('no file %s from process %s', $file, $self->id);
+                    $diffs{$file} = sprintf('no file %s from process %s', $file, $other_process->id);
                 } else {
                     $diffs{$other_file} = sprintf('files are not the same (diff -u {%s,%s}/%s)', $output_dir, $other_output_dir, File::Spec->abs2rel($other_file, $other_output_dir));
                 }

--- a/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
+++ b/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
@@ -97,11 +97,20 @@ sub _compare_output_files {
             sub {
                 my ($other_file, $file) = @_;
                 if (! $file) {
-                    $diffs{$other_file} = sprintf('no file %s from process %s', $other_file, $self->id);
+                    $diffs{$other_file} = sprintf(
+                        'no file %s found for process %s and report %s with output directory %s',
+                        File::Spec->abs2rel($other_file, $other_output_dir), $self->id, $report, $output_dir
+                    );
                 } elsif (! $other_file) {
-                    $diffs{$file} = sprintf('no file %s from process %s', $file, $other_process->id);
+                    $diffs{$file} = sprintf(
+                        'no file %s found for process %s and report %s with output_directory %s',
+                        File::Spec->abs2rel($file, $output_dir), $other_process->id, $report, $output_dir
+                    );
                 } else {
-                    $diffs{$other_file} = sprintf('files are not the same (diff -u {%s,%s}/%s)', $output_dir, $other_output_dir, File::Spec->abs2rel($other_file, $other_output_dir));
+                    $diffs{$other_file} = sprintf(
+                        'files are not the same for report %s (diff -u {%s,%s}/%s)',
+                        $report, $output_dir, $other_output_dir, File::Spec->abs2rel($other_file, $other_output_dir)
+                    );
                 }
             },
         );

--- a/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
+++ b/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
@@ -95,13 +95,13 @@ sub _compare_output_files {
             $other_output_dir,
             $output_dir,
             sub {
-                my ($a, $b) = @_;
-                if (! $b) {
-                    $diffs{$a} = sprintf('no file %s from process %s', $a, $other_process->id);
-                } elsif (! $a) {
-                    $diffs{$b} = sprintf('no file %s from process %s', $b, $self->id);
+                my ($other_file, $file) = @_;
+                if (! $file) {
+                    $diffs{$other_file} = sprintf('no file %s from process %s', $other_file, $other_process->id);
+                } elsif (! $other_file) {
+                    $diffs{$file} = sprintf('no file %s from process %s', $file, $self->id);
                 } else {
-                    $diffs{$a} = sprintf('files are not the same (diff -u {%s,%s}/%s)', $output_dir, $other_output_dir, File::Spec->abs2rel($a, $other_output_dir));
+                    $diffs{$other_file} = sprintf('files are not the same (diff -u {%s,%s}/%s)', $output_dir, $other_output_dir, File::Spec->abs2rel($other_file, $other_output_dir));
                 }
             },
         );

--- a/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
+++ b/lib/perl/Genome/VariantReporting/Process/CreateReport.pm
@@ -103,7 +103,7 @@ sub _compare_output_files {
                     );
                 } elsif (! $other_file) {
                     $diffs{$file} = sprintf(
-                        'no file %s found for process %s and report %s with output_directory %s',
+                        'no file %s found for process %s and report %s with output directory %s',
                         File::Spec->abs2rel($file, $output_dir), $other_process->id, $report, $other_output_dir
                     );
                 } else {


### PR DESCRIPTION
This is a first step towards tackling https://jira.gsc.wustl.edu/browse/AT-680. This PR implements a compare_output subroutine for Genome::Process that would give a similar output to G::M::B::compare_output.