### PR TITLE
Start filtering instrument data by config rules on mass assignment

### DIFF
--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -98,22 +98,23 @@ sub _process_models {
                 $model->id, ($created_new ? 'created' : 'found'), $instrument_data->id ));
 
         $self->_assign_model_to_analysis_project($analysis_project, $model, $config_profile_item, $created_new);
-        $self->_assign_instrument_data_to_model($model, $instrument_data, $created_new);
+        $self->_assign_instrument_data_to_model($model, $instrument_data, $config_profile_item, $created_new);
         $self->_update_model($model);
         $self->_request_build_if_necessary($model, $created_new);
     }
 }
 
 sub _assign_instrument_data_to_model {
-    my ($self, $model, $instrument_data, $newly_created) = @_;
+    my ($self, $model, $instrument_data, $config_profile_item, $newly_created) = @_;
 
     #if a model is newly created, we want to assign all applicable instrument data to it
     my %params_hash = (model => $model);
     my $executed_ok = 1;
     if ($newly_created && $model->auto_assign_inst_data) {
-        my $cmd = Genome::Model::Command::InstrumentData::Assign::AnalysisProject->create(
+        my $cmd = Genome::Model::Command::InstrumentData::Assign::AnalysisProject::ByConfig->create(
             model => $model,
             analysis_project => $model->analysis_project,
+            config_profile_item => $config_profile_item,
         );
         $executed_ok &&= eval{ $cmd->execute; };
     } else {

--- a/lib/perl/Genome/Model/Command/InstrumentData/Assign/AnalysisProject/ByConfig.pm
+++ b/lib/perl/Genome/Model/Command/InstrumentData/Assign/AnalysisProject/ByConfig.pm
@@ -1,0 +1,24 @@
+package Genome::Model::Command::InstrumentData::Assign::AnalysisProject::ByConfig;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::Command::InstrumentData::Assign::AnalysisProject::ByConfig {
+    is => 'Genome::Model::Command::InstrumentData::Assign::AnalysisProject',
+    has_input => [
+        config_profile_item => {
+            is => 'Genome::Config::Profile::Item',
+        },
+    ],
+};
+
+sub _resolve_instrument_data {
+    my $self = shift;
+    my $model = $self->model;
+    my $ruleset = Genome::Config::Translator->get_rule_model_map_from_config($self->config_profile_item);
+    return grep { $ruleset->match($_) } $self->SUPER::_resolve_instrument_data();
+}
+
+1;


### PR DESCRIPTION
This isn't passing tests yet, but I wanted to get feedback on the idea first. @tmooney especially should probably take a look at this.

This actually grew out of these JIRA issues: 
 * https://jira.gsc.wustl.edu/browse/BIO-1326
 * https://jira.gsc.wustl.edu/browse/BIO-1315

Essentially, the rules in the configuration specified only bisulfite data, but `auto_assign_inst_data` was turned on. The `Genome::Model::Command::InstrumentData::Assign` commands don't know anything about config, and thus just do their own checks (do the subjects match? trsn? etc) and then blindly assign everything that's compatible.

We discussed the following potential fixes:
 * Add a condition to `compatible_instrument_data` in appropriate models that checks to make sure that the library preps are the same

* Add a condition to the `G::M::C::ID::Assign` commands that checks for similar library preps

And decided the we didn't like the idea of specifying this information in both the rules and somewhere in code. This is the general idea we came up with. Every piece of instrument data that we AutoAssign to a model must itself pass the ruleset for that config item. Thoughts?