### PR TITLE
A Command for Reprocessing an Analysis Project

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddConfigFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddConfigFile.pm
@@ -64,19 +64,12 @@ sub execute {
     $self->_apply_tags($result);
 
     if($self->reprocess_existing){
-        $self->_mark_instrument_data_bridges;
+        Genome::Config::AnalysisProject::Command::Reprocess->execute(
+            analysis_project => $self->analysis_project
+        );
     }
 
     return $result;
-}
-
-sub _mark_instrument_data_bridges {
-    my $self = shift;
-    my $analysis_project = $self->analysis_project;
-    for my $bridge ($analysis_project->analysis_project_bridges){
-        $bridge->status('new');
-    }
-    return 1;
 }
 
 sub _apply_tags {

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.pm
@@ -54,7 +54,9 @@ sub execute {
     }
 
     if($self->reprocess_existing){
-        $self->_mark_instrument_data_bridges;
+        Genome::Config::AnalysisProject::Command::Reprocess->execute(
+            analysis_project => $self->analysis_project
+        );
     }
 
     return $self->analysis_project;
@@ -90,15 +92,6 @@ sub _add_config_items_to_project {
         );
     }
 
-    return 1;
-}
-
-sub _mark_instrument_data_bridges {
-    my $self = shift;
-    my $analysis_project = $self->analysis_project;
-    for my $bridge ($analysis_project->analysis_project_bridges){
-        $bridge->status('new');
-    }
     return 1;
 }
 

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Reprocess.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Reprocess.pm
@@ -1,0 +1,46 @@
+package Genome::Config::AnalysisProject::Command::Reprocess;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Config::AnalysisProject::Command::Reprocess {
+    is => 'Genome::Config::AnalysisProject::Command::Base',
+};
+
+sub help_brief {
+    return 'reschedules instrument data for processing';
+}
+
+sub help_synopsis {
+    return 'genome config analysis-project reprocess <analysis-project>';
+}
+
+sub help_detail {
+    return <<'EOS';
+This will reschedule all instrument-data for the analysis-project to be
+reprocessed.  This command has the same effect as the --reprocess-existing
+option to the add-config-file and add-menu-item commands.
+
+If the analysis-project is currently held or pending, the reprocessing will
+not occur until the analysis-project has been released.
+EOS
+}
+
+sub valid_statuses {
+    return ('Pending', 'Hold', 'In Progress');
+}
+
+sub execute {
+    my $self = shift;
+
+    my $analysis_project = $self->analysis_project;
+    for my $bridge ($analysis_project->analysis_project_bridges) {
+        $bridge->reschedule;
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Reprocess.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Reprocess.t
@@ -20,17 +20,20 @@ my $analysis_project = Genome::Config::AnalysisProject->create(
     name => 'Test Project for Reprocess Command',
 );
 
+my $bridge_class = 'Genome::Config::AnalysisProject::InstrumentDataBridge';
+my $possible_statuses = $bridge_class->__meta__->property(property_name => 'status')->valid_values;
+
 my @instrument_data;
 my @bridges;
-for my $i (0..3) {
+
+for my $i (0..$#$possible_statuses) {
     my $instrument_data = Genome::Test::Factory::InstrumentData::Solexa->setup_object(lane => $i);
     push @instrument_data, $instrument_data;
 
-    my $bridge_class = 'Genome::Config::AnalysisProject::InstrumentDataBridge';
     my $bridge = $bridge_class->create(
         analysis_project => $analysis_project,
         instrument_data => $instrument_data,
-        status => $bridge_class->__meta__->property(property_name => 'status')->valid_values->[$i],
+        status => $possible_statuses->[$i],
     );
     push @bridges, $bridge;
 }

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Reprocess.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Reprocess.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use Test::More tests => 5;
+
+use above 'Genome';
+
+use Genome::Test::Factory::InstrumentData::Solexa;
+
+my $command_class = 'Genome::Config::AnalysisProject::Command::Reprocess';
+use_ok($command_class);
+
+my $analysis_project = Genome::Config::AnalysisProject->create(
+    name => 'Test Project for Reprocess Command',
+);
+
+my @instrument_data;
+my @bridges;
+for my $i (0..3) {
+    my $instrument_data = Genome::Test::Factory::InstrumentData::Solexa->setup_object(lane => $i);
+    push @instrument_data, $instrument_data;
+
+    my $bridge_class = 'Genome::Config::AnalysisProject::InstrumentDataBridge';
+    my $bridge = $bridge_class->create(
+        analysis_project => $analysis_project,
+        instrument_data => $instrument_data,
+        status => $bridge_class->__meta__->property(property_name => 'status')->valid_values->[$i],
+    );
+    push @bridges, $bridge;
+}
+
+my %statuses = map(($_->status => 1), @bridges);
+cmp_ok(scalar(keys %statuses), '>', 1, 'bridges do not all have the same initial status');
+
+my $cmd = $command_class->create(analysis_project => $analysis_project);
+isa_ok($cmd, $command_class, 'created command');
+
+ok($cmd->execute, 'executed command');
+
+subtest 'all bridges are rescheduled' => sub {
+    for my $bridge (@bridges) {
+        is($bridge->status, 'new', 'bridge is rescheduled');
+    }
+};

--- a/lib/perl/Genome/Config/AnalysisProject/InstrumentDataBridge.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/InstrumentDataBridge.pm
@@ -35,4 +35,10 @@ class Genome::Config::AnalysisProject::InstrumentDataBridge {
     id_generator => '-uuid',
 };
 
+sub reschedule {
+    my $self = shift;
+
+    $self->status('new');
+}
+
 1;


### PR DESCRIPTION
If a user forgets to use the `--reprocess-existing` option on one of the other commands (or they'd prefer to wait before reprocessing), this command can be used to the same effect.