### PR TITLE
Fix duplicate models on coverage report summary

### DIFF
--- a/lib/perl/Genome/Model/Set/View/Coverage/Xml.pm
+++ b/lib/perl/Genome/Model/Set/View/Coverage/Xml.pm
@@ -2,6 +2,7 @@ package Genome::Model::Set::View::Coverage::Xml;
 
 use strict;
 use warnings;
+use List::AllUtils qw(uniq);
 
 class Genome::Model::Set::View::Coverage::Xml {
     is => 'UR::Object::View::Default::Xml',
@@ -439,7 +440,7 @@ sub _results_for_build {
         push @results, $build;
     }
 
-    return @results;
+    return uniq @results;
 }
 
 sub _get_model_node {


### PR DESCRIPTION
Here's an [example coverage report](https://imp-apipe.gsc.wustl.edu/view/genome/model-group/coverage.html?id=695ce2caba6442d2b9f824bd87f752de). Per RT [104057](https://rt.gsc.wustl.edu/Ticket/Display.html?id=104057#txn-1838158). :sheep: