### PR TITLE
Defer SR user creation to commit time and lock to prevent duplicates.

### DIFF
--- a/lib/perl/Genome/Command/DelegatesToResult.t
+++ b/lib/perl/Genome/Command/DelegatesToResult.t
@@ -119,6 +119,7 @@ sub check_sr_user {
     my $user = shift;
     my $label = shift;
 
+    UR::Context->commit();
     subtest sprintf("SoftwareResult::User (%s)", $user->name) => sub {
         my $sr_user = Genome::SoftwareResult::User->get(
             user => $user,

--- a/lib/perl/Genome/InstrumentData/Command/RefineReads/GatkBestPractices.t
+++ b/lib/perl/Genome/InstrumentData/Command/RefineReads/GatkBestPractices.t
@@ -48,6 +48,8 @@ isa_ok($base_recalibrator_bam_result, 'Genome::InstrumentData::Gatk::BaseRecalib
 my $base_recalibrator_result = $base_recalibrator_bam_result->base_recalibrator_result;
 ok($base_recalibrator_result, 'get base_recalibrator_result');
 
+UR::Context->commit();
+
 # Users
 my @sr_users = $bam_source->users;
 is(@sr_users, 1, 'add user to bam source');

--- a/lib/perl/Genome/SoftwareResult/User.t
+++ b/lib/perl/Genome/SoftwareResult/User.t
@@ -146,6 +146,17 @@ subtest 'multiple shortcutters result in only one user' => sub {
     }
     UR::Context->commit();
 
+    subtest 'lock not still held after commit is complete' => sub {
+        my $resource = Genome::SoftwareResult::User->_resolve_lock_name({
+                label => 'sponsor',
+                user => $users_hash{users}{sponsor},
+                software_result => $sr,
+        });
+        my $lock = Genome::Sys->lock_resource(resource_lock => $resource, scope => 'site', max_try => 1);
+        ok($lock, 'got lock');
+        Genome::Sys->unlock_resource(resource_lock => $lock);
+    };
+
     my @users = $sr->users;
     is(scalar(@users), 2, 'users only added once across all three calls');
     my @sponsors = grep { $_->label eq 'sponsor' } @users;

--- a/lib/perl/Genome/SoftwareResult/User.t
+++ b/lib/perl/Genome/SoftwareResult/User.t
@@ -21,10 +21,6 @@ class SR_Test {
     },
 };
 
-sub SR_Test::create {
-    return shift->Genome::SoftwareResult::create(@_);
-}
-
 sub _newly_created_callback {
     return (SR_Test->create(p1 => 'turkey'), 1);
 }

--- a/lib/perl/Genome/VariantReporting/Command/CreateReport.t
+++ b/lib/perl/Genome/VariantReporting/Command/CreateReport.t
@@ -41,7 +41,7 @@ subtest 'working_command' => sub {
         translations_file => get_translations_file($input_vcf),
     );
     my $p = $cmd->execute();
-
+    UR::Context->commit();
     my $expected_result_dir = File::Spec->join($test_dir, "expected_in_result");
 
     my $output_dir = Genome::Sys->create_temp_directory;
@@ -67,6 +67,7 @@ subtest 'working_command' => sub {
             translations_file => get_translations_file($other_input_vcf),
         );
         my $other_p = $other_cmd->execute();
+        UR::Context->commit();
         is_deeply({$p->compare_output($other_p->id)}, {}, 'Two identical process executions produce the same output');
     };
 
@@ -85,6 +86,7 @@ subtest 'working_command' => sub {
             translations_file => get_translations_file($other_input_vcf),
         );
         my $other_p = $other_cmd->execute();
+        UR::Context->commit();
         my %diffs = $p->compare_output($other_p->id);
         my $report_file = File::Spec->join($p->output_directory('__test__'), 'report.txt');
         my $other_report_file = File::Spec->join($other_p->output_directory('__test__'), 'report.txt');
@@ -122,6 +124,7 @@ subtest 'working_command' => sub {
            translations_file => get_translations_file_for_plan2($other_input_vcf),
         );
         my $other_p = $other_cmd->execute();
+        UR::Context->commit();
         my %diffs = $p->compare_output($other_p->id);
         like($diffs{'__translated_test__'}, qr/no directory __translated_test__ found/, 'Additional report gets detected');
         like($diffs{File::Spec->join('__test__', 'plan.yaml')}, qr/files are not the same/, 'Plan file difference gets detected');

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/Trio.t
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/Trio.t
@@ -89,6 +89,8 @@ my $cmd = $pkg->create(
 my $p = $cmd->execute();
 isa_ok($p, 'Genome::VariantReporting::Process::Trio');
 
+UR::Context->commit();
+
 test_xml($p->workflow_file, __FILE__);
 
 my $output_dir = Genome::Sys->create_temp_directory();


### PR DESCRIPTION
There was a race condition here where multiple processes thought they needed to create the sponsor relationship.  This adds locking around the user creation to avoid the duplicates.

The creation is delayed to a pre-commit hook to avoid needing to either commit the user relationship in a separate transaction or potentially hold the lock for a long time.