### PR TITLE
New picard option

### DIFF
--- a/lib/perl/Genome/Model/Tools/Picard/MarkDuplicates.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/MarkDuplicates.pm
@@ -55,7 +55,7 @@ class Genome::Model::Tools::Picard::MarkDuplicates {
         },
         read_name_regex => {
             is => 'Text',
-            doc => 'Set to null to turn off optical duplicate detection',
+            doc => "Set to 'null' to turn off optical duplicate detection",
             is_optional => 1,
         },
     ],

--- a/lib/perl/Genome/Model/Tools/Picard/MarkDuplicates.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/MarkDuplicates.pm
@@ -53,6 +53,11 @@ class Genome::Model::Tools::Picard::MarkDuplicates {
             doc => 'comment to include as a @CO in the BAM header',
             is_optional => 1,
         },
+        read_name_regex => {
+            is => 'Text',
+            doc => 'Set to null to turn off optical duplicate detection',
+            is_optional => 1,
+        },
     ],
 };
 
@@ -103,6 +108,9 @@ sub execute {
     }
     if ($self->include_comment and not ($self->use_version =~ /1\.([0-9]+)/ and int($1) < 77)) {
         $dedup_cmd .= " COMMENT='" . $self->include_comment . "'";
+    }
+    if (defined $self->read_name_regex) {
+        $dedup_cmd .= sprintf(" READ_NAME_REGEX='%s'", $self->read_name_regex);
     }
     my $version = $self->use_version;
     if ($self->max_records_in_ram) {

--- a/lib/perl/Genome/Model/Tools/Sam/MarkDuplicates.pm
+++ b/lib/perl/Genome/Model/Tools/Sam/MarkDuplicates.pm
@@ -133,7 +133,10 @@ sub execute {
         assume_sorted     => $self->assume_sorted,
     );
 
-    my @valid_markdup_params = qw(max_sequences_for_disk_read_ends_map); #list here each time adding new parameters
+    my @valid_markdup_params = qw(
+            max_sequences_for_disk_read_ends_map
+            read_name_regex
+        ); #list here each time adding new parameters
 
     my $dedup_params = $self->dedup_params;
     if ($dedup_params) {

--- a/lib/perl/Genome/Model/Tools/Sam/MarkDuplicates.t
+++ b/lib/perl/Genome/Model/Tools/Sam/MarkDuplicates.t
@@ -30,7 +30,8 @@ my $cmd_1 = Genome::Model::Tools::Sam::MarkDuplicates->create(file_to_mark=>$inp
                                                               log_file=>$log_file,
                                                               tmp_dir=>$tmp_dir,
                                                               remove_duplicates=>1,
-                                                              max_jvm_heap_size=>2,        
+                                                              max_jvm_heap_size=>2,
+                                                              dedup_params => "read_name_regex null",
                                                             );
 
 


### PR DESCRIPTION
This new option is needed for the X10 data; see AT-732
As an added sanity check that this will work, I made a somatic validation build a637dfde0ba24bf8acc90bf02da71296 that uses the new parameter in its alignment strategy.  It correctly submitted the option to the MarkDuplicates command line, and picard ran without complaint.