### PR TITLE
Reserve tmp since our output is written there before being allocated.

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/VarscanSomaticValidation.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/VarscanSomaticValidation.pm
@@ -14,7 +14,7 @@ class Genome::Model::Tools::DetectVariants2::VarscanSomaticValidation {
     ],
     has_param => [
         lsf_resource => {
-            default_value => "-M 10000000 -R 'select[mem>10000] rusage[mem=10000]'",
+            default_value => "-M 10000000 -R 'select[mem>10000 && gtmp>100] rusage[mem=10000,gtmp=100]'",
         },
     ],
     doc => 'This tool is a wrapper around `gmt varscan validation` to make it meet the API for variant detection in pipelines'


### PR DESCRIPTION
This process was filling /tmp on one of our blades but other jobs would still be scheduled there.