### PR TITLE
Make sample/library name_labels transient

### DIFF
--- a/lib/perl/Genome/VariantReporting/Report/DocmReport.pm
+++ b/lib/perl/Genome/VariantReporting/Report/DocmReport.pm
@@ -20,26 +20,24 @@ class Genome::VariantReporting::Report::DocmReport {
             is_translated => 1,
             doc => 'List of sample names to be used in the report',
         },
-        sample_name_labels => {
-            is => 'HASH',
-            is_translated => 1,
-            is_optional => 1,
-            default => {},
-            doc => 'Hash of sample_name to label',
-        },
         library_names => {
             is => 'Text',
             is_many => 1,
             is_translated => 1,
             doc => 'List of library names to be used in the report',
         },
+    ],
+    has_transient_optional_translated => [
+        sample_name_labels => {
+            is => 'HASH',
+            default => {},
+            doc => 'Hash of sample_name to label',
+        },
         library_name_labels => {
             is => 'HASH',
-            is_translated => 1,
-            is_optional => 1,
             default => {},
             doc => 'Hash of library_name to label',
-        }
+        },
     ],
     doc => 'Output readcount information from bam readcount',
 };

--- a/lib/perl/Genome/VariantReporting/Report/FullReport.pm
+++ b/lib/perl/Genome/VariantReporting/Report/FullReport.pm
@@ -19,26 +19,12 @@ class Genome::VariantReporting::Report::FullReport {
             is_translated => 1,
             doc => 'List of sample names to be used in the report',
         },
-        sample_name_labels => {
-            is => 'HASH',
-            is_translated => 1,
-            is_optional => 1,
-            default => {},
-            doc => 'Hash of sample_name to label',
-        },
         library_names => {
             is => 'Text',
             is_many => 1,
             is_translated => 1,
             doc => 'List of library names to be used in the report',
         },
-        library_name_labels => {
-            is => 'HASH',
-            is_translated => 1,
-            is_optional => 1,
-            default => {},
-            doc => 'Hash of library_name to label',
-        }
     ],
     has_transient_optional_translated => [
         sample_name_labels => {

--- a/lib/perl/Genome/VariantReporting/Report/FullReport.pm
+++ b/lib/perl/Genome/VariantReporting/Report/FullReport.pm
@@ -40,6 +40,18 @@ class Genome::VariantReporting::Report::FullReport {
             doc => 'Hash of library_name to label',
         }
     ],
+    has_transient_optional_translated => [
+        sample_name_labels => {
+            is => 'HASH',
+            default => {},
+            doc => 'Hash of sample_name to label',
+        },
+        library_name_labels => {
+            is => 'HASH',
+            default => {},
+            doc => 'Hash of library_name to label',
+        },
+    ],
     doc => "Extensive tab-delimited report covering a set of one or more samples",
 };
 


### PR DESCRIPTION
HASH type properties cannot be persisted in the DB.  It would be nice to have these values persisted though because if they change, then the Report that gets generated may be different.

I'd like to use UR::Value::JSON for these, but it seems that doesn't "just work".  Perhaps a discussion with @brummett is in order...