### PR TITLE
Set LSF memory request for SomVal's VerifyBam step.

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/VerifyBam.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/VerifyBam.pm
@@ -11,6 +11,13 @@ class Genome::Model::SomaticValidation::Command::VerifyBam {
             is => 'Genome::InstrumentData::VerifyBamIdResult',
         },
     ],
+    has_param => [
+        lsf_resource => {
+            default_value => "-R 'select[mem>12000] rusage[mem=12000]' -M 12000000",
+            is_optional => 1,
+            doc => 'default LSF resource expectations',
+        },
+    ],
 };
 
 sub shortcut {


### PR DESCRIPTION
In the latest validation test this was taking just over 9000 megabytes of memory to run.