### PR TITLE
make analysis_projects singular on models

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.t
@@ -29,7 +29,7 @@ my $cmd2 = $class->create(
 isa_ok($cmd2, $class, 'created command');
 ok($cmd2->execute, 'command succeeds when pending analysis project');
 for my $m (@models) {
-    is($m->analysis_projects, $analysis_project, 'analysis project assigned');
+    is($m->analysis_project, $analysis_project, 'analysis project assigned');
 }
 
 my $cmd3 = $class->create(
@@ -50,9 +50,9 @@ my $cmd4 = $class->create(
 );
 isa_ok($cmd4, $class, 'created command');
 ok(!$cmd4->execute, 'command fails when models already assigned to a different project');
-ok(!$other_model->analysis_projects, 'unassigned model not assigned to');
+ok(!$other_model->analysis_project, 'unassigned model not assigned to');
 for my $m (@models) {
-    is($m->analysis_projects, $analysis_project, 'analysis project remains properly assigned');
+    is($m->analysis_project, $analysis_project, 'analysis project remains properly assigned');
     is($m->config_profile_items, $profile_item, 'model linked to correct configuration');
 }
 
@@ -63,7 +63,7 @@ my $cmd5 = $class->create(
 );
 isa_ok($cmd5, $class, 'created command');
 ok(!$cmd5->execute, 'command fails when attempting to assign to an active config profile item');
-ok(!$other_model->analysis_projects, 'unassigned model not assigned to');
+ok(!$other_model->analysis_project, 'unassigned model not assigned to');
 
 my $wrong_class_profile_item = add_config($other_analysis_project, 'Genome::Model::SomaticValidation');
 my $cmd6 = $class->create(
@@ -72,7 +72,7 @@ my $cmd6 = $class->create(
 );
 isa_ok($cmd6, $class, 'created command');
 ok(!$cmd6->execute, 'command fails when attempting to assign to a config profile item for the wrong model type');
-ok(!$other_model->analysis_projects, 'unassigned model not assigned to');
+ok(!$other_model->analysis_project, 'unassigned model not assigned to');
 
 $other_profile_item->status('disabled');
 my $cmd7 = $class->create(
@@ -81,7 +81,7 @@ my $cmd7 = $class->create(
 );
 isa_ok($cmd7, $class, 'created command');
 ok($cmd7->execute, 'command succeeds in "normal" case');
-is($other_model->analysis_projects, $other_analysis_project, 'model assigned appropriately');
+is($other_model->analysis_project, $other_analysis_project, 'model assigned appropriately');
 is($other_model->config_profile_items, $other_profile_item, 'model linked to correct configuration');
 
 

--- a/lib/perl/Genome/Config/AnalysisProject/Command/View.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/View.pm
@@ -306,7 +306,7 @@ sub _get_model_summary {
 
     my $summary = {};
     my $model_iterator = Genome::Model->create_iterator(
-        'analysis_projects.id' => $self->analysis_project->id,
+        'analysis_project.id' => $self->analysis_project->id,
     );
     while (my $model = $model_iterator->next) {
         $summary->{$model->class}->{$model->status}++;

--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -109,24 +109,22 @@ sub _assign_instrument_data_to_model {
 
     #if a model is newly created, we want to assign all applicable instrument data to it
     my %params_hash = (model => $model);
-    my $executed_all_ok = 1;
+    my $executed_ok = 1;
     if ($newly_created && $model->auto_assign_inst_data) {
-        for my $analysis_project ($model->analysis_projects) {
-            my $cmd = Genome::Model::Command::InstrumentData::Assign::AnalysisProject->create(
-                model => $model,
-                analysis_project => $analysis_project,
-            );
-            $executed_all_ok &&= eval{ $cmd->execute; };
-        }
+        my $cmd = Genome::Model::Command::InstrumentData::Assign::AnalysisProject->create(
+            model => $model,
+            analysis_project => $model->analysis_project,
+        );
+        $executed_ok &&= eval{ $cmd->execute; };
     } else {
         my $cmd = Genome::Model::Command::InstrumentData::Assign::ByExpression->create(
             model => $model,
             instrument_data => [$instrument_data]
         );
-        $executed_all_ok &&= eval{ $cmd->execute };
+        $executed_ok &&= eval{ $cmd->execute };
     }
 
-    unless ($executed_all_ok) {
+    unless ($executed_ok) {
         die(sprintf('Failed to assign %s to %s', $instrument_data->__display_name__,
                 $model->__display_name__));
     }
@@ -236,7 +234,7 @@ sub _get_model_for_config_hash {
 
     my @extra_params = (auto_assign_inst_data => 1);
 
-    my @found_models = $class_name->get(@extra_params, %read_config, analysis_projects => [$analysis_project]);
+    my @found_models = $class_name->get(@extra_params, %read_config, analysis_project => $analysis_project);
     my @m = grep { $_->analysis_project_bridges->profile_item_id eq $config_profile_item->id } @found_models;
 
     if (scalar(@m) > 1) {

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -179,10 +179,16 @@ class Genome::Model {
             is_many => 1,
         },
         analysis_projects => {
+            via => '__self__',
+            to => 'analysis_project',
+            is_deprecated => 1,
+            doc => 'use analysis_project instead',
+        },
+        analysis_project => {
             is => 'Genome::Config::AnalysisProject',
             via => 'analysis_project_bridges',
             to => 'analysis_project',
-            is_many => 1,
+            is_many => 0,
         },
         config_profile_items => {
             is => 'Genome::Config::Profile::Item',

--- a/lib/perl/Genome/Model/Build/Command/View.pm
+++ b/lib/perl/Genome/Model/Build/Command/View.pm
@@ -73,7 +73,7 @@ sub write_report {
 
     my $build = $self->build;
     $self->_display_build($handle, $build);
-    $self->_display_analysis_projects($handle, $build);
+    $self->_display_analysis_project($handle, $build);
 
     if ($self->full) {
         $self->inputs(1);
@@ -141,19 +141,13 @@ EOS
         $self->_color_pair('Data Directory', $build->data_directory));
 }
 
-sub _display_analysis_projects {
+sub _display_analysis_project {
     my ($self, $handle, $build) = @_;
 
     my $model = $build->model;
 
-    if ($model->analysis_projects) {
-        print $handle $self->_color_pair('Analysis Projects'), "\n";
-        for my $ap ($model->analysis_projects) {
-            print $handle $self->_pad_right(sprintf("    %s", $ap->id),
-                $self->COLUMN_WIDTH);
-            printf $handle " %s\n", $ap->name;
-        }
-        print "\n";
+    if (my $ap = $model->analysis_project) {
+        print $handle $self->_color_pair('Analysis Project', $ap->name), "\n\n";
     }
 }
 

--- a/lib/perl/Genome/Model/Command/Define/ImportedReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Command/Define/ImportedReferenceSequence.pm
@@ -102,9 +102,8 @@ class Genome::Model::Command::Define::ImportedReferenceSequence {
             is => 'Text',
             doc => 'newly created build ID of reference sequence model',
         },
-        analysis_projects => {
+        analysis_project => {
             is => 'Genome::Config::AnalysisProject',
-            is_many => 1,
             doc => 'Analysis Project to which to associate the new model (if any)',
         },
     ],
@@ -311,8 +310,8 @@ sub _get_or_create_model {
             'name' => $self->model_name,
             'is_rederivable' => $self->is_rederivable,
         );
-        if($self->analysis_projects) {
-            $model->add_analysis_project_bridge(analysis_project => $self->analysis_projects);
+        if($self->analysis_project) {
+            $model->add_analysis_project_bridge(analysis_project => $self->analysis_project);
         }
 
         if($model) {

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
@@ -148,7 +148,7 @@ sub execute {
         prefix => $sample_id,
         server_dispatch => 'inline',
         is_rederivable => 1,
-        analysis_projects => [$self->build->model->analysis_projects],
+        analysis_project => $self->build->model->analysis_project,
     );
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.pm
@@ -111,7 +111,7 @@ sub execute {
         prefix => $prefix,
         server_dispatch => 'inline',
         is_rederivable => 1,
-        analysis_projects => [$build->model->analysis_projects],
+        analysis_project => $build->model->analysis_project,
     );
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');


### PR DESCRIPTION
Models can only belong to one `AnalysisProject` so the `analysis_projects` property
should be singular.  When originally implemented this was believe to not be
supported by UR.  This adds `analysis_project` and deprecates `analysis_projects`.