### PR TITLE
Don't try to add users to deleted results.

### DIFF
--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -121,6 +121,7 @@ sub _register_users {
             }
             my @locks;
             for my $params (@all_params) {
+                next if $params->{user}->isa('UR::DeletedRef');
                 push @locks, $class->_get_or_create_with_lock($params);
             }
             my $unlocker;

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -124,6 +124,9 @@ sub _register_users {
                 next if $params->{user}->isa('UR::DeletedRef');
                 push @locks, $class->_get_or_create_with_lock($params);
             }
+
+            return unless @locks;
+
             my $unlocker;
             $unlocker = UR::Context->process->add_observer(
                 aspect => 'commit',


### PR DESCRIPTION
If the result is deleted for any reason, we don't still want to try to add users.  (We know it's not coming back unless another pre-commit hook resurrects it...)

For example, `Genome::InstrumentData::WithIntermediateResults` gets the intermediate results (thus adding a callback) immediately before deleting them.