### PR TITLE
fix option spec

### DIFF
--- a/bin/genome-env-next
+++ b/bin/genome-env-next
@@ -116,7 +116,7 @@ function parse_opts {
     DISABLE_DB="" DISABLE_MIGRATIONS="" DISABLE_UR="" DISABLE_WF="" DB_SNAPSHOT_NAME="" SQITCH_REPO="" UR_REPO="" WF_REPO=""
 
     local opts
-    while getopts :hMDd:Uu:vWw: opts "$@"
+    while getopts :hMm:Dd:Uu:Ww: opts "$@"
     do
         case $opts in
             h)


### PR DESCRIPTION
I let the option spec get out of sync again.  This fixes it for changes that
were previously made to the case statement:

- add the -m option
- remove the -v option