### PR TITLE
Only check that converter exists during ROI validation.

### DIFF
--- a/lib/perl/Genome/Model/Build/PhenotypeCorrelation.pm
+++ b/lib/perl/Genome/Model/Build/PhenotypeCorrelation.pm
@@ -14,12 +14,12 @@ sub reference_being_replaced_for_input {
         }
 
         if ($roi_reference and !$rsb->is_compatible_with($roi_reference)) {
-            my $converter =  Genome::Model::Build::ReferenceSequence::Converter->get_with_lock(
-                source_reference_build => $roi_reference,
-                destination_reference_build => $rsb,
+            my $converter_exists =  Genome::Model::Build::ReferenceSequence::Converter->exists_for_references(
+                $roi_reference,
+                $rsb,
             );
 
-            if ($converter) {
+            if ($converter_exists) {
                 return 1;
             }
         }

--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
@@ -183,12 +183,12 @@ sub check_region_of_interest {
             }
 
             if ($roi_reference and !$rsb->is_compatible_with($roi_reference)) {
-                my $converter =  Genome::Model::Build::ReferenceSequence::Converter->get_with_lock(
-                    source_reference_build => $roi_reference, 
-                    destination_reference_build => $rsb,
+                my $converter_exists =  Genome::Model::Build::ReferenceSequence::Converter->exists_for_references(
+                    $roi_reference,
+                    $rsb,
                 );
 
-                unless ($converter) {
+                unless ($converter_exists) {
                     push @tags, UR::Object::Tag->create(
                         type => 'invalid',
                         properties => [qw/ region_of_interest_set_name /],

--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.t
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.t
@@ -4,10 +4,66 @@ use strict;
 use warnings;
 
 use above 'Genome';
-use Test::More tests => 1;
+use Test::More tests => 5;
 
-# This test was auto-generated because './Model/Build/ReferenceAlignment.pm'
-# had no '.t' file beside it.  Please remove this test if you believe it was
-# created unnecessarily.  This is a bare minimum test that just compiles Perl
-# and the UR class.
 use_ok('Genome::Model::Build::ReferenceAlignment');
+
+use Genome::Test::Factory::Build;
+use Genome::Test::Factory::InstrumentData::Solexa;
+use Genome::Test::Factory::Model::ReferenceAlignment;
+
+my $model = Genome::Test::Factory::Model::ReferenceAlignment->setup_object();
+my $other_reference = Genome::Test::Factory::Model::ReferenceAlignment->create_reference_sequence_build();
+
+my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id);
+
+subtest 'no instrument data does not validate' => sub {
+    expect_failure('instrument_data');
+};
+
+my $instrument_data = Genome::Test::Factory::InstrumentData::Solexa->setup_object(
+    clusters => 5,
+    is_paired_end => 1,
+);
+$model->add_instrument_data($instrument_data);
+$build->add_instrument_data($instrument_data);
+
+subtest 'with instrument data does validate' => sub {
+    expect_success();
+};
+
+
+my $fl = Genome::FeatureList->__define__(
+    name => 'test list for reference alignment validation ' . time(),
+    reference => $other_reference,
+    format => 'true-BED',
+);
+
+$model->region_of_interest_set_name($fl->name);
+$build->region_of_interest_set_name($fl->name);
+
+subtest 'roi with different reference does not validate' => sub {
+    expect_failure('region_of_interest_set_name');
+};
+
+$fl->reference($model->reference_sequence_build);
+
+subtest 'roi with same reference does validate' => sub {
+    expect_success();
+};
+
+
+sub expect_failure {
+    my $property_name = shift;
+
+    my @tags = $build->validate_for_start();
+    is(scalar(@tags), 1, 'found an error in validation') or return;
+    my @properties = $tags[0]->properties;
+    is($properties[0], $property_name, 'expected property found in tag');
+}
+
+sub expect_success {
+    my @tags = $build->validate_for_start();
+    is(scalar(@tags), 0, 'found no errors in validation')
+        or diag(Data::Dumper::Dumper @tags);
+}

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/Converter.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/Converter.pm
@@ -62,8 +62,8 @@ sub exists_for_references {
     my $source_reference = shift;
     my $destination_reference = shift;
 
-    my @ref = $class->_faster_get(source_reference_build => $source_reference, destination_reference_build => $destination_reference);
-    return (scalar(@ref) > 0);
+    my $ref = $class->_faster_get(source_reference_build => $source_reference, destination_reference_build => $destination_reference);
+    return defined($ref);
 }
 
 sub convert_bed {


### PR DESCRIPTION
These should have been changed as part of #429 but were not.