### PR TITLE
add baseq, mapq parameters for docm bamrc.

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -403,6 +403,8 @@ sub map_workflow_inputs {
       push @dirs, $docm_report_dir;
       push @inputs, docm_report_dir => $docm_report_dir;
       push @inputs, docm_variants_file => $docm_variants_file;
+      push @inputs, docmreport_min_bq => 0;
+      push @inputs, docmreport_min_mq => 1;
     }
 
     #SummarizeSvs
@@ -966,8 +968,10 @@ sub _resolve_workflow_for_build {
     $add_link->($input_connector, 'build', $docm_report_op, 'builds');
     $add_link->($input_connector, 'docm_variants_file', $docm_report_op, 'docm_variants_file');
     $add_link->($input_connector, 'bam_readcount_version', $docm_report_op, 'bam_readcount_version');
+    $add_link->($input_connector, 'docmreport_min_bq', $docm_report_op, 'bq');
+    $add_link->($input_connector, 'docmreport_min_mq', $docm_report_op, 'mq');
     $add_link->($docm_report_op, 'result', $output_connector, 'docm_report_result');
-  }
+}
 
   #SummarizeCnvs - Generate a summary of CNV results, copy cnvs.hq, cnvs.png, single-bam copy number plot PDF, etc. to the cnv directory
   #This step relies on the generate-clonality-plots step already having been run


### PR DESCRIPTION
control the mapping quality and base quality parameters for
bam-readcounting for DOCM sites. We need to be as sensitive as possible
so set these to the absolute minimum.