### PR TITLE
A default implementation of G:C:DelegatesToResult->input_hash()

### DIFF
--- a/lib/perl/Genome/Command/DelegatesToResult.pm
+++ b/lib/perl/Genome/Command/DelegatesToResult.pm
@@ -34,8 +34,22 @@ sub result_class {
 
 sub input_hash {
     my $self = shift;
-    my $class = $self->class;
-    die "Abstract method 'input_hash' must be defined in class $class";
+
+    my %inputs = ();
+    for my $property ($self->result_class->__meta__->properties()) {
+        next unless $property->{is_param} or $property->{is_input};
+
+        my $name = $property->property_name;
+        next unless $self->can($name);
+
+        if($property->is_many) {
+            $inputs{$name} = [$self->$name];
+        } else {
+            $inputs{$name} = $self->$name;
+        }
+    }
+
+    return %inputs;
 }
 
 sub _input_hash {

--- a/lib/perl/Genome/Model/Tools/Htseq/Count.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count.pm
@@ -76,26 +76,6 @@ sub result_class {
     return __PACKAGE__ . '::Result';
 }
 
-sub input_hash {
-    my $self = shift;
-
-    my %inputs = ();
-    for my $property ($self->result_class->__meta__->properties()) {
-        next unless $property->{is_param} or $property->{is_input};
-
-        my $name = $property->property_name;
-        next unless $self->can($name);
-
-        if($property->is_many) {
-            $inputs{$name} = [$self->$name];
-        } else {
-            $inputs{$name} = $self->$name;
-        }
-    }
-
-    return %inputs;
-}
-
 sub help_synopsis {
     return <<EOS
 

--- a/lib/perl/Genome/VariantReporting/Framework/MergeReports.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/MergeReports.pm
@@ -60,18 +60,4 @@ sub result_class {
     return "Genome::VariantReporting::Framework::Component::Report::MergedReport";
 }
 
-sub input_hash {
-    my $self = shift;
-
-    return (
-        report_results => [$self->report_results],
-        sort_columns => [$self->sort_columns],
-        contains_header => $self->contains_header,
-        use_header_from => $self->use_header_from,
-        separator => $self->separator,
-        split_indicators => [$self->split_indicators],
-        entry_sources => [$self->entry_sources],
-    );
-}
-
 1;


### PR DESCRIPTION
As suggested in #375, use the new implementation of `input_hash` from `Genome::Model::Tools::Htseq::Count` as the default for all `Genome::Command::DelegatesToResult`.