### PR TITLE
Start of a System for Notifying

### DIFF
--- a/lib/perl/Genome/Notify.pm
+++ b/lib/perl/Genome/Notify.pm
@@ -1,0 +1,35 @@
+package Genome::Notify;
+
+use strict;
+use warnings;
+
+use Params::Validate qw();
+
+use Genome;
+
+class Genome::Notify {
+    is => 'UR::Singleton',
+};
+
+sub notify {
+    my $class = shift;
+    my %options = Params::Validate::validate(@_, {
+        subject => { isa => 'UR::Object' },
+        type    => { isa => 'Genome::Notify::NoticeType' },
+        header  => { type => Params::Validate::SCALAR },
+        body    => { type => Params::Validate::SCALAR },
+        target  => { isa => 'Genome::Sys::User' },
+    });
+
+    my $notice = Genome::Notify::Notice->issue(%options);
+    return unless $notice;
+
+    my $notifier = Genome::Notify::Preference->notifier_for_target(
+        type => $options{type},
+        target => $options{target},
+    );
+
+    $notifier->notify($notice);
+}
+
+1;

--- a/lib/perl/Genome/Notify.t
+++ b/lib/perl/Genome/Notify.t
@@ -1,0 +1,99 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+
+use Test::More tests => 4;
+
+my $class = 'Genome::Notify';
+
+use_ok($class);
+
+class Genome::Notify::Notifier::Test {
+    is => 'Genome::Notify::Notifier',
+};
+
+my $count;
+my $last_notice;
+sub Genome::Notify::Notifier::Test::notify {
+    my $class = shift;
+    my $notice = shift;
+
+    $count++;
+    $last_notice = $notice;
+
+    isa_ok($notice, 'Genome::Notify::Notice');
+    ok(!$notice->acknowledged, 'notice being notified is not acknowledged');
+}
+
+my $type = Genome::Notify::NoticeType->create(
+    name => 'Test for Notify.t',
+    default_notifier_class => 'Genome::Notify::Notifier::Test',
+);
+
+subtest 'setup a notice type' => sub {
+    plan tests => 2;
+    isa_ok($type, 'Genome::Notify::NoticeType');
+    ok(!$type->__errors__, 'type is valid');
+};
+
+my %notice_info = (
+    subject => UR::Value::Text->get('test'),
+    type => $type,
+    header => 'Test Notice!',
+    body => 'This is a sentence in the test notice.',
+    target => Genome::Sys->current_user,
+);
+
+subtest 'new notice' => sub {
+    $count = 0;
+    $class->notify(%notice_info);
+    is($count, 1, 'notified once');
+    $class->notify(%notice_info);
+    is($count, 1, 'notice not repeated while not acknowledged');
+    $last_notice->acknowledged(1);
+    $class->notify(%notice_info);
+    is($count, 2, 'recurrence of an acknowledge notice re-notifies');
+    done_testing();
+};
+
+class Genome::Notify::Notifier::TestAlternate {
+    is => 'Genome::Notify::Notifier',
+};
+
+my $alternate_count;
+sub Genome::Notify::Notifier::TestAlternate::notify {
+    my $class = shift;
+    my $notice = shift;
+
+    $alternate_count++;
+
+    isa_ok($notice, 'Genome::Notify::Notice');
+    ok(!$notice->acknowledged, 'notice being notified is not acknowledged');
+}
+
+subtest 'notice preference respected' => sub {
+    my $preference = Genome::Notify::Preference->create(
+        type => $type,
+        notifier_class => 'Genome::Notify::Notifier::TestAlternate',
+        target => Genome::Sys->current_user,
+    );
+    isa_ok($preference, 'Genome::Notify::Preference');
+    ok(!$preference->__errors__, 'Preference has no errors');
+
+    $count = 0;
+    $alternate_count = 0;
+
+    $notice_info{subject} = UR::Value::Text->get('preference test');
+
+    $class->notify(%notice_info);
+    is($count, 0, 'default notifier not triggered');
+    is($alternate_count, 1, 'preferred notifier triggered instead');
+    done_testing();
+};

