### PR TITLE
fix for when GetTerminalSize is not supported

### DIFF
--- a/lib/perl/Genome/Command/Viewer.pm
+++ b/lib/perl/Genome/Command/Viewer.pm
@@ -18,11 +18,9 @@ sub write_report {
 }
 
 sub get_terminal_width {
-    my $screen_width = 80;
-
-    # this can fail in cases where no terminal is queriable
-    eval {($screen_width) = GetTerminalSize();};
-
+    # GetTerminalSize() returns an empty array if unsupported, e.g. in apipe-ci logs.
+    my ($screen_width) = GetTerminalSize();
+    $screen_width ||= 80;
     return $screen_width;
 }
 

--- a/lib/perl/Genome/Command/WorkflowMixin.pm
+++ b/lib/perl/Genome/Command/WorkflowMixin.pm
@@ -522,6 +522,8 @@ sub _print_error_log_preview {
     # terminate any unfinished color regions in preview
     $preview .= $self->_color(' ', 'white');
 
+    # get_terminal_width() appears to be a case of object schizophrenia, it
+    # comes from Genome::Command::Viewer.
     my $screen_width = $self->get_terminal_width();
     if (length($preview) > $screen_width - 20) {
         $preview = substr($preview, 0, $screen_width - 20) . "...";


### PR DESCRIPTION
This fixes an issue I noticed when build tests time out or fail.  We get
these warnings:

```
00:34:47 Unable to get Terminal Size. The TIOCGWINSZ ioctl didn't work. The COLUMNS and LINES environment variables didn't work. The resize program didn't work. at /usr/lib/perl5/Term/ReadKey.pm line 362.
00:34:47 Use of uninitialized value $screen_width in subtraction (-) at /gscmnt/gc7008/info/jenkins/workspace/Genome-Long-Model-Tests/lib/perl/Genome/Command/WorkflowMixin.pm line 526.
00:34:47 Use of uninitialized value $screen_width in subtraction (-) at /gscmnt/gc7008/info/jenkins/workspace/Genome-Long-Model-Tests/lib/perl/Genome/Command/WorkflowMixin.pm line 527.
```