### PR TITLE
s/paralellize/parallelize/

### DIFF
--- a/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
@@ -62,7 +62,7 @@ sub _run {
     }
 }
 
-sub _paralellize {
+sub _parallelize {
     my $self = shift;
     my @alignment_results = @_;
 


### PR DESCRIPTION
It's easier to call this subroutine when the `l`s are in the proper places!