### PR TITLE
Tweaks to DetermineError

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DetermineError.pm
+++ b/lib/perl/Genome/Model/Build/Command/DetermineError.pm
@@ -323,10 +323,11 @@ sub find_die_or_warn_in_log {
 
             $EXCEPTION_FINDING_REGEX,
                 sub {
-                    ($error_date, $error_text, $error_source_file, $error_source_line, $error_host)
-                        = @+{'date','error_text','error_source_file','error_source_line','host'};
-
-                    last SCAN_FILE if ($error_host);
+                    unless($error_text) {
+                        ($error_date, $error_text, $error_source_file, $error_source_line, $error_host)
+                            = @+{'date','error_text','error_source_file','error_source_line','host'};
+                        last SCAN_FILE if ($error_host);
+                    }
                 },
         );
     }

--- a/lib/perl/Genome/Model/Build/Command/DetermineError.t
+++ b/lib/perl/Genome/Model/Build/Command/DetermineError.t
@@ -1,6 +1,8 @@
 use strict;
 use warnings;
 
+use above 'Genome';
+
 use Genome::Model::Build::Command::DetermineError;
 
 use Test::More tests => 5;


### PR DESCRIPTION
*We're after the very last `die()`-ish message in the log file.
*Use `above` so we test the current directory instead of stable.