--- a/lib/perl/Genome/Notify/Notice.pm
+++ b/lib/perl/Genome/Notify/Notice.pm
@@ -1,0 +1,65 @@
+package Genome::Notify::Notice;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Notify::Notice {
+    is => ['Genome::Utility::ObjectWithTimestamps','Genome::Utility::ObjectWithCreatedBy'],
+    table_name => 'notify.notice',
+    has => [
+        id => {
+            is => 'Text',
+        },
+        type => {
+            is => 'Genome::Notify::NoticeType',
+            id_by => 'type_id',
+            doc => 'The type of notice',
+        },
+        header => {
+            is => 'Text',
+            doc => 'Header (or "subject line") of the notice',
+        },
+        body => {
+            is => 'Text',
+            doc => 'Body of the notice',
+        },
+        subject => {
+            is => 'UR::Object',
+            id_by => 'subject_id',
+            id_class_by => 'subject_class_name',
+            doc => 'Entity about which this notice was issued',
+        },
+        acknowledged => {
+            is => 'Boolean',
+            doc => 'Whether this notice has been seen or noticed',
+        },
+        target => {
+            is => 'Genome::Sys::User',
+            id_by => 'target_id',
+            doc => 'The person who is to be notified',
+        },
+    ],
+};
+
+sub issue {
+    my $class = shift;
+    my @params = @_;
+
+    my $needs_notification;
+    my $notice;
+    if(my $existing_notice = $class->get(@params)) {
+       $notice = $existing_notice;
+       $needs_notification = $notice->acknowledged;
+       $notice->acknowledged(0);
+    } else {
+       $needs_notification = 1;
+       $notice = $class->create(@params);
+    }
+
+    return $notice if $needs_notification;
+    return;
+}
+
+1;

--- a/lib/perl/Genome/Notify/NoticeType.pm
+++ b/lib/perl/Genome/Notify/NoticeType.pm
@@ -1,0 +1,43 @@
+package Genome::Notify::NoticeType;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Notify::NoticeType {
+    is => ['UR::Object'],
+    table_name => 'notify.notice_type',
+    has => [
+        id => {
+            is => 'Text',
+        },
+        name => {
+            is => 'Text',
+            doc => 'The type of notice',
+        },
+        default_notifier_class => {
+            is => 'Text',
+            doc => 'The default way to notify a target for notices of this type',
+        },
+    ],
+};
+
+sub __errors__ {
+    my $self = shift;
+
+    my @errors = $self->SUPER::__errors__;
+
+    my $notifier = $self->default_notifier_class;
+    if($notifier and not UNIVERSAL::isa($notifier, 'Genome::Notify::Notifier')) {
+        push @errors, UR::Object::Tag->create(
+            type => 'error',
+            properties => ['default_notifier_class'],
+            desc => 'default_notifier_class must be a Genome::Notify::Notifier',
+        );
+    }
+
+    return @errors;
+}
+
+1;

--- a/lib/perl/Genome/Notify/Notifier.pm
+++ b/lib/perl/Genome/Notify/Notifier.pm
@@ -1,0 +1,23 @@
+package Genome::Notify::Notifier;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Notify::Notifier {
+    is => 'UR::Object',
+    is_abstract => 1,
+    has_classwide => [
+        name => {
+            is => 'Text',
+            doc => 'A user-friendly name for this notifier',
+        },
+    ],
+};
+
+sub notify {
+    die 'subclass must implement notify';
+}
+
+1;

--- a/lib/perl/Genome/Notify/Notifier/Email.pm
+++ b/lib/perl/Genome/Notify/Notifier/Email.pm
@@ -1,0 +1,32 @@
+package Genome::Notify::Notifier::Email;
+
+use strict;
+use warnings;
+
+use Genome;
+use Genome::Utility::Email;
+
+class Genome::Notify::Notifier::Email {
+    is => 'Genome::Notify::Notifier',
+    has_classwide_constant => [
+        name => {
+            value => 'e-mail',
+        },
+    ],
+    doc => 'The notice will be e-mailed. The e-mail will not be repeated until the notice is acknowledged.',
+};
+
+sub notify {
+    my $class = shift;
+    my $notice = shift;
+
+    Genome::Utility::Email::send(
+        from    => $ENV{GENOME_EMAIL_PIPELINE},
+        replyto => $ENV{GENOME_EMAIL_NOREPLY},
+        to      => $notice->target->email,
+        subject => $notice->header,
+        body    => $notice->body,
+    );
+}
+
+1;

