### PR TITLE
Make vaf interpreters transient optional parameters

### DIFF
--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MaxVafObservedInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MaxVafObservedInterpreter.pm
@@ -23,6 +23,16 @@ class Genome::VariantReporting::Suite::BamReadcount::MaxVafObservedInterpreter {
             doc => 'A list of normal samples to use for calculation'
         },
     ],
+    has_transient_optional => [
+        tumor_vaf_interpreter => {
+            is => 'Genome::VariantReporting::Suite::BamReadcount::VafInterpreter',
+            is_structural => 1,
+        },
+        normal_vaf_interpreter => {
+            is => 'Genome::VariantReporting::Suite::BamReadcount::VafInterpreter',
+            is_structural => 1,
+        },
+    ],
     doc => 'Calculate the maximum vaf value observed between all the specified normal samples, and the maximum vaf value observed between all the tumor samples',
 };
 
@@ -49,14 +59,13 @@ sub _interpret_entry {
 
     my %normal_vafs;
     my %tumor_vafs;
-    my @sample_name_accessors = qw/normal_sample_names tumor_sample_names/;
-    my @vaf_hash_names        = (\%normal_vafs,        \%tumor_vafs);
-    my $it                    = each_array(@sample_name_accessors, @vaf_hash_names);
-    while ( my ($sample_name_accessor, $vaf_hash_ref) = $it->() ) {
+    my @sample_name_accessors     = qw/normal_sample_names    tumor_sample_names/;
+    my @vaf_hash_names            = (\%normal_vafs,           \%tumor_vafs);
+    my @vaf_interpreter_accessors = qw/normal_vaf_interpreter tumor_vaf_interpreter/;
+    my $it                    = each_array(@sample_name_accessors, @vaf_hash_names, @vaf_interpreter_accessors);
+    while ( my ($sample_name_accessor, $vaf_hash_ref, $vaf_interpreter_accessor) = $it->() ) {
         if ($self->$sample_name_accessor) {
-            my $interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
-                sample_names => [$self->$sample_name_accessor],
-            );
+            my $interpreter = $self->$vaf_interpreter_accessor;
             my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);
             for my $alt_allele (@$passed_alt_alleles) {
                 for my $sample_name ($self->$sample_name_accessor) {
@@ -84,6 +93,34 @@ sub _interpret_entry {
         }
     }
     return %return_values;
+}
+
+sub normal_vaf_interpreter {
+    my $self = shift;
+
+    return unless $self->normal_sample_names;
+
+    unless (defined($self->__normal_vaf_interpreter)) {
+        my $vaf_interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
+            sample_names => [$self->normal_sample_names],
+        );
+        $self->__normal_vaf_interpreter($vaf_interpreter);
+    }
+    return $self->__normal_vaf_interpreter;
+}
+
+sub tumor_vaf_interpreter {
+    my $self = shift;
+
+    return unless $self->tumor_sample_names;
+
+    unless (defined($self->__tumor_vaf_interpreter)) {
+        my $vaf_interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
+            sample_names => [$self->tumor_sample_names],
+        );
+        $self->__tumor_vaf_interpreter($vaf_interpreter);
+    }
+    return $self->__tumor_vaf_interpreter;
 }
 
 1;

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MaxVafObservedInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MaxVafObservedInterpreter.pm
@@ -64,14 +64,13 @@ sub _interpret_entry {
     my @vaf_interpreter_accessors = qw/normal_vaf_interpreter tumor_vaf_interpreter/;
     my $it                    = each_array(@sample_name_accessors, @vaf_hash_names, @vaf_interpreter_accessors);
     while ( my ($sample_name_accessor, $vaf_hash_ref, $vaf_interpreter_accessor) = $it->() ) {
-        if ($self->$sample_name_accessor) {
-            my $interpreter = $self->$vaf_interpreter_accessor;
-            my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);
-            for my $alt_allele (@$passed_alt_alleles) {
-                for my $sample_name ($self->$sample_name_accessor) {
-                    my $vaf = $result{$alt_allele}->{$interpreter->create_sample_specific_field_name('vaf', $sample_name)};
-                    $vaf_hash_ref->{$alt_allele}->{$sample_name} = $vaf;
-                }
+        my $interpreter = $self->$vaf_interpreter_accessor;
+        next unless $interpreter;
+        my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);
+        for my $alt_allele (@$passed_alt_alleles) {
+            for my $sample_name ($self->$sample_name_accessor) {
+                my $vaf = $result{$alt_allele}->{$interpreter->create_sample_specific_field_name('vaf', $sample_name)};
+                $vaf_hash_ref->{$alt_allele}->{$sample_name} = $vaf;
             }
         }
     }

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MinCoverageObservedInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/MinCoverageObservedInterpreter.pm
@@ -8,7 +8,12 @@ use Scalar::Util qw( looks_like_number );
 
 class Genome::VariantReporting::Suite::BamReadcount::MinCoverageObservedInterpreter {
     is => ['Genome::VariantReporting::Framework::Component::Interpreter', 'Genome::VariantReporting::Framework::Component::WithManySampleNames'],
-    has => [],
+    has_transient_optional => [
+        vaf_interpreter => {
+            is => 'Genome::VariantReporting::Suite::BamReadcount::VafInterpreter',
+            is_structural => 1,
+        },
+    ],
     doc => 'Calculate the minimum coverage (ref_count+var_count) between all the samples specified',
 };
 
@@ -31,10 +36,7 @@ sub _interpret_entry {
     my $entry = shift;
     my $passed_alt_alleles = shift;
 
-    my $interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
-        sample_names => [$self->sample_names],
-        sample_name_labels => $self->sample_name_labels,
-    );
+    my $interpreter = $self->vaf_interpreter;
     my %result = $interpreter->interpret_entry($entry, $passed_alt_alleles);
 
     my %coverages;
@@ -56,6 +58,19 @@ sub _interpret_entry {
         }
     }
     return %return_values;
+}
+
+sub vaf_interpreter {
+    my $self = shift;
+
+    unless (defined($self->__vaf_interpreter)) {
+        my $vaf_interpreter = Genome::VariantReporting::Suite::BamReadcount::VafInterpreter->create(
+            sample_names => [$self->sample_names],
+            sample_name_labels => $self->sample_name_labels,
+        );
+        $self->__vaf_interpreter($vaf_interpreter);
+    }
+    return $self->__vaf_interpreter;
 }
 
 1;


### PR DESCRIPTION
We want to avoid creating throwaway vaf interpreter objects every time _interpret_entry is called. Instead this PR makes it so that the vaf interpreter(s) are made into transient optional parameters.