### PR TITLE
Flexbar --(no-)length-dist parameter

### DIFF
--- a/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
+++ b/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
@@ -18,7 +18,7 @@ class Genome::Model::Tools::Sx::Trim::Flexbar {
             is => 'Boolean',
             is_optional => 1,
             default => 0,
-            doc => 'Remove the reverse compl;ement of the single adapter.',
+            doc => 'Remove the reverse complement of the single adapter.',
         },
         no_length_dist => {
             is => 'Boolean',
@@ -66,12 +66,12 @@ sub _cmd_properties {
         adapter_min_overlap => {
             is => 'Text',
             is_optional => 1,
-            doc => ' Minimum overlap of adapter and read in base pairs.',
+            doc => 'Minimum overlap of adapter and read in base pairs.',
         },
         adapter_threshold  => {
             is => 'Number',
             is_optional => 1,
-            doc => 'Allowed mismatches and indels per 10 bases for adapter',
+            doc => 'Allowed mismatches and indels per 10 bases for adapter.',
         },
         adapter_trim_end => {
             is => 'Text',
@@ -81,7 +81,7 @@ sub _cmd_properties {
         adapter_tail_length => {
             is => 'Number',
             is_optional => 1,
-            doc => ' Number of bases for tail trim-end types, default: adapter length',
+            doc => 'Number of bases for tail trim-end types, default: adapter length',
         },
         adapter_no_adapt => {
             is => 'Boolean',

--- a/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
+++ b/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
@@ -247,6 +247,18 @@ sub _env_var_for_version {
     return $env_var;
 }
 
+sub _resolve_length_dist_parameter {
+    my $self = shift;
+
+    my $no_length_dist = $self->no_length_dist;
+
+    if ( $self->version >= 230 ) {
+        return $no_length_dist? '' : ' --length-dist';
+    } else {
+        return $no_length_dist? ' --no-length-dist' : '';
+    }
+}
+
 sub _resolve_adapters {
     my $self = shift;
 
@@ -280,18 +292,6 @@ sub _resolve_adapters {
     }
 
     return 1;
-}
-
-sub _resolve_length_dist_parameter {
-    my $self = shift;
-
-    my $no_length_dist = $self->no_length_dist;
-
-    if ( $self->version >= 230 ) {
-        return $no_length_dist? '' : ' --length-dist';
-    } else {
-        return $no_length_dist? ' --no-length-dist' : '';
-    }
 }
 
 sub _required_type_and_counts_for_inputs {

--- a/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
+++ b/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
@@ -68,123 +68,123 @@ sub _cmd_properties {
             is_optional => 1,
             doc => ' Minimum overlap of adapter and read in base pairs.',
         },
-         adapter_threshold  => {
-             is => 'Number',
-             is_optional => 1,
-             doc => 'Allowed mismatches and indels per 10 bases for adapter',
-         },
-         adapter_trim_end => {
-             is => 'Text',
-             valid_values => [qw/ ANY RIGHT LEFT RIGHT_TAIL LEFT_TAIL  /],
-             doc => 'Decides on which end adapter removal is performed.',
-         },
-         adapter_tail_length => {
-             is => 'Number',
-             is_optional => 1,
-             doc => ' Number of bases for tail trim-end types, default: adapter length',
-         },
-         adapter_no_adapt => {
-             is => 'Boolean',
-             is_optional => 1,
-             doc => 'Do not adapt min-overlap to overlap length at ends.',
-         },
-         adapter_match => {
-             is => 'Number',
-             is_optional => 1,
-             doc => 'Match score.',
-         },
-         adapter_mismatch => {
-             is => 'Number',
-             is_optional => 1,
-             doc => 'Mismatch score.',
-         },
-         adapter_gap_cost => {
-             is => 'Number',
-             is_optional => 1,
-             doc => 'Gap score.',
-         },
-         min_readlength => {
-             is => 'Text',
-             is_optional => 1,
-             doc => 'Minimum readlength in basepairs after adapter removal or read will be discarded.',
-         },
+        adapter_threshold  => {
+            is => 'Number',
+            is_optional => 1,
+            doc => 'Allowed mismatches and indels per 10 bases for adapter',
+        },
+        adapter_trim_end => {
+            is => 'Text',
+            valid_values => [qw/ ANY RIGHT LEFT RIGHT_TAIL LEFT_TAIL  /],
+            doc => 'Decides on which end adapter removal is performed.',
+        },
+        adapter_tail_length => {
+            is => 'Number',
+            is_optional => 1,
+            doc => ' Number of bases for tail trim-end types, default: adapter length',
+        },
+        adapter_no_adapt => {
+            is => 'Boolean',
+            is_optional => 1,
+            doc => 'Do not adapt min-overlap to overlap length at ends.',
+        },
+        adapter_match => {
+            is => 'Number',
+            is_optional => 1,
+            doc => 'Match score.',
+        },
+        adapter_mismatch => {
+            is => 'Number',
+            is_optional => 1,
+            doc => 'Mismatch score.',
+        },
+        adapter_gap_cost => {
+            is => 'Number',
+            is_optional => 1,
+            doc => 'Gap score.',
+        },
+        min_readlength => {
+            is => 'Text',
+            is_optional => 1,
+            doc => 'Minimum readlength in basepairs after adapter removal or read will be discarded.',
+        },
         min_read_length => {
-             is => 'Text',
-             is_optional => 1,
-             doc => 'Minimum readlength in basepairs after adapter removal or read will be discarded, use in version 230 only',
-         },
-         max_uncalled => {
-             is => 'Text',
-             is_optional => 1,
-             doc => 'Number of allowed uncalled bases in a read.',
-         },
-	post_trim_length =>  {
-	    is => 'Number',
-	    is_optional => 1,
-	    doc => 'Trim to specified read length from 3\' end after removal, v230 only',
-	},
-	pre_trim_left => {
-	    is => 'Number',
-	    is_optional => 1,
-	    doc => 'Trim given number of bases on 5\' read end before detection, v230 only.',
-	},
-	pre_trim_right => {
-	    is => 'Number',
-	    is_optional => 1,
-	    doc => 'Trim specified number of bases on 3\' end prior to detection, v230 only.',
-	},
-	pre_trim_phred => {
-	    is => 'Number',
-	    is_optional => 1,
-	    doc => 'Trim 3\' end until specified or higher quality reached, v230 only',
-	},
-         removal_tag => {
-             is => 'Boolean',
-             is_optional => 1,
-             doc => 'Tag reads for which adapter or barcode is removed.',
-         },
-         threads => {
-             is => 'Text',
-             is_optional => 1,
-             default_value => 1,
-             doc => 'Number of threads to use.',
-         },
-     );
- }
+            is => 'Text',
+            is_optional => 1,
+            doc => 'Minimum readlength in basepairs after adapter removal or read will be discarded, use in version 230 only',
+        },
+        max_uncalled => {
+            is => 'Text',
+            is_optional => 1,
+            doc => 'Number of allowed uncalled bases in a read.',
+        },
+        post_trim_length =>  {
+            is => 'Number',
+            is_optional => 1,
+            doc => 'Trim to specified read length from 3\' end after removal, v230 only',
+        },
+        pre_trim_left => {
+            is => 'Number',
+            is_optional => 1,
+            doc => 'Trim given number of bases on 5\' read end before detection, v230 only.',
+        },
+        pre_trim_right => {
+            is => 'Number',
+            is_optional => 1,
+            doc => 'Trim specified number of bases on 3\' end prior to detection, v230 only.',
+        },
+        pre_trim_phred => {
+            is => 'Number',
+            is_optional => 1,
+            doc => 'Trim 3\' end until specified or higher quality reached, v230 only',
+        },
+        removal_tag => {
+            is => 'Boolean',
+            is_optional => 1,
+            doc => 'Tag reads for which adapter or barcode is removed.',
+        },
+        threads => {
+            is => 'Text',
+            is_optional => 1,
+            default_value => 1,
+            doc => 'Number of threads to use.',
+        },
+    );
+}
 
- sub execute {
-     my $self = shift;
+sub execute {
+    my $self = shift;
 
-     my $resolve_adapters = $self->_resolve_adapters;
-     return if not $resolve_adapters;
+    my $resolve_adapters = $self->_resolve_adapters;
+    return if not $resolve_adapters;
 
-     my @input_params = $self->_resolve_input_params;
-     return if not @input_params;
+    my @input_params = $self->_resolve_input_params;
+    return if not @input_params;
 
-     my $output = $self->_init_ouptut;
-     return if not $output;
+    my $output = $self->_init_ouptut;
+    return if not $output;
 
-     $self->debug_message('Run flexbar...');
+    $self->debug_message('Run flexbar...');
 
-     my $cmd = $self->build_command;
+    my $cmd = $self->build_command;
 
-     $cmd .= $self->_resolve_length_dist_parameter;
+    $cmd .= $self->_resolve_length_dist_parameter;
 
-     # set input param name .. either reads or source
-     my $input_param_name = $self->_input_data_param_name();
-     $cmd .= ' --'.$input_param_name.' '.$input_params[0]->{file};
-     $cmd .= ' --'.$input_param_name.'2 '.$input_params[1]->{file} if $input_params[1];
+    # set input param name .. either reads or source
+    my $input_param_name = $self->_input_data_param_name();
+    $cmd .= ' --'.$input_param_name.' '.$input_params[0]->{file};
+    $cmd .= ' --'.$input_param_name.'2 '.$input_params[1]->{file} if $input_params[1];
 
-     # set input format ..sanger or sanger-fastq
-     my $input_format = $self->_input_data_format();
-     $cmd .= ' --format '.$input_format;
+    # set input format ..sanger or sanger-fastq
+    my $input_format = $self->_input_data_format();
+    $cmd .= ' --format '.$input_format;
 
-     # set output file name
-     $cmd .= ' --target '.$self->_tmpdir.'/output.fastq',
+    # set output file name
+    $cmd .= ' --target '.$self->_tmpdir.'/output.fastq',
 
-     # set versions env variable
-     my $env_var = $self->_env_var_for_version();
-     $cmd = $env_var.' '.$cmd if $env_var;
+    # set versions env variable
+    my $env_var = $self->_env_var_for_version();
+    $cmd = $env_var.' '.$cmd if $env_var;
 
     my $rv = $self->_run_command($cmd);
     return if not $rv;
@@ -197,7 +197,7 @@ sub _cmd_properties {
         return;
     }
     $self->debug_message('Output: '.join(' ', @outputs));
-    
+
     my $output_reader = Genome::Model::Tools::Sx::Reader->create(
         config => [ map { $_.':type=sanger' } @outputs ],
     );
@@ -221,8 +221,8 @@ sub _input_data_param_name {
 
     my $name = 'source';
     if( $self->version eq '230' ) {
-	$name = 'reads';
-    }   
+        $name = 'reads';
+    }
     return $name;
 }
 
@@ -231,7 +231,7 @@ sub _input_data_format {
 
     my $format = 'fastq-sanger';
     if( $self->version eq '230' ) {
-	$format = 'sanger';
+        $format = 'sanger';
     }
     return $format;
 }
@@ -241,8 +241,8 @@ sub _env_var_for_version {
 
     my $env_var;
     if( $self->version eq '230' ) {
-	$env_var = 'LD_LIBRARY_PATH=/gscmnt/gc3001/assembly/Downloads/Flexbar_2.4/flexbar_v2.4_linux64';
-	# this is needed to use multiple nodes for v230
+        $env_var = 'LD_LIBRARY_PATH=/gscmnt/gc3001/assembly/Downloads/Flexbar_2.4/flexbar_v2.4_linux64';
+        # this is needed to use multiple nodes for v230
     }
     return $env_var;
 }

--- a/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
+++ b/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
@@ -20,6 +20,11 @@ class Genome::Model::Tools::Sx::Trim::Flexbar {
             default => 0,
             doc => 'Remove the reverse compl;ement of the single adapter.',
         },
+        no_length_dist => {
+            is => 'Boolean',
+            is_optional => 1,
+            doc => 'Prevent writing length distributions for read output files.',
+        },
         version => {
             is => 'Text',
             valid_values => [ __PACKAGE__->cmd_versions ],
@@ -113,12 +118,6 @@ sub _cmd_properties {
              is_optional => 1,
              doc => 'Number of allowed uncalled bases in a read.',
          },
-         no_length_dist => {
-             is => 'Boolean',
-             is_optional => 1,
-#            default_value => '1',
-             doc => 'Prevent writing length distributions for read output files.',
-         },
 	post_trim_length =>  {
 	    is => 'Number',
 	    is_optional => 1,
@@ -168,6 +167,8 @@ sub _cmd_properties {
      $self->debug_message('Run flexbar...');
 
      my $cmd = $self->build_command;
+
+     $cmd .= $self->_resolve_length_dist_parameter;
 
      # set input param name .. either reads or source
      my $input_param_name = $self->_input_data_param_name();
@@ -279,6 +280,18 @@ sub _resolve_adapters {
     }
 
     return 1;
+}
+
+sub _resolve_length_dist_parameter {
+    my $self = shift;
+
+    my $no_length_dist = $self->no_length_dist;
+
+    if ( $self->version >= 230 ) {
+        return $no_length_dist? '' : ' --length-dist';
+    } else {
+        return $no_length_dist? ' --no-length-dist' : '';
+    }
 }
 
 sub _required_type_and_counts_for_inputs {

--- a/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
+++ b/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.pm
@@ -220,7 +220,7 @@ sub _input_data_param_name {
     my $self = shift;
 
     my $name = 'source';
-    if( $self->version eq '230' ) {
+    if( $self->version >= 230 ) {
         $name = 'reads';
     }
     return $name;
@@ -230,7 +230,7 @@ sub _input_data_format {
     my $self = shift;
 
     my $format = 'fastq-sanger';
-    if( $self->version eq '230' ) {
+    if( $self->version >= 230 ) {
         $format = 'sanger';
     }
     return $format;

--- a/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.t
+++ b/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar.t
@@ -41,7 +41,7 @@ my $cmd = Genome::Model::Tools::Sx::Trim::Flexbar->create(
 ok($cmd, "create flexbar to remove single adapter");
 ok(eval{$cmd->execute}, "execute");
 print "$@\n" if $@;
-is_deeply($cmd->_cmds, ['/usr/bin/flexbar229 --adapter-gap-cost -20 --adapter-match 3 --adapter-min-overlap 16 --adapter-mismatch -3 --adapter-trim-end ANY --adapters '.$cmd->_tmpdir.'/adapters.fasta --max-uncalled 100 --no-length-dist --threads 4 --source '.$datadir.'/input_1.fastq --source2 '.$datadir.'/input_2.fastq --format fastq-sanger --target '.$cmd->_tmpdir.'/output.fastq'], 'flexbar command');
+is_deeply($cmd->_cmds, ['/usr/bin/flexbar229 --adapter-gap-cost -20 --adapter-match 3 --adapter-min-overlap 16 --adapter-mismatch -3 --adapter-trim-end ANY --adapters '.$cmd->_tmpdir.'/adapters.fasta --max-uncalled 100 --threads 4 --no-length-dist --source '.$datadir.'/input_1.fastq --source2 '.$datadir.'/input_2.fastq --format fastq-sanger --target '.$cmd->_tmpdir.'/output.fastq'], 'flexbar command');
 
 my @output = glob("$temp_dir/*fastq");
 is(@output, 1, "got 1 fastq files");
@@ -71,7 +71,7 @@ $cmd = Genome::Model::Tools::Sx::Trim::Flexbar->create(
 ok($cmd, "create flexbar to remove single adapter for v230");
 ok(eval{$cmd->execute}, "execute");
 print "$@\n" if $@;
-is_deeply( $cmd->_cmds, ['LD_LIBRARY_PATH=/gscmnt/gc3001/assembly/Downloads/Flexbar_2.4/flexbar_v2.4_linux64 /gsc/bin/flexbar --adapter-match 3 --adapter-min-overlap 16 --adapter-mismatch -3 --adapter-trim-end ANY --adapters '.$cmd->_tmpdir.'/adapters.fasta --max-uncalled 100 --threads 4 --reads '.$datadir.'/input_1.fastq --reads2 '.$datadir.'/input_2.fastq --format sanger --target '.$cmd->_tmpdir.'/output.fastq'], 'flexbar command');
+is_deeply( $cmd->_cmds, ['LD_LIBRARY_PATH=/gscmnt/gc3001/assembly/Downloads/Flexbar_2.4/flexbar_v2.4_linux64 /gsc/bin/flexbar --adapter-match 3 --adapter-min-overlap 16 --adapter-mismatch -3 --adapter-trim-end ANY --adapters '.$cmd->_tmpdir.'/adapters.fasta --max-uncalled 100 --threads 4 --length-dist --reads '.$datadir.'/input_1.fastq --reads2 '.$datadir.'/input_2.fastq --format sanger --target '.$cmd->_tmpdir.'/output.fastq'], 'flexbar command');
 
 @output = glob("$temp_dir/*fastq");
 is(@output, 1, "got 1 fastq files");

--- a/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar/V2x4.pm
+++ b/lib/perl/Genome/Model/Tools/Sx/Trim/Flexbar/V2x4.pm
@@ -119,6 +119,11 @@ sub _cmd_properties {
             is_optional => 1,
             doc => 'Print valid optimal read alignment. One of ALL, MOD, and TAB.',
         },
+        length_dist => {
+            is => 'Boolean',
+            is_optional => 1,
+            doc => 'Generate length distribution for read output files.',
+        },
         removal_tags => {
             is => 'Boolean',
             is_optional => 1,


### PR DESCRIPTION
The parameter changed between the two flexbar versions.

It looks like some other parameters changed, too, which this command handled by having both and cautioning the user to use one or the other.  It seemed really confusing to me to end up with
```
--length-dist
--nolength-dist
--no-length-dist
--nono-length-dist
```
half of which work with one version and half with another, so I took a different approach here.  If that's against the spirit of SX, I could switch it to the above.