### PR TITLE
Proposed Fixes for RT#103295

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
@@ -1277,6 +1277,7 @@ sub coverage_stats_summary_hash_ref {
 
 sub region_of_interest_set_bed_file {
     my $self = shift;
+    my $bed_file_path = shift; # optional
 
     my $roi_set = $self->model->region_of_interest_set;
     return unless $roi_set;
@@ -1300,7 +1301,11 @@ sub region_of_interest_set_bed_file {
         # This is to retain backward compatibility, previously all BED files had short roi names(like r###)
         $use_short_names = 1;
     }
-    my $bed_file_path = $self->reference_coverage_directory .'/'. $roi_set->id .'.bed';
+
+    unless ($bed_file_path) {
+        $bed_file_path = $self->reference_coverage_directory .'/'. $roi_set->id .'.bed';
+    }
+
     unless (-e $bed_file_path) {
         my %dump_params = (
             feature_list => $roi_set,
@@ -1317,6 +1322,7 @@ sub region_of_interest_set_bed_file {
             die('Failed to print bed file to path '. $bed_file_path);
         }
     }
+
     return $bed_file_path;
 }
 

--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
@@ -1306,7 +1306,7 @@ sub region_of_interest_set_bed_file {
         $bed_file_path = $self->reference_coverage_directory .'/'. $roi_set->id .'.bed';
     }
 
-    unless (-e $bed_file_path) {
+    unless (-s $bed_file_path) {
         my %dump_params = (
             feature_list => $roi_set,
             output_path => $bed_file_path,

--- a/lib/perl/Genome/Model/Tools/CopyNumber/Cnmops.pm
+++ b/lib/perl/Genome/Model/Tools/CopyNumber/Cnmops.pm
@@ -124,7 +124,8 @@ sub get_ROI_bed{
   if($self->roi_bed) {
     return $self->roi_bed;
   } elsif($refalign->last_succeeded_build->region_of_interest_set_bed_file) {
-    return $refalign->last_succeeded_build->region_of_interest_set_bed_file;
+    my $bed_path = Genome::Sys->create_temp_file_path();
+    return $refalign->last_succeeded_build->region_of_interest_set_bed_file($bed_path);
   } else {
     die $self->error_message("Unable to find ROI_set_bed file for " . $refalign->name);
   }

--- a/lib/perl/Genome/Model/Tools/CopyNumber/Cnmops.pm
+++ b/lib/perl/Genome/Model/Tools/CopyNumber/Cnmops.pm
@@ -121,14 +121,18 @@ sub get_refalign_bam {
 sub get_ROI_bed{
   my $self = shift;
   my $refalign = shift;
+
   if($self->roi_bed) {
     return $self->roi_bed;
-  } elsif($refalign->last_succeeded_build->region_of_interest_set_bed_file) {
-    my $bed_path = Genome::Sys->create_temp_file_path();
-    return $refalign->last_succeeded_build->region_of_interest_set_bed_file($bed_path);
-  } else {
-    die $self->error_message("Unable to find ROI_set_bed file for " . $refalign->name);
   }
+
+  my $bed_path = Genome::Sys->create_temp_file_path();
+  my $roi_bed_file = $refalign->last_succeeded_build->region_of_interest_set_bed_file($bed_path);
+  if ($roi_bed_file) {
+    return $roi_bed_file;
+  }
+
+  die $self->error_message("Unable to find ROI_set_bed file for " . $refalign->name);
 }
 
 sub call_cnmops {

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -669,6 +669,9 @@ sub copy_file {
     #  the files can never be exactly the same.
 
     unless ( File::Copy::copy($file, $dest) ) {
+        # It is unclear whether File::Copy::copy intends to remove $dest but we
+        # definitely have cases where it's not.
+        unlink $dest;
         Carp::croak("Can't copy $file to $dest: $!");
     }
 


### PR DESCRIPTION
This is trying to correct the problem that region_of_interest_set_bed_file
writes to a build's data directory but is not run by the build.  This is a
common problem and this only covers when tiny occurence of it.

It also tries to address the fact that the failure left an empty file in place
and that this empty file was passed as an argument to downstream operations.

See [RT#103295][1] for full details.

/cc @jasonwalker80 @malachig 

[1]: https://rt.gsc.wustl.edu/Ticket/Display.html?id=103295