### PR TITLE
Fix a bug on comparing flagstat

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.t
@@ -18,7 +18,7 @@ use Genome::Utility::Test qw(compare_ok);
 my $pkg = 'Genome::InstrumentData::AlignmentResult::Command::RecreatePerLaneBam';
 use_ok($pkg) or die;
 
-my $test_dir = Genome::Utility::Test->data_dir_ok($pkg, 'v2');
+my $test_dir = Genome::Utility::Test->data_dir_ok($pkg, 'v3');
 my $id       = 2894005341;
 my $out_base = 'all_sequences.bam';
 my $out_dir  = Genome::Sys->create_temp_directory();


### PR DESCRIPTION
Expect one line diff on duplicates between extracting bam flagstat and comparison flagstat. Expect no diff between reverting Markdup bam flagstat and comparison flagstat.The comparison flagstat is always from the original per lane bam that is not markdupped. The unit test is updated accordingly.