### PR TITLE
Pass users to the "dependencies".

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -108,10 +108,9 @@ sub _supports_multiple_reference {
 
 sub get_or_create {
     my $class = shift;
-
-    my @objects = $class->SUPER::get_or_create(@_);
-
     my %params = @_;
+
+    my @objects = $class->SUPER::get_or_create(%params);
 
     for my $obj (@objects) {
         next unless ref($obj); # sometimes UR gives us back the package name when deleting?

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -111,9 +111,11 @@ sub get_or_create {
 
     my @objects = $class->SUPER::get_or_create(@_);
 
+    my %params = @_;
+
     for my $obj (@objects) {
         next unless ref($obj); # sometimes UR gives us back the package name when deleting?
-        unless ($obj->generate_dependencies_as_needed()) {
+        unless ($obj->generate_dependencies_as_needed($params{users})) {
             $obj->error_message("Failed to get AlignmentIndex objects for dependencies of " . $obj->__display_name__);
             return;
         }
@@ -155,7 +157,7 @@ sub create {
         return;
     }
 
-    unless ($self->generate_dependencies_as_needed()) {
+    unless ($self->generate_dependencies_as_needed($self->_user_data_for_nested_results)) {
         $self->error_message("Failed to create AlignmentIndex objects for dependencies");
         return;
     }
@@ -170,6 +172,7 @@ sub create {
 # -ssmith
 sub generate_dependencies_as_needed {
     my $self = shift;
+    my $users = shift;
 
     # if the reference is a compound reference
     if ($self->reference_build->append_to) {
@@ -177,7 +180,7 @@ sub generate_dependencies_as_needed {
             aligner_name => $self->aligner_name,
             aligner_params => $self->aligner_params,
             aligner_version => $self->aligner_version,
-            users => $self->_user_data_for_nested_results,
+            users => $users,
         );
 
         for my $b ($self->reference_build->append_to) { # (append_to is_many)


### PR DESCRIPTION
AlignerIndices do a strange thing where they do work even in the `get()` case (where the usual `WithNestedResults` hash is not provided (since it's not "nested"!)).  We thus need to pass along the users explicitly in this case.

(Alternatively `WithNestedResults` could fill in the hash in all cases, but external callers should still not rely on its presence.)