### PR TITLE
Speedup CopyCat Annotation Lister

### DIFF
--- a/lib/perl/Genome/Model/Tools/CopyCat/List.pm
+++ b/lib/perl/Genome/Model/Tools/CopyCat/List.pm
@@ -10,6 +10,9 @@ class Genome::Model::Tools::CopyCat::List {
             is_constant => 1,
             value => 'Genome::Model::Tools::CopyCat::AnnotationData',
         },
+        show => {
+            value => 'id,reference_sequence,version,output_dir',
+        }
     ],
     doc => 'List CopyCat annotation data sets',
 };

--- a/lib/perl/Genome/Model/Tools/CopyCat/List.pm
+++ b/lib/perl/Genome/Model/Tools/CopyCat/List.pm
@@ -14,4 +14,8 @@ class Genome::Model::Tools::CopyCat::List {
     doc => 'List CopyCat annotation data sets',
 };
 
+sub _hint_string {
+    return '';
+}
+
 1;


### PR DESCRIPTION
The lister by default shows (and therefore "hints" at all the properties of the SoftwareResult, which triggers the giant non-performant query on SoftwareResult with joins on the Inputs and Params.  This change means more (but smaller) DB queries, which reduces the runtime of the command from several minutes to under three seconds.
