### PR TITLE
Don't try to add users to deleted results.

### DIFF
--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -121,7 +121,7 @@ sub _register_users {
             }
             my @locks;
             for my $params (@all_params) {
-                next if $params->{user}->isa('UR::DeletedRef');
+                next if $params->{user}->isa('UR::DeletedRef') or $params->{software_result}->isa('UR::DeletedRef');
                 push @locks, $class->_get_or_create_with_lock($params);
             }
 

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -121,7 +121,7 @@ sub _register_users {
             }
             my @locks;
             for my $params (@all_params) {
-                next if $params->{user}->isa('UR::DeletedRef') or $params->{software_result}->isa('UR::DeletedRef');
+                next if grep { $params->{$_}->isa('UR::DeletedRef') } qw(user software_result);
                 push @locks, $class->_get_or_create_with_lock($params);
             }
 


### PR DESCRIPTION
Hot on the heels of #479 (which should have been called "Don't try to add deleted users to results"), here's a commit that does the other thing.

[I've run align-reads from reference alignment with this commit, and it succeeds at committing this time.]