### PR TITLE
Correct Custom BSMap Resource Requirements

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
@@ -28,9 +28,10 @@ sub required_arch_os { 'x86_64' }
 # LSF resources required to run the alignment.
 sub required_rusage {
     my $self = shift;
+    my %params = @_;
     my $cores = 4; # default to 4, although decomposed_aligner_params should always include "-p N" even if the processing-profile does not
 
-    my $params = $self->decomposed_aligner_params();
+    my $params = $self->decomposed_aligner_params($params{aligner_params});
     if ($params =~ /-p\s+(\d+)/) {
         $cores = $1;
     }

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Genome;
+use Genome::Utility::Text;
 
 class Genome::Model::Event::Build::ReferenceAlignment::AlignReads {
     is => ['Genome::Model::Event'],
@@ -47,7 +48,17 @@ sub bsub_rusage {
         aligner_params  => $self->model->processing_profile->read_aligner_params,
         queue           => $self->lsf_queue,
     );
-    return $rusage;
+
+    my $group = $self->_resolve_job_group;
+
+    return join(' ', $rusage, $group);
+}
+
+sub _resolve_job_group {
+    my $self = shift;
+
+    my $group_name = Genome::Utility::Text::sanitize_string_for_filesystem($self->results_class->__meta__->property(property_name => 'aligner_name')->default_value);
+    return sprintf('-g /align/%s', $group_name);
 }
 
 sub metrics_for_class {


### PR DESCRIPTION
* Pass along the params so we get the correct thread count.
* Specify a job group for each aligner so we can separately throttle them to avoid monopolizing the queues.  (This only applies to ReferenceAlignment for now.)