### PR TITLE
Make library_names optional for VafInterpreter

### DIFF
--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MaxVafObservedInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MaxVafObservedInterpreter.pm
@@ -56,7 +56,6 @@ sub _interpret_entry {
         for my $sample_name ($self->$sample_name_accessor) {
             my $interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
                 sample_name => $sample_name,
-                library_names => [],
             );
             my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);
             for my $alt_allele (@$passed_alt_alleles) {

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MinCoverageObservedInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MinCoverageObservedInterpreter.pm
@@ -36,7 +36,6 @@ sub _interpret_entry {
         my $interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
             sample_name => $sample_name,
             sample_name_label => $self->sample_name_labels->{$sample_name},
-            library_names => [],
         );
         my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);
         for my $alt_allele (@$passed_alt_alleles) {

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/VafInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/VafInterpreter.pm
@@ -13,6 +13,14 @@ class Genome::VariantReporting::Suite::BamReadcount::VafInterpreter {
     is => ['Genome::VariantReporting::Framework::Component::Interpreter',
         'Genome::VariantReporting::Suite::BamReadcount::ComponentBase',
         'Genome::VariantReporting::Framework::Component::WithManyLibraryNames',],
+    has_optional => [
+        library_names => {
+            is => 'Text',
+            is_many => 1,
+            is_translated => 1,
+            doc => 'List of library names to be used in the report',
+        },
+    ],
     doc => 'Calculate the variant allele frequency, number of reads supporting the reference, and number of reads supporting variant for a sample and its libraries',
 };
 


### PR DESCRIPTION
We use the VafInterpreter without library_names in the
MinCoverageObservedInterpreter and the MaxVafObservedInterpreter so it needs to be optional.