### PR TITLE
Query reference alignment build directly for inputs.

### DIFF
--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
@@ -43,7 +43,7 @@ sub bsub_rusage {
     my $delegate = $self->results_class;
     my $rusage = $delegate->required_rusage(
         instrument_data => $self->instrument_data,
-        reference_build => $self->model->reference_sequence_build,
+        reference_build => $self->build->reference_sequence_build,
         aligner_params  => $self->model->processing_profile->read_aligner_params,
         queue           => $self->lsf_queue,
     );

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AnnotateTranscriptVariants.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AnnotateTranscriptVariants.pm
@@ -73,7 +73,7 @@ sub execute {
         #reference_transcripts => $self->model->annotation_reference_transcripts, 
         use_version                => $annotator_version,
     );
-    my $abuild = $self->model->annotation_reference_build;
+    my $abuild = $self->build->annotation_reference_build;
     $params{build_id} = $abuild->id if $abuild;
 
     use Data::Dumper;

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/DetectVariants.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/DetectVariants.pm
@@ -34,7 +34,7 @@ sub execute{
     my $bam = $build->whole_rmdup_bam_file;
     $params{aligned_reads_input} = $bam;
 
-    my $reference_build = $build->model->reference_sequence_build;
+    my $reference_build = $build->reference_sequence_build;
     my $reference_fasta = $reference_build->full_consensus_path('fa');
     unless(-e $reference_fasta){
         die $self->error_message("fasta file for reference build doesn't exist!");

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/PrepareReferenceSequenceIndex.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/PrepareReferenceSequenceIndex.pm
@@ -34,7 +34,7 @@ sub lsf_queue {
 sub bsub_rusage {
     my $self = shift;
     my $delegate = $self->alignment_result_class;
-    my $rusage = $delegate->required_rusage_for_building_index(reference_build=>$self->model->reference_sequence_build);
+    my $rusage = $delegate->required_rusage_for_building_index(reference_build=>$self->build->reference_sequence_build);
     return $rusage;
 }
 

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/RunReports.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/RunReports.pm
@@ -31,7 +31,7 @@ sub execute {
         delete $REPORT_TYPES{InputBaseCounts};
     }
 
-    unless (defined $model->dbsnp_build) {
+    unless (defined $build->dbsnp_build) {
         $self->debug_message("No dbsnp_build defined for model, skipping dbsnp concordance report.");
         delete $REPORT_TYPES{DbSnpConcordance};
     } 
@@ -41,7 +41,7 @@ sub execute {
         delete $REPORT_TYPES{GoldSnpConcordance};
     }
     
-    unless ( ($model->dna_type eq 'cdna' || $model->dna_type eq 'rna') && $model->reference_sequence_name =~ /^XStrans_adapt_smallRNA_ribo/ ) {
+    unless ( ($model->dna_type eq 'cdna' || $model->dna_type eq 'rna') && $build->reference_sequence_name =~ /^XStrans_adapt_smallRNA_ribo/ ) {
         delete $REPORT_TYPES{ReferenceCoverage};
     }
     
@@ -139,7 +139,7 @@ sub verify_successful_completion {
 
     delete $REPORT_TYPES{InputBaseCounts} if $model->read_aligner_name =~ /^Imported$/i;
 
-    unless ( ($model->dna_type eq 'cdna' || $model->dna_type eq 'rna') && $model->reference_sequence_name =~ /^XStrans_adapt_smallRNA_ribo/ ) {
+    unless ( ($model->dna_type eq 'cdna' || $model->dna_type eq 'rna') && $build->reference_sequence_name =~ /^XStrans_adapt_smallRNA_ribo/ ) {
         delete $REPORT_TYPES{ReferenceCoverage};
     }
         


### PR DESCRIPTION
The model inputs might have changed from what's recorded on the build as we progress.  The builds then cannot be trusted.