### PR TITLE
Relax requirements for scheduling reference alignment reports.

### DIFF
--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/RunReports.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/RunReports.pm
@@ -31,10 +31,10 @@ sub execute {
         delete $REPORT_TYPES{InputBaseCounts};
     }
 
-    unless (defined $build->dbsnp_build) {
-        $self->debug_message("No dbsnp_build defined for model, skipping dbsnp concordance report.");
+    unless (defined $build->dbsnp_build && defined $model->snv_detection_strategy) {
+        $self->debug_message("Either no dbsnp_build or snv detection for build; skipping dbsnp concordance report.");
         delete $REPORT_TYPES{DbSnpConcordance};
-    } 
+    }
 
     unless ($self->validate_gold_snp_path) {
         $self->debug_message("No valid gold_snp_path for the build, skip GoldSnpConcordance report");

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -520,7 +520,7 @@ sub generate_reports_job_classes {
     my @steps = (
         'Genome::Model::Event::Build::ReferenceAlignment::RunReports'
     );
-    if((defined $self->snv_detection_strategy || defined $self->indel_detection_strategy) && defined $self->duplication_handler_name) {
+    if(defined $self->duplication_handler_name || defined $self->merger_name) {
         return @steps;
     }
     else {


### PR DESCRIPTION
It has been requested that we still run reports (particularly MapCheck) even if no variant detection is performed.