### PR TITLE
Add functionality to compare Genome::Process output files

### DIFF
--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -679,31 +679,13 @@ sub _compare_output_directories {
             my $other_target = defined($other_file)? abs_path($other_file) : undef;
             my $target = defined($file) ? abs_path($file) : undef;
             if (! $target) {
-                if (-f $other_target) {
-                    $diffs{$other_target} = sprintf(
-                        $template,
-                        'file', File::Spec->abs2rel($other_file, $other_output_dir), $self->id
-                    );
-                }
-                elsif (-d $other_target) {
-                    $diffs{File::Spec->abs2rel($other_file, $other_output_dir)} = sprintf(
-                        $template,
-                        'directory', File::Spec->abs2rel($other_file, $other_output_dir), $self->id
-                    );
-                }
+                my $type = ( -f $other_target ? 'file' : 'directory' );
+                my $rel_path = File::Spec->abs2rel($other_file, $other_output_dir);
+                $diffs{$rel_path} = sprintf($template, $type, $rel_path, $self->id);
             } elsif (! $other_target) {
-                if (-f $target) {
-                    $diffs{$target} = sprintf(
-                        $template,
-                        'file', File::Spec->abs2rel($file, $output_dir), $other_process->id
-                    );
-                }
-                elsif (-d $target) {
-                    $diffs{File::Spec->abs2rel($file, $output_dir)} = sprintf(
-                        $template,
-                        'directory', File::Spec->abs2rel($other_file, $other_output_dir), $self->id
-                    );
-                }
+                my $type = ( -f $target ? 'file' : 'directory' );
+                my $rel_path = File::Spec->abs2rel($file, $output_dir);
+                $diffs{$rel_path} = sprintf($template, $type, $rel_path, $other_process->id);
             } else {
                 if (-d $target && -d $other_target) {
                     my %additional_diffs = $self->_compare_output_directories($target, $other_target, $other_process);
@@ -713,7 +695,7 @@ sub _compare_output_directories {
                     #Files are in fact the same - do nothing
                 }
                 else {
-                    $diffs{$other_target} = sprintf(
+                    $diffs{File::Spec->abs2rel($file, $output_dir)} = sprintf(
                         'files are not the same (diff -u %s %s)',
                         $target, $other_target
                     );

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -675,30 +675,31 @@ sub _compare_output_directories {
         $output_dir,
         sub {
             my ($other_file, $file) = @_;
+            my $template = 'no %s %s found for process %s';
             if (! $file) {
                 if (-f $other_file) {
                     $diffs{abs_path($other_file)} = sprintf(
-                        'no file %s found for process %s',
-                        File::Spec->abs2rel($other_file, $other_output_dir), $self->id
+                        $template,
+                        'file', File::Spec->abs2rel($other_file, $other_output_dir), $self->id
                     );
                 }
                 elsif (-d $other_file) {
                     $diffs{File::Spec->abs2rel($other_file, $other_output_dir)} = sprintf(
-                        'no directory %s found for process %s',
-                        File::Spec->abs2rel($other_file, $other_output_dir), $self->id
+                        $template,
+                        'directory', File::Spec->abs2rel($other_file, $other_output_dir), $self->id
                     );
                 }
             } elsif (! $other_file) {
                 if (-f $file) {
                     $diffs{abs_path($file)} = sprintf(
-                        'no file %s found for process %s',
-                        File::Spec->abs2rel($file, $output_dir), $other_process->id
+                        $template,
+                        'file', File::Spec->abs2rel($file, $output_dir), $other_process->id
                     );
                 }
                 elsif (-d $file) {
                     $diffs{File::Spec->abs2rel($file, $output_dir)} = sprintf(
-                        'no directory %s found for process %s',
-                        File::Spec->abs2rel($other_file, $other_output_dir), $self->id
+                        $template,
+                        'directory', File::Spec->abs2rel($other_file, $other_output_dir), $self->id
                     );
                 }
             } else {

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -630,5 +630,31 @@ sub result_is_on_cle_disk_group {
     return Genome::Disk::Group::Validate::GenomeDiskGroups::is_cle_disk_group_name($disk_group_name);
 }
 
+sub compare_output {
+    my ($self, $other_process_id) = @_;
+    my $process_id = $self->id;
+
+    unless (defined ($other_process_id)) {
+        die $self->error_message('Require process ID argument!');
+    }
+    my $other_process = Genome::Process->get($other_process_id);
+    unless ($other_process) {
+        die $self->error_message('Could not get process for ID (%s)', $other_process_id);
+    }
+
+    unless ($self->class eq $other_process->class) {
+        die $self->error_message('Processes (%s) and (%s) are not of the same type', $process_id, $other_process_id);
+    }
+
+    my %diffs = $self->_compare_output_files($other_process);
+
+    return %diffs;
+}
+
+sub _compare_output_files {
+    my ($self, $other_process) = @_;
+
+    die $self->error_message('Abstract method (_compare_output_files) must be defined in subclass (%s)', $self->class);
+}
 
 1;

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -697,7 +697,7 @@ sub _compare_output_directories {
                 else {
                     $diffs{File::Spec->abs2rel($file, $output_dir)} = sprintf(
                         'files are not the same (diff -u %s %s)',
-                        $target, $other_target
+                        $file, $other_file
                     );
                 }
             }

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -600,7 +600,7 @@ sub unique_results {
 sub result_with_label {
     my ($self, $label) = validate_pos(@_, 1, 1);
 
-    my @results = grep {$_->users(label => $label)} $self->unique_results;
+    my @results = grep {() = $_->users(label => $label)} $self->unique_results;
     if (scalar(@results) != 1) {
         die sprintf("Found (%d) results with label (%s), but expected only one, they are: %s",
             scalar(@results), $label, pp(map {$_->id} @results));

--- a/lib/perl/Genome/Process.t
+++ b/lib/perl/Genome/Process.t
@@ -128,33 +128,3 @@ while (my ($subdir, $test_info) = each %tests) {
 }
 
 done_testing();
-
-sub compare {
-    my ($original_dir, $other_dir) = @_;
-
-    my @diffs;
-    Genome::Utility::File::DirCompare->compare(
-        $original_dir,
-        $other_dir,
-        sub {
-            my ($original_file, $other_file) = @_;
-            if (! $original_file) {
-                push @diffs, sprintf(
-                    'Additional file %s in directory %s',
-                    File::Spec->abs2rel($other_file, $other_dir), $other_dir
-                );
-            } elsif (! $other_file) {
-                push @diffs, sprintf(
-                    'Missing file %s in directory %s',
-                    File::Spec->abs2rel($original_file, $original_dir), $other_dir
-                );
-            } else {
-                push @diffs, sprintf(
-                    'File content changed for file %s (diff -u %s %s)',
-                    File::Spec->abs2rel($original_file, $original_dir), $original_file, $other_file
-                );
-            }
-        },
-    );
-    return @diffs;
-}

--- a/lib/perl/Genome/Process.t.d/additional/file1
+++ b/lib/perl/Genome/Process.t.d/additional/file1
@@ -1,0 +1,2 @@
+line 1
+line 2

--- a/lib/perl/Genome/Process.t.d/additional/file2
+++ b/lib/perl/Genome/Process.t.d/additional/file2
@@ -1,0 +1,2 @@
+other line 1
+other line 2

--- a/lib/perl/Genome/Process.t.d/additional/file3
+++ b/lib/perl/Genome/Process.t.d/additional/file3
@@ -1,0 +1,2 @@
+another line 1
+another line 2

--- a/lib/perl/Genome/Process.t.d/changed/file1
+++ b/lib/perl/Genome/Process.t.d/changed/file1
@@ -1,0 +1,2 @@
+line 1
+line 2

--- a/lib/perl/Genome/Process.t.d/changed/file2
+++ b/lib/perl/Genome/Process.t.d/changed/file2
@@ -1,0 +1,2 @@
+other line 1
+other line 3

--- a/lib/perl/Genome/Process.t.d/cicular_symlink
+++ b/lib/perl/Genome/Process.t.d/cicular_symlink
@@ -1,0 +1,1 @@
+circular_symlink/file2

--- a/lib/perl/Genome/Process.t.d/circular_symlink/file1
+++ b/lib/perl/Genome/Process.t.d/circular_symlink/file1
@@ -1,0 +1,2 @@
+line 1
+line 2

--- a/lib/perl/Genome/Process.t.d/circular_symlink/file2
+++ b/lib/perl/Genome/Process.t.d/circular_symlink/file2
@@ -1,0 +1,1 @@
+../cicular_symlink

--- a/lib/perl/Genome/Process.t.d/deep_symlink/file1
+++ b/lib/perl/Genome/Process.t.d/deep_symlink/file1
@@ -1,0 +1,2 @@
+line 1
+line 2

--- a/lib/perl/Genome/Process.t.d/deep_symlink/file2
+++ b/lib/perl/Genome/Process.t.d/deep_symlink/file2
@@ -1,0 +1,1 @@
+../symlink_to_symlink

--- a/lib/perl/Genome/Process.t.d/identical/file1
+++ b/lib/perl/Genome/Process.t.d/identical/file1
@@ -1,0 +1,2 @@
+line 1
+line 2

--- a/lib/perl/Genome/Process.t.d/identical/file2
+++ b/lib/perl/Genome/Process.t.d/identical/file2
@@ -1,0 +1,2 @@
+other line 1
+other line 2

--- a/lib/perl/Genome/Process.t.d/missing/file1
+++ b/lib/perl/Genome/Process.t.d/missing/file1
@@ -1,0 +1,2 @@
+line 1
+line 2

--- a/lib/perl/Genome/Process.t.d/original/file1
+++ b/lib/perl/Genome/Process.t.d/original/file1
@@ -1,0 +1,2 @@
+line 1
+line 2

--- a/lib/perl/Genome/Process.t.d/original/file2
+++ b/lib/perl/Genome/Process.t.d/original/file2
@@ -1,0 +1,2 @@
+other line 1
+other line 2

--- a/lib/perl/Genome/Process.t.d/symlink/file1
+++ b/lib/perl/Genome/Process.t.d/symlink/file1
@@ -1,0 +1,2 @@
+line 1
+line 2

--- a/lib/perl/Genome/Process.t.d/symlink/file2
+++ b/lib/perl/Genome/Process.t.d/symlink/file2
@@ -1,0 +1,1 @@
+../symlink_to_symlink

--- a/lib/perl/Genome/Process.t.d/symlink_to_symlink
+++ b/lib/perl/Genome/Process.t.d/symlink_to_symlink
@@ -1,0 +1,1 @@
+identical/file2

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t
@@ -52,6 +52,78 @@ subtest 'working_command' => sub {
     my $expected_process_dir = File::Spec->join($test_dir, "expected_in_process");
     compare_dir_ok($p->metadata_directory, $expected_process_dir,
         'All metadata files are as expected');
+
+    subtest 'test compare_output subroutine - same inputs' => sub {
+        my $other_test_dir = Genome::Sys->create_temp_directory;
+        Genome::Sys->rsync_directory(
+            source_directory => $code_test_dir,
+            target_directory => $other_test_dir
+        );
+        my $other_input_vcf = File::Spec->join($other_test_dir, 'input.vcf');
+        my $other_cmd = $pkg->create(
+            input_vcf => $other_input_vcf,
+            variant_type => 'snvs',
+            plan_file => File::Spec->join($other_test_dir, 'plan.yaml'),
+            translations_file => get_translations_file($other_input_vcf),
+        );
+        my $other_p = $other_cmd->execute();
+        is_deeply({$p->compare_output($other_p->id)}, {}, 'Two identical process executions produce the same output');
+    };
+
+    subtest 'test compare_output subroutine - different inputs' => sub {
+        my $other_test_dir = Genome::Sys->create_temp_directory;
+        Genome::Sys->rsync_directory(
+            source_directory => $code_test_dir,
+            target_directory => $other_test_dir
+        );
+        my $other_input_vcf = File::Spec->join($other_test_dir, 'other_input.vcf');
+
+        my $other_cmd = $pkg->create(
+            input_vcf => $other_input_vcf,
+            variant_type => 'snvs',
+            plan_file => File::Spec->join($other_test_dir, 'plan.yaml'),
+            translations_file => get_translations_file($other_input_vcf),
+        );
+        my $other_p = $other_cmd->execute();
+        my %diffs = $p->compare_output($other_p->id);
+        my $report_file = File::Spec->join($p->output_directory('__test__'), 'report.txt');
+        my $other_report_file = File::Spec->join($other_p->output_directory('__test__'), 'report.txt');
+        is_deeply([keys %diffs], [$other_report_file], 'Two process executions with different input files produce different reports');
+
+        subtest 'test compare_output subroutine - missing file in other report directory' => sub {
+            unlink $other_report_file;
+            %diffs = $p->compare_output($other_p->id);
+            my $other_process_id = $other_p->id;
+            like($diffs{$report_file}, qr/report\.txt.*$other_process_id/, 'Missing files in other report output directory gets detected');
+        };
+        subtest 'test compare_output subroutine - missing file in report directory' => sub {
+            Genome::Sys->move_file($report_file, $other_report_file);
+            %diffs = $p->compare_output($other_p->id);
+            my $process_id = $p->id;
+            like($diffs{$other_report_file}, qr/report\.txt.*$process_id/, 'Missing files in report output directory gets detected');
+            Genome::Sys->copy_file($other_report_file, $report_file);
+        };
+    };
+
+    subtest 'test compare_output subroutine - different plan files with additional report' => sub {
+        my $other_test_dir = Genome::Sys->create_temp_directory;
+        Genome::Sys->rsync_directory(
+            source_directory => $code_test_dir,
+            target_directory => $other_test_dir
+        );
+        my $other_input_vcf = File::Spec->join($other_test_dir, 'input.vcf');
+
+        my $other_cmd = $pkg->create(
+           input_vcf => $other_input_vcf,
+           variant_type => 'snvs',
+           plan_file => File::Spec->join($other_test_dir, 'plan2.yaml'),
+           translations_file => get_translations_file_for_plan2($other_input_vcf),
+        );
+        my $other_p = $other_cmd->execute();
+        my %diffs = $p->compare_output($other_p->id);
+        like($diffs{'__translated_test__'}, qr/no directory __translated_test__ found/, 'Additional report gets detected');
+        like($diffs{File::Spec->join($other_p->output_directory('__test__'), 'plan.yaml')}, qr/files are not the same/, 'Plan file difference gets detected');
+    };
 };
 
 subtest 'no_translations_file' => sub {
@@ -120,6 +192,25 @@ sub get_translations_file {
     my $input_vcf = shift;
 
     my $provider = Genome::VariantReporting::Framework::Component::RuntimeTranslations->create();
+    my $tmp_dir = Genome::Sys->create_temp_directory;
+    my $translations_file = File::Spec->join($tmp_dir, 'resources.yaml');
+    $provider->write_to_file($translations_file);
+    return $translations_file;
+}
+
+sub get_translations_file_for_plan2 {
+    my $input_vcf = shift;
+
+    my $provider = Genome::VariantReporting::Framework::Component::RuntimeTranslations->create(
+        translations => {
+            __input__ => 'test',
+            tumor => 'test sample',
+            old_value => 'new value',
+            old_value1 => 'new value 1',
+            old_value2 => 'new value 2',
+            to_translate1 => 'test',
+        }
+    );
     my $tmp_dir = Genome::Sys->create_temp_directory;
     my $translations_file = File::Spec->join($tmp_dir, 'resources.yaml');
     $provider->write_to_file($translations_file);

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t
@@ -88,19 +88,21 @@ subtest 'working_command' => sub {
         my %diffs = $p->compare_output($other_p->id);
         my $report_file = File::Spec->join($p->output_directory('__test__'), 'report.txt');
         my $other_report_file = File::Spec->join($other_p->output_directory('__test__'), 'report.txt');
-        is_deeply([keys %diffs], [$other_report_file], 'Two process executions with different input files produce different reports');
+        my $diff_key = File::Spec->join('__test__', 'report.txt');
+        is_deeply([keys %diffs], [$diff_key], 'Two process executions with different input files produce different reports');
 
         subtest 'test compare_output subroutine - missing file in other report directory' => sub {
             unlink $other_report_file;
             %diffs = $p->compare_output($other_p->id);
             my $other_process_id = $other_p->id;
-            like($diffs{$report_file}, qr/report\.txt.*$other_process_id/, 'Missing files in other report output directory gets detected');
+            like($diffs{$diff_key}, qr/__test__\/report\.txt.*$other_process_id/, 'Missing files in other report output directory gets detected');
+            Genome::Sys->copy_file($report_file, $other_report_file);
         };
         subtest 'test compare_output subroutine - missing file in report directory' => sub {
-            Genome::Sys->move_file($report_file, $other_report_file);
+            unlink $report_file;
             %diffs = $p->compare_output($other_p->id);
             my $process_id = $p->id;
-            like($diffs{$other_report_file}, qr/report\.txt.*$process_id/, 'Missing files in report output directory gets detected');
+            like($diffs{$diff_key}, qr/__test__\/report\.txt.*$process_id/, 'Missing files in report output directory gets detected');
             Genome::Sys->copy_file($other_report_file, $report_file);
         };
     };
@@ -122,7 +124,7 @@ subtest 'working_command' => sub {
         my $other_p = $other_cmd->execute();
         my %diffs = $p->compare_output($other_p->id);
         like($diffs{'__translated_test__'}, qr/no directory __translated_test__ found/, 'Additional report gets detected');
-        like($diffs{File::Spec->join($other_p->output_directory('__test__'), 'plan.yaml')}, qr/files are not the same/, 'Plan file difference gets detected');
+        like($diffs{File::Spec->join('__test__', 'plan.yaml')}, qr/files are not the same/, 'Plan file difference gets detected');
     };
 };
 

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/expected_in_process/plan.yaml
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/expected_in_process/plan.yaml
@@ -4,4 +4,5 @@ experts:
 reports:
     __test__:
         interpreters:
-            __test__: {}
+            __test__:
+                info_field: TST

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/other_input.vcf
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/other_input.vcf
@@ -1,0 +1,51 @@
+##fileformat=VCFv4.1
+##source=Samtools
+##reference=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/BUILD.36.3/special_requests/assembly_variants/NCBI36_WUGSC_variant.fa.gz
+##phasing=none
+##center=genome.wustl.edu
+##FILTER=<ID=PASS,Description="Passed all filters">
+##FILTER=<ID=SnpFilter,Description="Filter description">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth at this position in the sample">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Depth of reads supporting alleles 0/1/2/3...">
+##FORMAT=<ID=DP4,Number=4,Type=Integer,Description="Number of high-quality ref-forward, ref-reverse, alt-forward and alt-reverse bases">
+##FORMAT=<ID=BQ,Number=.,Type=Integer,Description="Average base quality for reads supporting alleles">
+##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post-transcriptional modification,5=unknown">
+##FORMAT=<ID=GQ,Number=.,Type=Integer,Description="Conditional Phred-scaled genotype quality">
+##FORMAT=<ID=MQ,Number=1,Type=Integer,Description="Phred style probability score that the variant is novel with respect to the genome's ancestor">
+##FORMAT=<ID=FA,Number=1,Type=Float,Description="Fraction of reads supporting ALT">
+##FORMAT=<ID=VAQ,Number=1,Type=Integer,Description="Variant allele quality">
+##FORMAT=<ID=FT,Number=1,Type=String,Description="Sample genotype filter">
+##source=Sniper
+##FILTER=<ID=FalsePositive,Description="Filter description">
+##FILTER=<ID=SomaticScoreMappingQuality,Description="Filter description">
+##FORMAT=<ID=AMQ,Number=.,Type=Integer,Description="Average mapping quality for each allele present in the genotype">
+##FORMAT=<ID=IGT,Number=1,Type=String,Description="Genotype when called independently (only filled if called in joint prior mode)">
+##FORMAT=<ID=BCOUNT,Number=4,Type=Integer,Description="Occurrence count for each base at this site (A,C,G,T)">
+##FORMAT=<ID=JGQ,Number=1,Type=Integer,Description="Joint genotype quality (only filled if called in join prior mode)">
+##FORMAT=<ID=SSC,Number=1,Type=Integer,Description="Somatic score between 0 and 255">
+##FILTER=<ID=IntersectionFailure,Description="Variant callers do not agree on this position">
+##source=VarscanSomatic
+##FILTER=<ID=VarscanHighConfidence,Description="Filter description">
+##source=Strelka
+##FORMAT=<ID=FDP,Number=1,Type=Integer,Description="Number of basecalls filtered from original read depth for tier1">
+##FORMAT=<ID=SDP,Number=1,Type=Integer,Description="Number of reads with deletions spanning this site at tier1">
+##FORMAT=<ID=SUBDP,Number=1,Type=Integer,Description="Number of reads below tier1 mapping quality threshold aligned across this site">
+##FORMAT=<ID=AU,Number=2,Type=Integer,Description="Number of 'A' alleles used in tiers 1,2">
+##FORMAT=<ID=CU,Number=2,Type=Integer,Description="Number of 'C' alleles used in tiers 1,2">
+##FORMAT=<ID=GU,Number=2,Type=Integer,Description="Number of 'G' alleles used in tiers 1,2">
+##FORMAT=<ID=TU,Number=2,Type=Integer,Description="Number of 'T' alleles used in tiers 1,2">
+##INFO=<ID=QSS,Number=1,Type=Integer,Description="Quality score for any somatic snv, ie. for the ALT allele to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=TQSS,Number=1,Type=Integer,Description="Data tier used to compute QSS">
+##INFO=<ID=NT,Number=1,Type=String,Description="Genotype of the normal in all data tiers, as used to classify somatic variants. One of {ref,het,hom,conflict}.">
+##INFO=<ID=QSS_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=TQSS_NT,Number=1,Type=Integer,Description="Data tier used to compute QSS_NT">
+##INFO=<ID=SGT,Number=1,Type=String,Description="Most likely somatic genotype excluding normal noise states">
+##FILTER=<ID=BCNoise,Description="Fraction of basecalls filtered at this site in either sample is at or above 0.4">
+##FILTER=<ID=SpanDel,Description="Fraction of reads crossing site with spanning deletions in either sample exceeeds 0.75">
+##FILTER=<ID=QSS_ref,Description="Normal sample is not homozygous ref or ssnv Q-score < 15, ie calls with NT!=ref or QSS_NT < 15">
+##FILTER=<ID=DP,Description="Greater than 3x chromosomal mean depth in Normal sample">
+##fileDate=20140422
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TEST-patient1-somval_tumor1	TEST-patient1-somval_tumor1-[Samtools]	TEST-patient1-somval_normal1	TEST-patient1-somval_normal1-[Sniper]	TEST-patient1-somval_tumor1-[Sniper]	TEST-patient1-somval_normal1-[VarscanSomatic]	TEST-patient1-somval_tumor1-[VarscanSomatic]	TEST-patient1-somval_normal1-[Strelka]	TEST-patient1-somval_tumor1-[Strelka]
+1	511466	.	G	T	2	.	.	GT:GQ:DP:BQ:MQ:AD:FA:VAQ:SS:FT	1/1:0:1:0,37:32:0,1:1:2:.:IntersectionFailure;SnpFilter	1/1:0:1:0,37:32:0,1:1:2:.:SnpFilter	.	.	.	.	.	.	.
+1	558077	.	C	T	4	.	.	GT:GQ:DP:BQ:MQ:AD:FA:VAQ:SS:FT	0/1:0:1:0,34:46:0,1:1:4:.:IntersectionFailure;SnpFilter	0/1:0:1:0,34:46:0,1:1:4:.:SnpFilter	.	.	.	.	.	.	.

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/plan.yaml
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/plan.yaml
@@ -4,4 +4,5 @@ experts:
 reports:
     __test__:
         interpreters:
-            __test__: {}
+            __test__:
+                info_field: TST

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/plan2.yaml
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t.d/plan2.yaml
@@ -1,0 +1,20 @@
+experts:
+    __test__:
+        __planned__: foo
+    __translated_test__:
+        __planned__: tumor
+        __input__: __input__
+reports:
+    __test__:
+        interpreters:
+            __test__:
+                info_field: TST
+    __translated_test__:
+        interpreters:
+            __translated_test__:
+                translated1: to_translate1
+                translated2:
+                    - old_value
+                translated3:
+                    - old_value1
+                    - old_value2

--- a/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/interpreters/__test__
+++ b/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/interpreters/__test__
@@ -1,6 +1,10 @@
 [4mOVERVIEW[0m
 (undocumented)
 
+[4mPROPERTIES[0m
+  [1minfo_field[0m   Text
+    (undocumented)
+
 [4mREQUIRED EXPERTS[0m
 __test__
 

--- a/lib/perl/Genome/VariantReporting/Framework/Test/Interpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Test/Interpreter.pm
@@ -7,6 +7,12 @@ use Data::Dump qw(pp);
 
 class Genome::VariantReporting::Framework::Test::Interpreter {
     is => 'Genome::VariantReporting::Framework::Component::Interpreter',
+    has => {
+        info_field => {
+            is => 'Text',
+            is_optional => 1,
+        }
+    }
 };
 
 sub name {
@@ -28,7 +34,7 @@ sub _interpret_entry {
 
     my %return_values;
     for my $variant_allele (@$passed_alt_alleles) {
-        $return_values{$variant_allele}->{info} = pp($entry->info_for_allele($variant_allele));
+        $return_values{$variant_allele}->{info} = pp($entry->info_for_allele($variant_allele, $self->info_field));
     }
 
     return %return_values;

--- a/lib/perl/Genome/VariantReporting/Framework/Test/WithTranslationsRun.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Test/WithTranslationsRun.pm
@@ -19,5 +19,5 @@ sub name {
 }
 
 sub result_class {
-    'Genome::VariantReporting::Framework::Test::RunResult';
+    'Genome::VariantReporting::Framework::Test::WithTranslationsRunResult';
 }

--- a/lib/perl/Genome/VariantReporting/Framework/Test/WithTranslationsRunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Test/WithTranslationsRunResult.pm
@@ -1,4 +1,4 @@
-package Genome::VariantReporting::Framework::Test::RunResult;
+package Genome::VariantReporting::Framework::Test::WithTranslationsRunResult;
 
 use strict;
 use warnings FATAL => 'all';
@@ -6,30 +6,12 @@ use Genome;
 use Genome::File::Vcf::Reader;
 use Genome::File::Vcf::Writer;
 
-class Genome::VariantReporting::Framework::Test::RunResult {
-    is => 'Genome::VariantReporting::Framework::Component::Expert::Result',
-    has_input => [
-        __input___lookup => {
-            is_many => 1,
-        },
-    ],
-    has_param => [
-        __planned__ => {},
-    ],
-    has_transient_optional => [
-        __input__ => {
-            is_many => 1,
-        },
-    ],
+class Genome::VariantReporting::Framework::Test::WithTranslationsRunResult {
+    is => 'Genome::VariantReporting::Framework::Test::RunResult',
 };
 
-
-sub output_filename {
-    return '__test__.vcf.gz';
-}
-
 my $info_type = {
-        id => 'TST',
+        id => 'TSTT',
         number => '1',
         type => 'String',
         description => 'Some test info showing things got passed in as expected',
@@ -49,21 +31,12 @@ sub _run {
         $self->__planned__,
     );
     while (my $entry = $reader->next) {
-        $entry->set_info_field('TST', $some_info);
+        $entry->set_info_field('TSTT', $some_info);
         $writer->write($entry);
     }
     $writer->close();
 
     return 1;
 }
-
-sub add_to_header {
-    my ($header, $key, $values) = @_;
-
-    $header->metainfo->{$key} = Genome::File::Vcf::Header::String->new(
-        content => join(', ', @$values),
-    );
-}
-
 
 1;


### PR DESCRIPTION
This PR supersedes https://github.com/genome/genome/pull/374.

This is a first step towards tackling https://jira.gsc.wustl.edu/browse/AT-680. This PR implements a compare_output subroutine for Genome::Process that would give a similar output to G::M::B::compare_output.

In this PR Genome::Process::_compare_output_files handles the comparison instead of being abstract and deferring the implementation to the child classes. It utilizes Genome::Process::symlink_results to symlink all the results of a process into one directory. Genome::Process::_compare_output_directories handles the actual comparison of those directories.