### PR TITLE
Some minor changes to the variant caller interpreter

### DIFF
--- a/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/interpreters/variant-callers
+++ b/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/interpreters/variant-callers
@@ -8,7 +8,6 @@ Output a list of variant callers that called this position for the specified sam
     This is a translated property.
   [1mvalid_callers[0m   String
     List of variant callers to include in determination for filtering
-    Default value ["VarscanSomatic", "Sniper", "Strelka"] if not specified
 
 [4mAVAILABLE FIELDS[0m
   [1mvariant_caller_count[0m

--- a/lib/perl/Genome/VariantReporting/Generic/VariantCallersInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Generic/VariantCallersInterpreter.pm
@@ -12,7 +12,6 @@ class Genome::VariantReporting::Generic::VariantCallersInterpreter {
         valid_callers => {
             is => 'String',
             is_many => 1,
-            default_value => [qw(VarscanSomatic Sniper Strelka)],
             doc => 'List of variant callers to include in determination for filtering',
         },
     ],

--- a/lib/perl/Genome/VariantReporting/Generic/VariantCallersInterpreter.t
+++ b/lib/perl/Genome/VariantReporting/Generic/VariantCallersInterpreter.t
@@ -108,6 +108,7 @@ sub run_test {
     my %expected_return_values = @_;
 
     my $interpreter = $pkg->create(
+        valid_callers => [qw(VarscanSomatic Sniper Strelka)],
         sample_name => $sample_name,
     );
     lives_ok(sub {$interpreter->validate}, "Filter validates ok");

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_indels.yaml
@@ -69,6 +69,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels
@@ -185,6 +189,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_indels.yaml
@@ -73,6 +73,8 @@ reports:
                     - VarscanSomatic
                     - Sniper
                     - Strelka
+                    - Pindel
+                    - GatkSomaticIndel
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels
@@ -193,6 +195,8 @@ reports:
                     - VarscanSomatic
                     - Sniper
                     - Strelka
+                    - Pindel
+                    - GATKSomaticIndel
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_snvs.yaml
@@ -62,6 +62,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels
@@ -170,6 +174,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_indels_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_indels_report.yaml
@@ -76,6 +76,8 @@ reports:
                     - VarscanSomatic
                     - Sniper
                     - Strelka
+                    - Pindel
+                    - GatkSomaticIndel
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_indels_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_indels_report.yaml
@@ -72,6 +72,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_snvs_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_snvs_report.yaml
@@ -65,6 +65,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_indels.yaml
@@ -64,6 +64,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels
@@ -160,6 +164,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_indels.yaml
@@ -168,6 +168,8 @@ reports:
                     - VarscanSomatic
                     - Sniper
                     - Strelka
+                    - Pindel
+                    - GatkSomaticIndel
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_indels.yaml
@@ -68,6 +68,8 @@ reports:
                     - VarscanSomatic
                     - Sniper
                     - Strelka
+                    - Pindel
+                    - GatkSomaticIndel
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_snvs.yaml
@@ -56,6 +56,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: normal
             'many-samples-vaf':
                 sample_names:
@@ -143,6 +147,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: normal
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_indels.yaml
@@ -69,6 +69,8 @@ reports:
                     - VarscanSomatic
                     - Sniper
                     - Strelka
+                    - Pindel
+                    - GatkSomaticIndel
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_indels.yaml
@@ -65,6 +65,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_snvs.yaml
@@ -58,6 +58,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/somatic_indels_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/somatic_indels_report.yaml
@@ -74,6 +74,8 @@ reports:
                     - VarscanSomatic
                     - Sniper
                     - Strelka
+                    - Pindel
+                    - GatkSomaticIndel
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/somatic_indels_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/somatic_indels_report.yaml
@@ -70,6 +70,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels

--- a/lib/perl/Genome/VariantReporting/plan_files/somatic_snvs_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/somatic_snvs_report.yaml
@@ -63,6 +63,10 @@ reports:
                 normal_sample_names:
                     - normal
             'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
                 sample_name: discovery_tumor
             'many-samples-vaf':
                 sample_name_labels: sample_name_labels


### PR DESCRIPTION
- List the valid_callers explicitly in the plan files instead of having a default
- Add GatkSomaticIndel and Pindel to the list of valid_callers in the indel plan files