### PR TITLE
update gmt joinx vcf-report to check versions properly

### DIFF
--- a/lib/perl/Genome/Model/Tools/Joinx/VcfReport.pm
+++ b/lib/perl/Genome/Model/Tools/Joinx/VcfReport.pm
@@ -73,14 +73,11 @@ EOS
 
 sub execute {
     my $self = shift;
-    $DB::single = 1;
+
+    $self->check_minimum_version($MINIMUM_JOINX_VERSION);
+
     my ($per_sample_output, $per_site_output) = qw{ per_sample_report.txt per_site_report.txt }; #these are the default output file names in the program
 
-    if($self->use_version < $MINIMUM_JOINX_VERSION) {
-        $self->error_message("This module requires joinx version $MINIMUM_JOINX_VERSION or higher to function correctly.");
-        return;
-    }
-    
     my $input_file = $self->input_file;
 
     unless(-s $input_file) {

--- a/lib/perl/Genome/Model/Tools/Joinx/VcfReport.t
+++ b/lib/perl/Genome/Model/Tools/Joinx/VcfReport.t
@@ -4,10 +4,58 @@ use strict;
 use warnings;
 
 use above 'Genome';
-use Test::More tests => 1;
+use Test::More;
+use Test::Exception;
 
-# This test was auto-generated because './Model/Tools/Joinx/VcfReport.pm'
-# had no '.t' file beside it.  Please remove this test if you believe it was
-# created unnecessarily.  This is a bare minimum test that just compiles Perl
-# and the UR class.
-use_ok('Genome::Model::Tools::Joinx::VcfReport');
+my $pkg = 'Genome::Model::Tools::Joinx::VcfReport';
+use_ok($pkg);
+
+my $test_data = File::Spec->catfile($ENV{GENOME_TEST_INPUTS}, "Genome-Model-Tools-Joinx-VcfReport");
+
+my $input_file = File::Spec->catfile($test_data, "input.vcf");
+my $expected_site = File::Spec->catfile($test_data, "expected-site.txt");
+my $expected_sample = File::Spec->catfile($test_data, "expected-sample.txt");
+
+my $site_out = Genome::Sys->create_temp_file_path;
+my $sample_out = Genome::Sys->create_temp_file_path;
+
+
+my %base_params =(
+        per_site_output_file => $site_out,
+        per_sample_output_file => $sample_out,
+        input_file => $input_file,
+        generate_report => 0
+        );
+
+my $bad_cmd = $pkg->create(use_version => '1.4', %base_params);
+ok($bad_cmd, "created command with invalid version");
+dies_ok(sub {$bad_cmd->execute}, "command with invalid version fails to execute");
+
+sub make_versioned_test {
+    my $version = shift;
+
+    return sub {
+        my $cmd = $pkg->create(
+                use_version => $version,
+                %base_params,
+                );
+
+        ok($cmd, "created_command");
+        ok($cmd->execute, "executed command");
+
+        my $site_diff = Genome::Sys->diff_file_vs_file($expected_site, $site_out);
+        ok(!$site_diff, "site file is correct") or diag $site_diff;
+
+        my $sample_diff = Genome::Sys->diff_file_vs_file($expected_sample, $sample_out);
+        ok(!$sample_diff, "sample file is correct") or diag $sample_diff;
+    }
+}
+
+for my $minor_version (8..11) {
+    my $version = "1.$minor_version";
+    subtest "Test version $version" => make_versioned_test($version);
+}
+
+
+
+done_testing();


### PR DESCRIPTION
it was using floating point comparisons for the 'minimum version' check.
the base class already had a "check_minimum_version" method that does
the right thing. added a test too.