### PR TITLE
Tweak internals of SR User locking

### DIFF
--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -159,12 +159,12 @@ sub _lock_and_get_or_create {
 
     my $resource = $class->_resolve_lock_name($params);
     my $lock = Genome::Sys->lock_resource(resource_lock => $resource, scope => 'site');
-    $class->_get_or_create($params);
+    $class->_load_or_create($params);
 
     return $lock;
 }
 
-sub _get_or_create {
+sub _load_or_create {
     my $class = shift;
     my $params = shift;
 

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -99,14 +99,14 @@ sub _register_users {
     my $label = $newly_created ? 'created' : 'shortcut';
     $user_hash{$label} = $requestor;
 
-    my @all_params;
+    my @param_sets;
     while(my ($label, $object) = each %user_hash) {
         my %params = (
             label           => $label,
             user            => $object,
             software_result => $software_result,
         );
-        push @all_params, \%params;
+        push @param_sets, \%params;
     }
 
     my $observer;
@@ -120,7 +120,7 @@ sub _register_users {
                 Carp::confess 'observer triggered multiple times!';
             }
             my @locks;
-            for my $params (@all_params) {
+            for my $params (@param_sets) {
                 next if grep { $params->{$_}->isa('UR::DeletedRef') } qw(user software_result);
                 push @locks, $class->_lock_and_get_or_create($params);
             }

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -122,7 +122,7 @@ sub _register_users {
             my @locks;
             for my $params (@param_sets) {
                 next if grep { $params->{$_}->isa('UR::DeletedRef') } qw(user software_result);
-                push @locks, $class->_lock_and_get_or_create($params);
+                push @locks, $class->_lock_and_create_if_needed($params);
             }
 
             return unless @locks;
@@ -150,7 +150,7 @@ sub _register_users {
     }
 }
 
-sub _lock_and_get_or_create {
+sub _lock_and_create_if_needed {
     my $class = shift;
     my $params = shift;
 

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -173,7 +173,7 @@ sub _load_or_create {
         $self = $class->create(%$params);
     }
 
-    return $self;
+    return 1;
 }
 
 sub _resolve_lock_name {

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -122,7 +122,7 @@ sub _register_users {
             my @locks;
             for my $params (@all_params) {
                 next if grep { $params->{$_}->isa('UR::DeletedRef') } qw(user software_result);
-                push @locks, $class->_get_or_create_with_lock($params);
+                push @locks, $class->_lock_and_get_or_create($params);
             }
 
             return unless @locks;
@@ -150,7 +150,7 @@ sub _register_users {
     }
 }
 
-sub _get_or_create_with_lock {
+sub _lock_and_get_or_create {
     my $class = shift;
     my $params = shift;
 


### PR DESCRIPTION
It was suggested that `_get_or_create_with_lock` was a confusing name for a thing that returns a lock.  Here's a perhaps better alternative.  It's also possible we could restructure this instead?