### PR TITLE
Change how the PerLibraryvafInterpreter handles planned libraries

### DIFF
--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/PerLibraryVafInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/PerLibraryVafInterpreter.pm
@@ -38,16 +38,6 @@ sub _interpret_entry {
     my $entry = shift;
     my $passed_alt_alleles = shift;
 
-    if ($self->library_names) {
-        my $available_libraries = $self->available_libraries($entry);
-        my $expected_libraries  = Set::Scalar->new($self->library_names);
-        unless ($available_libraries->is_equal($expected_libraries)) {
-            die $self->error_message(
-                "Available libraries (%s) are not identical to planned libraries (%s)",
-                join(', ', $available_libraries->members), join(', ', $expected_libraries->members)
-            );
-        }
-    }
     my %return_values;
 
     for my $sample_name ($self->sample_names) {
@@ -96,7 +86,7 @@ sub per_library_coverage {
 sub flatten_hash {
     my ($self, $per_library_hash, $field_name) = @_;
     my %flattened_hash;
-    for my $library_name (keys %$per_library_hash) {
+    for my $library_name ($self->library_names) {
         $flattened_hash{$self->create_library_specific_field_name($field_name, $library_name)} = $per_library_hash->{$library_name};
     }
     return %flattened_hash;

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/PerLibraryVafInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/PerLibraryVafInterpreter.pm
@@ -87,7 +87,12 @@ sub flatten_hash {
     my ($self, $per_library_hash, $field_name) = @_;
     my %flattened_hash;
     for my $library_name ($self->library_names) {
-        $flattened_hash{$self->create_library_specific_field_name($field_name, $library_name)} = $per_library_hash->{$library_name};
+        if (defined($per_library_hash->{$library_name})) {
+            $flattened_hash{$self->create_library_specific_field_name($field_name, $library_name)} = $per_library_hash->{$library_name};
+        }
+        else {
+            $flattened_hash{$self->create_library_specific_field_name($field_name, $library_name)} = $self->interpretation_null_character;
+        }
     }
     return %flattened_hash;
 }

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/PerLibraryVafInterpreter.t
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/PerLibraryVafInterpreter.t
@@ -142,4 +142,31 @@ subtest "long indel" => sub {
     is_deeply(\%result, \%expected, "Values are as expected");
 };
 
+subtest 'additional libraries' => sub {
+    my $interpreter = $pkg->create(
+        sample_names => ["S1"],
+        library_names => [@$library_names, 'additional_library'],
+    );
+    lives_ok(sub {$interpreter->validate}, "Interpreter validates");
+
+    my %expected = (
+        G => {
+            'Solexa-135852_var_count' => '155',
+            'Solexa-135853_var_count' => '186',
+            'Solexa-135852_ref_count' => '2',
+            'Solexa-135853_ref_count' => '1',
+            'Solexa-135852_vaf' => '87.0786516853933',
+            'Solexa-135853_vaf' => '99.4652406417112',
+            'additional_library_var_count' => '.',
+            'additional_library_ref_count' => '.',
+            'additional_library_vaf' => '.',
+        }
+    );
+
+    my $entry = create_default_entry();
+    my %result = $interpreter->interpret_entry($entry, ['G']);
+    is_deeply(\%result, \%expected, "Values are as expected");
+
+};
+
 done_testing;

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/PerLibraryVafInterpreter.t
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/PerLibraryVafInterpreter.t
@@ -142,16 +142,4 @@ subtest "long indel" => sub {
     is_deeply(\%result, \%expected, "Values are as expected");
 };
 
-subtest "libraries don't match" => sub {
-    for my $incorrect_library_names ([qw(Solexa-135853)], [qw(Solexa-135854 Solexa-135853 Solexa-135852)], [qw(nonexistent_library)]) {
-        my $interpreter = $pkg->create(
-            sample_names => ["S1"],
-            library_names => $incorrect_library_names,
-        );
-        lives_ok(sub {$interpreter->validate}, "Interpreter validates");
-        my $entry = create_default_entry();
-        dies_ok(sub{$interpreter->interpret_entry($entry, ['G'])}, "Libraries don't match fails ok");
-    }
-};
-
 done_testing;


### PR DESCRIPTION
Instead of trying to check that the planned libraries match the libraries provided in the vcf, restrict the interpretations to the set of planned libraries.