### PR TITLE
Trust an Allocation's Status When Deciding if Archived

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -283,7 +283,7 @@ sub unarchive {
 
 sub is_archived {
     my $self = shift;
-    return $self->volume->is_archive;
+    return $self->status eq 'archived';
 }
 
 sub tar_path {

--- a/lib/perl/Genome/Disk/Command/Allocation/Reallocate.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Reallocate.t
@@ -35,6 +35,7 @@ my $arch_vol = $archived_allocation->volume;
 my $prefix = $arch_vol->archive_volume_prefix . "/foo";
 $arch_vol->mount_path($prefix);
 $archived_allocation->mount_path($prefix);
+$archived_allocation->status('archived');
 ok($archived_allocation->volume);
 ok($archived_allocation, 'Successfully created archived test allocation') or die;
 print $archived_allocation->volume->mount_path . "\n";

--- a/lib/perl/Genome/Disk/Command/Allocation/Unarchive.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Unarchive.t
@@ -109,6 +109,7 @@ my $allocation = Genome::Disk::Allocation->create(
     mount_path => $archive_volume->mount_path,
 );
 ok($allocation, 'created test allocation');
+$allocation->status('archived');
 ok($allocation->is_archived, 'allocation is archived prior to running command, as expected');
 
 # Create a test tarball
@@ -145,6 +146,7 @@ $allocation = Genome::Disk::Allocation->create(
     mount_path => $archive_volume->mount_path,
 );
 ok($allocation, 'created test allocation');
+$allocation->status('archived');
 ok($allocation->is_archived, 'allocation is archived before running command, as expected');
 
 # Create a test tarball

--- a/lib/perl/Genome/Test/Factory/DiskAllocation.pm
+++ b/lib/perl/Genome/Test/Factory/DiskAllocation.pm
@@ -38,7 +38,12 @@ my $overloaded_archiving_methods;
 sub overload_archiving_methods {
     return 1 if $overloaded_archiving_methods;
     Sub::Install::reinstall_sub({
-            code => sub{ $_[0]->{_mount_path} = $_[0]->mount_path; $_[0]->mount_path( archived_volume()->mount_path ); return 1; },
+            code => sub{
+                $_[0]->{_mount_path} = $_[0]->mount_path;
+                $_[0]->mount_path( archived_volume()->mount_path );
+                $_[0]->status('archived');
+                return 1;
+            },
             into => 'Genome::Disk::Allocation',
             as   => 'archive',
         });
@@ -46,6 +51,7 @@ sub overload_archiving_methods {
     Sub::Install::reinstall_sub({
             code => sub{ 
                 $_[0]->mount_path( $_[0]->{_mount_path} // tmp_volume()->mount_path );
+                $_[0]->status('active');
                 return 1;
             },
             into => 'Genome::Disk::Allocation',


### PR DESCRIPTION
When a previously-archived allocation is purged it will have status `purged` but a mount path pointing to the disk archive.  This leads to trouble when someone or something tries to unarchive this purged allocation.