### PR TITLE
Variant reporting: fail vep annotation early if feature list contains invalid characters

### DIFF
--- a/lib/perl/Genome/FeatureList.pm
+++ b/lib/perl/Genome/FeatureList.pm
@@ -359,7 +359,7 @@ sub processed_bed_file {
     Genome::Sys->write_file($temp_file, $content);
     return $temp_file;
 }
-Memoize::memoize('processed_bed_file');
+Memoize::memoize('processed_bed_file', LIST_CACHE => 'MERGE');
 
 sub generate_merged_bed_file {
     my $self = shift;

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -8,6 +8,7 @@ use IPC::Run qw(run);
 use File::Basename qw(dirname);
 use JSON;
 use Memoize qw();
+use List::MoreUtils qw(uniq);
 
 my $_JSON_CODEC = new JSON->allow_nonref;
 
@@ -62,6 +63,7 @@ sub output_filename {
 sub _run {
     my $self = shift;
 
+    $self->_validate_feature_lists;
     $self->_sort_input_vcf;
     $self->_strip_input_vcf;
     $self->_split_alternate_alleles;
@@ -72,6 +74,27 @@ sub _run {
     $self->_zip;
 
     return;
+}
+
+my @INVALID_FEATURE_LIST_CHARACTERS = qw/;/;
+
+sub _validate_feature_lists {
+    my $self = shift;
+
+    for my $tag ($self->custom_annotation_tags) {
+        my $id = $self->decoded_feature_list_ids->{$tag};
+        my $feature_list_file_path = $self->_get_processed_file_path_for_feature_list($id);
+        my $bed_reader = Genome::Utility::IO::BedReader->create(
+            input => $feature_list_file_path,
+            headers => [qw/chr start end annotation/],
+        );
+        while (my $bed_entry = $bed_reader->next) {
+            my $invalid_characters_string = join('', @INVALID_FEATURE_LIST_CHARACTERS);
+            if (my @invalid_characters_captured = $bed_entry->{annotation} =~ m/([\Q$invalid_characters_string\E])/g) {
+                die $self->error_message("Feature list (%s) contains the following invalid characters (%s)", $id, join(' ', uniq @invalid_characters_captured));
+            }
+        }
+    }
 }
 
 sub _sort_input_vcf {
@@ -157,9 +180,22 @@ sub _user_params {
 sub _get_file_path_for_feature_list {
     my ($self, $id) = @_;
     my $feature_list = Genome::FeatureList->get($id);
-    return $feature_list->get_tabix_and_gzipped_bed_file,
+    my $processed_bed = $self->_get_processed_file_path_for_feature_list($id);
+    my $sorted_processed_bed = Genome::Sys->create_temp_file_path;
+    Genome::Model::Tools::Joinx::Sort->execute(
+        input_files => [$processed_bed],
+        output_file => $sorted_processed_bed,
+    );
+    return $feature_list->gzip_and_tabix_bed($sorted_processed_bed);
 }
 Memoize::memoize("_get_file_path_for_feature_list", LIST_CACHE => 'MERGE');
+
+sub _get_processed_file_path_for_feature_list {
+    my ($self, $id) = @_;
+    my $feature_list = Genome::FeatureList->get($id);
+    return $feature_list->processed_bed_file(short_name => 0),
+}
+Memoize::memoize("_get_processed_file_path_for_feature_list", LIST_CACHE => 'MERGE');
 
 sub custom_annotation_inputs {
     my $self = shift;

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -88,10 +88,13 @@ sub _validate_feature_lists {
             input => $feature_list_file_path,
             headers => [qw/chr start end annotation/],
         );
-        while (my $bed_entry = $bed_reader->next) {
+        #Only check the first 10 lines to reduce computational cost
+        #Typically, invalid characters will be present on every line
+        for my $line (1..10) {
+            my $bed_entry = $bed_reader->next;
             my $invalid_characters_string = join('', @INVALID_FEATURE_LIST_CHARACTERS);
             if (my @invalid_characters_captured = $bed_entry->{annotation} =~ m/([\Q$invalid_characters_string\E])/g) {
-                die $self->error_message("Feature list (%s) contains the following invalid characters (%s)", $id, join(' ', uniq @invalid_characters_captured));
+                die $self->error_message("Feature list (%s) contains the following invalid characters (%s) in the 4th column on line (%s).", $id, join(' ', uniq @invalid_characters_captured), $line);
             }
         }
     }

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -81,7 +81,7 @@ my @INVALID_FEATURE_LIST_CHARACTERS = qw/;/;
 sub _validate_feature_lists {
     my $self = shift;
 
-    for my $tag ($self->custom_annotation_tags) {
+    TAG: for my $tag ($self->custom_annotation_tags) {
         my $id = $self->decoded_feature_list_ids->{$tag};
         my $feature_list_file_path = $self->_get_processed_file_path_for_feature_list($id);
         my $bed_reader = Genome::Utility::IO::BedReader->create(
@@ -92,6 +92,7 @@ sub _validate_feature_lists {
         #Typically, invalid characters will be present on every line
         for my $line (1..10) {
             my $bed_entry = $bed_reader->next;
+            next TAG unless defined($bed_entry);
             my $invalid_characters_string = join('', @INVALID_FEATURE_LIST_CHARACTERS);
             if (my @invalid_characters_captured = $bed_entry->{annotation} =~ m/([\Q$invalid_characters_string\E])/g) {
                 die $self->error_message("Feature list (%s) contains the following invalid characters (%s) in the 4th column on line (%s).", $id, join(' ', uniq @invalid_characters_captured), $line);

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -184,13 +184,7 @@ sub _user_params {
 sub _get_file_path_for_feature_list {
     my ($self, $id) = @_;
     my $feature_list = Genome::FeatureList->get($id);
-    my $processed_bed = $self->_get_processed_file_path_for_feature_list($id);
-    my $sorted_processed_bed = Genome::Sys->create_temp_file_path;
-    Genome::Model::Tools::Joinx::Sort->execute(
-        input_files => [$processed_bed],
-        output_file => $sorted_processed_bed,
-    );
-    return $feature_list->gzip_and_tabix_bed($sorted_processed_bed);
+    return $feature_list->get_tabix_and_gzipped_bed_file;
 }
 Memoize::memoize("_get_file_path_for_feature_list", LIST_CACHE => 'MERGE');
 


### PR DESCRIPTION
Sometimes a feature list that is used for vep annotation in the variant reporting subsystem will contain special characters which might cause downstream tools to fail. E.g., semicolons cause errors for joinx vcf-merge if they aren't used to separate info fields. This change will check the feature lists supplied to the vep annotation and crash if it contains a special character.

Right now the only special character I'm aware of is semicolon but this code change allows for easy addition of other invalid characters.