### PR TITLE
Properly scope the saved STDOUT and STDERR handles

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1493,20 +1493,20 @@ sub shellcmd {
                 my ($restore_stdout);
                 if ($redirect_stdout) {
                     no warnings 'once'; # OLDOUT is used only once, not
-                    open(OLDOUT, '>&STDOUT') || die "Can't dup STDOUT: $!";
+                    open(my $old_out, '>&', *STDOUT) || die "Can't dup STDOUT: $!";
                     open(STDOUT, '>', $redirect_stdout) || die "Can't redirect stdout to $redirect_stdout: $!";
                     $restore_stdout = UR::Util::on_destroy(sub {
-                        open(STDOUT, '>&OLDOUT');
+                        open(STDOUT, '>&', $old_out);
                     });
                 }
 
                 my ($restore_stderr);
                 if ($redirect_stderr) {
                     no warnings 'once'; # OLDERR is used only once, not
-                    open(OLDERR, '>&STDERR') || die "Can't dup STDERR: $!";
+                    open(my $old_err, '>&', *STDERR) || die "Can't dup STDERR: $!";
                     open(STDERR, '>', $redirect_stderr) || die "Can't redirect stderr to $redirect_stderr: $!";
                     $restore_stderr = UR::Util::on_destroy(sub {
-                        open(STDERR, '>&OLDERR');
+                        open(STDERR, '>&', $old_err);
                     });
                 }
 


### PR DESCRIPTION
This should fix the two tests hanging on Jenkins:
    InstrumentData/Command/Import/Basic_sra.t
    InstrumentData/Command/Import/WorkFlow/SraToBam.t

The problem is that Genome::InstrumentData::Command::Import::WorkFlow::SraToBam::do_shellcmd_with_stdout()
is reading from a file of saved STDERR of a child process run with
Genome::Sys::shellcmd() and printing it to its own STDERR.  However, the
current process' STDERR is also printing to that same file.  The tests hang
because do_shellcmd_with_stdout() never gets to the end of the file (it's
filling it as it's reading).

I'm not sure what the _actual_ bug is, but this seems to fix it, while
removing global filehandle variables.  The strange part is that the tests ran fine
when I added seemingly unrelated prints inside the guard closures, and also ran
fine in debuggers.