### PR TITLE
Change cascading behavior of Analysis Project delete().

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject.pm
+++ b/lib/perl/Genome/Config/AnalysisProject.pm
@@ -95,14 +95,9 @@ sub delete {
         die $self->error_message($msg, $self->__display_name__, 'instrument data');
     }
 
-    eval {
-        my @events = Genome::Timeline::Event::AnalysisProject->get(analysis_project => $self);
-        for ($self->config_items, $self->subject_mappings, @events) {
-            $_->delete();
-        }
-    };
-    if(my $error = $@) {
-        die($error);
+    my @events = Genome::Timeline::Event::AnalysisProject->get(analysis_project => $self);
+    for ($self->config_items, $self->subject_mappings, @events) {
+        $_->delete();
     }
 
     return $self->SUPER::delete();

--- a/lib/perl/Genome/Config/AnalysisProject.pm
+++ b/lib/perl/Genome/Config/AnalysisProject.pm
@@ -86,23 +86,25 @@ sub __display_name__ {
 
 sub delete {
     my $self = shift;
+
+    my $msg = 'Cannot delete analysis project %s because it has %s.';
+    if ($self->model_bridge_set->count) {
+        die $self->error_message($msg, $self->__display_name__, 'models');
+    }
+    if ($self->analysis_project_bridge_set->count) {
+        die $self->error_message($msg, $self->__display_name__, 'instrument data');
+    }
+
     eval {
-        for ($self->config_items) {
-            $_->delete();
-        }
-        for ($self->model_bridges) {
-            $_->delete();
-        }
-        for ($self->analysis_project_bridges) {
-            $_->delete();
-        }
-        for ($self->subject_mappings) {
+        my @events = Genome::Timeline::Event::AnalysisProject->get(analysis_project => $self);
+        for ($self->config_items, $self->subject_mappings, @events) {
             $_->delete();
         }
     };
     if(my $error = $@) {
         die($error);
     }
+
     return $self->SUPER::delete();
 }
 


### PR DESCRIPTION
* Refuse to delete if models or instrument data are assigned.
* Cascade to delete any existing timeline events.

I tested this by deleting @chrisamiller's long-standing Analysis Project he's wanted deleted.  (There were previously other issues with deleting it that were resolved by earlier schema changes.)