--- a/lib/perl/Genome/Notify/Notifier/Ignore.pm
+++ b/lib/perl/Genome/Notify/Notifier/Ignore.pm
@@ -1,0 +1,25 @@
+package Genome::Notify::Notifier::Ignore;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Notify::Notifier::Ignore {
+    is => 'Genome::Notify::Notifier',
+    has_classwide_constant => [
+        name => {
+            value => 'ignore',
+        },
+   ],
+   doc => 'The notice will be immediately acknowledged.',
+};
+
+sub notify {
+    my $class = shift;
+    my $notice = shift;
+
+    $notice->acknowledged(1);
+}
+
+1;

--- a/lib/perl/Genome/Notify/Notifier/Nothing.pm
+++ b/lib/perl/Genome/Notify/Notifier/Nothing.pm
@@ -1,0 +1,25 @@
+package Genome::Notify::Notifier::Nothing;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Notify::Notifier::Nothing {
+    is => 'Genome::Notify::Notifier',
+    has_classwide_constant => [
+        name => {
+            value => 'do nothing',
+        },
+   ],
+   doc => 'The notice will not be actively communicated, but will remain unacknowledged.',
+};
+
+sub notify {
+    my $class = shift;
+    my $notice = shift;
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Notify/Preference.pm
+++ b/lib/perl/Genome/Notify/Preference.pm
@@ -1,0 +1,64 @@
+package Genome::Notify::Preference;
+
+use strict;
+use warnings;
+
+use Params::Validate qw();
+
+use Genome;
+
+class Genome::Notify::Preference {
+    is => ['Genome::Utility::ObjectWithTimestamps'],
+    table_name => 'notify.preference',
+    has => [
+        id => {
+            is => 'Text',
+        },
+        type => {
+            is => 'Genome::Notify::NoticeType',
+            id_by => 'type_id',
+        },
+        notifier_class => {
+            is_optional => 1,
+            is => 'Text',
+            doc => 'An override for the default notifier for this type',
+        },
+        target => {
+            is => 'Genome::Sys::User',
+            id_by => 'target_id',
+            doc => 'The user whose preference this is',
+        },
+    ],
+};
+
+sub __errors__ {
+    my $self = shift;
+
+    my @errors = $self->SUPER::__errors__;
+
+    my $notifier = $self->notifier_class;
+    if($notifier and not UNIVERSAL::isa($notifier, 'Genome::Notify::Notifier')) {
+        push @errors, UR::Object::Tag->create(
+            type => 'error',
+            properties => ['notifier_class'],
+            desc => 'default_notifier_class must be a Genome::Notify::Notifier',
+        );
+    }
+
+    return @errors;
+}
+
+sub notifier_for_target {
+    my $class = shift;
+    my %options = Params::Validate::validate(@_, {
+        target => { isa => 'Genome::Sys::User' },
+        type   => { isa => 'Genome::Notify::NoticeType' },
+    });
+
+    my $preference = Genome::Notify::Preference->get(%options);
+
+    return $preference->notifier_class if $preference;
+    return $options{type}->default_notifier_class;
+}
+
+1;


### PR DESCRIPTION
Whereas:
* We need a way to tell AnalysisProject stakeholders when their project is misconfigured without sending them repeat notices every five minutes when CQID runs.
* Some users don't care about "Build Initialized" or other mail the system sends.

Therefore:
* This PR offers the start of a standard way to notify someone of something.

This is incomplete as of yet, but I thought it'd be better to solicit feedback early before getting too far along (unlike certain other recent PRs I opened :smile:).

Future work:
* A possible way to subscribe to notifications about a subject that one wouldn't normally get.
* Sqitch migrations to back some of these new classes.