### PR TITLE
update default DB snapshot

### DIFF
--- a/bin/genome-env-next
+++ b/bin/genome-env-next
@@ -233,7 +233,7 @@ function set_defaults {
 
     if test -z "$DB_SNAPSHOT_NAME"
     then
-        DB_SNAPSHOT_NAME="77c3c2a"
+        DB_SNAPSHOT_NAME="53a549f"
     fi
 
     if test -z "$UR_REPO"


### PR DESCRIPTION
Updated from previous version to fix missing ClinSeq data.

```
$ bin/genome-env-next genome-fill-db prove -v lib/perl/Genome/Model/ClinSeq.t lib/perl/Genome/Model/ClinSeq/Command/Converge/DgidbCounts.t lib/perl/Genome/Model/ClinSeq/Command/Converge/DgidbGenes.t
...
Test DB Name: 4FA4513AB80511E48973DEB2A9DCD391
...
$ test-db template create $(git rev-parse --short HEAD) 4FA4513AB80511E48973DEB2A9DCD391
```