### PR TITLE
Make library_names and sample_names manditory inputs

### DIFF
--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPair.t
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPair.t
@@ -14,10 +14,21 @@ use File::Slurp qw(read_file);
 use Genome::VariantReporting::Command::Wrappers::TestHelpers qw(get_build compare_directories);
 use Genome::VariantReporting::Framework::TestHelpers qw(test_dag_xml);
 use Genome::Utility::Test qw(compare_ok);
+use Sub::Install qw(reinstall_sub);
 
 my $pkg = "Genome::VariantReporting::Command::Wrappers::ModelPair";
 
 use_ok($pkg);
+
+reinstall_sub({
+    into => "Genome::VariantReporting::Command::Wrappers::ModelPair",
+    as => "get_library_names",
+    code => sub {return [qw(
+        TEST-patient1-somval_tumor1-extlib
+        TEST-patient1-somval_tumor2-extlib
+        TEST-patient1-somval_normal1-extlib
+    )]},
+});
 
 my $roi_name = "test_roi";
 my $tumor_sample = Genome::Test::Factory::Sample->setup_object(name => "TEST-patient1-somval_tumor1");

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/Trio.t
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/Trio.t
@@ -55,6 +55,17 @@ reinstall_sub( {
     }
 );
 
+use Genome::VariantReporting::Command::Wrappers::ModelPair;
+reinstall_sub({
+    into => "Genome::VariantReporting::Command::Wrappers::ModelPair",
+    as => "get_library_names",
+    code => sub {return [qw(
+        TEST-patient1-somval_tumor1-extlib
+        TEST-patient1-somval_tumor2-extlib
+        TEST-patient1-somval_normal1-extlib
+    )]},
+});
+
 my $cmd = $pkg->create(
     models => [$discovery_build->model, $followup_build->model, $normal_build->model],
     coverage_models => [$discovery_build->model, $followup_build->model, $normal_build->model],

--- a/lib/perl/Genome/VariantReporting/Framework/Component/Base.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Base.pm
@@ -49,6 +49,8 @@ sub properties_in_plan {
     for my $property ($class->__meta__->properties(
             implied_by => undef,
             is_structural => undef)) {
+        next if $property->{is_param} && $property->property_name =~ m/_md5$/;
+        next if $property->{is_param} && $property->property_name =~ m/_count$/;
         push @properties, $property;
     }
     return @properties;

--- a/lib/perl/Genome/VariantReporting/Framework/Component/WithManyLibraryNames.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/WithManyLibraryNames.pm
@@ -6,7 +6,7 @@ use Genome;
 
 class Genome::VariantReporting::Framework::Component::WithManyLibraryNames {
     is => ['Genome::VariantReporting::Framework::Component::WithTranslatedInputs'],
-    has_transient_optional => [
+    has => [
         library_names => {
             is => 'Text',
             is_many => 1,
@@ -16,6 +16,7 @@ class Genome::VariantReporting::Framework::Component::WithManyLibraryNames {
         library_name_labels => {
             is => 'HASH',
             is_translated => 1,
+            is_optional => 1,
             default => {},
             doc => 'Hash of library_name to label',
         }

--- a/lib/perl/Genome/VariantReporting/Framework/Component/WithManySampleNames.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/WithManySampleNames.pm
@@ -6,7 +6,7 @@ use Genome;
 
 class Genome::VariantReporting::Framework::Component::WithManySampleNames {
     is => ['Genome::VariantReporting::Framework::Component::WithTranslatedInputs'],
-    has_transient_optional => [
+    has => [
         sample_names => {
             is => 'Text',
             is_many => 1,
@@ -16,6 +16,7 @@ class Genome::VariantReporting::Framework::Component::WithManySampleNames {
         sample_name_labels => {
             is => 'HASH',
             is_translated => 1,
+            is_optional => 1,
             default => {},
             doc => 'Hash of sample_name to label',
         }

--- a/lib/perl/Genome/VariantReporting/Report/DocmReport.pm
+++ b/lib/perl/Genome/VariantReporting/Report/DocmReport.pm
@@ -13,6 +13,34 @@ class Genome::VariantReporting::Report::DocmReport {
     is => [ 'Genome::VariantReporting::Report::WithHeader',
         'Genome::VariantReporting::Framework::Component::WithManyLibraryNames',
         'Genome::VariantReporting::Framework::Component::WithManySampleNames'],
+    has_input => [
+        sample_names => {
+            is => 'Text',
+            is_many => 1,
+            is_translated => 1,
+            doc => 'List of sample names to be used in the report',
+        },
+        sample_name_labels => {
+            is => 'HASH',
+            is_translated => 1,
+            is_optional => 1,
+            default => {},
+            doc => 'Hash of sample_name to label',
+        },
+        library_names => {
+            is => 'Text',
+            is_many => 1,
+            is_translated => 1,
+            doc => 'List of library names to be used in the report',
+        },
+        library_name_labels => {
+            is => 'HASH',
+            is_translated => 1,
+            is_optional => 1,
+            default => {},
+            doc => 'Hash of library_name to label',
+        }
+    ],
     doc => 'Output readcount information from bam readcount',
 };
 

--- a/lib/perl/Genome/VariantReporting/Report/FullReport.pm
+++ b/lib/perl/Genome/VariantReporting/Report/FullReport.pm
@@ -7,7 +7,39 @@ use List::Util qw( min );
 use Genome::VariantReporting::Suite::BamReadcount::VafInterpreterHelpers qw(per_sample_vaf_headers per_library_vaf_headers);
 
 class Genome::VariantReporting::Report::FullReport {
-    is => [ 'Genome::VariantReporting::Report::WithHeader', 'Genome::VariantReporting::Framework::Component::WithManySampleNames', 'Genome::VariantReporting::Framework::Component::WithManyLibraryNames'],
+    is => [
+        'Genome::VariantReporting::Report::WithHeader',
+        'Genome::VariantReporting::Framework::Component::WithManySampleNames',
+        'Genome::VariantReporting::Framework::Component::WithManyLibraryNames'
+    ],
+    has_input => [
+        sample_names => {
+            is => 'Text',
+            is_many => 1,
+            is_translated => 1,
+            doc => 'List of sample names to be used in the report',
+        },
+        sample_name_labels => {
+            is => 'HASH',
+            is_translated => 1,
+            is_optional => 1,
+            default => {},
+            doc => 'Hash of sample_name to label',
+        },
+        library_names => {
+            is => 'Text',
+            is_many => 1,
+            is_translated => 1,
+            doc => 'List of library names to be used in the report',
+        },
+        library_name_labels => {
+            is => 'HASH',
+            is_translated => 1,
+            is_optional => 1,
+            default => {},
+            doc => 'Hash of library_name to label',
+        }
+    ],
     doc => "Extensive tab-delimited report covering a set of one or more samples",
 };
 

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/ManySamplesVafInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/ManySamplesVafInterpreter.pm
@@ -40,6 +40,7 @@ sub _interpret_entry {
         my $interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
             sample_name => $sample_name,
             sample_name_label => $self->sample_name_labels->{$sample_name},
+            library_names => [$self->library_names],
             library_name_labels => $self->library_name_labels,
         );
         my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MaxVafObservedInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MaxVafObservedInterpreter.pm
@@ -54,7 +54,10 @@ sub _interpret_entry {
     my $it                    = each_array(@sample_name_accessors, @vaf_hash_names);
     while ( my ($sample_name_accessor, $vaf_hash_ref) = $it->() ) {
         for my $sample_name ($self->$sample_name_accessor) {
-            my $interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(sample_name => $sample_name);
+            my $interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
+                sample_name => $sample_name,
+                library_names => [],
+            );
             my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);
             for my $alt_allele (@$passed_alt_alleles) {
                 my $vaf = $result{$alt_allele}->{$interpreter->create_sample_specific_field_name('vaf')};

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MinCoverageObservedInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MinCoverageObservedInterpreter.pm
@@ -36,6 +36,7 @@ sub _interpret_entry {
         my $interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
             sample_name => $sample_name,
             sample_name_label => $self->sample_name_labels->{$sample_name},
+            library_names => [],
         );
         my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);
         for my $alt_allele (@$passed_alt_alleles) {

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/VafInterpreter.t
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/VafInterpreter.t
@@ -19,9 +19,11 @@ my $pkg = 'Genome::VariantReporting::Suite::BamReadcount::VafInterpreter';
 use_ok($pkg);
 my $factory = Genome::VariantReporting::Framework::Factory->create();
 isa_ok($factory->get_class('interpreters', $pkg->name), $pkg);
+my $library_names = [qw(Solexa-135853 Solexa-135852)];
 
 subtest "one alt allele" => sub {
-    my $interpreter = $pkg->create(sample_name => "S1");
+    my $interpreter = $pkg->create(sample_name => "S1",
+        library_names => $library_names);
     lives_ok(sub {$interpreter->validate}, "Interpreter validates");
 
     my %expected = (
@@ -44,7 +46,8 @@ subtest "one alt allele" => sub {
 };
 
 subtest "insertion" => sub {
-    my $interpreter = $pkg->create(sample_name => "S4");
+    my $interpreter = $pkg->create(sample_name => "S4",
+        library_names => $library_names);
     lives_ok(sub {$interpreter->validate}, "Interpreter validates");
 
     my %expected = (
@@ -67,7 +70,8 @@ subtest "insertion" => sub {
 };
 
 subtest "deletion" => sub {
-    my $interpreter = $pkg->create(sample_name => "S1");
+    my $interpreter = $pkg->create(sample_name => "S1",
+        library_names => $library_names);
     lives_ok(sub {$interpreter->validate}, "Interpreter validates");
 
     my %expected = (


### PR DESCRIPTION
Some care has to be taken for the SoftwareResult subclasses (reports)
since they have to be listed as 'input' or 'param' or the SoftwareResult
infrastructure will yell about ambiguous properties.