### PR TITLE
Restrict AnalysisMenu Item Create

### DIFF
--- a/lib/perl/Genome/Config/AnalysisMenu/Command/Item/Create.pm
+++ b/lib/perl/Genome/Config/AnalysisMenu/Command/Item/Create.pm
@@ -35,8 +35,7 @@ sub execute {
     unless($self->_validate_file($file_path)){
         die $self->error_message("$file_path is invalid");
     }
-    my $allocated_file_path = $self->_copy_file_to_allocation($file_path);
-    my $item = Genome::Config::AnalysisMenu::Item->create(name => $name, file_path => $allocated_file_path, description => $self->description);
+    my $item = Genome::Config::AnalysisMenu::Item->create(name => $name, file_path => $file_path, description => $self->description);
     $self->status_message("Successfully created AnalysisMenu Item $name for $file_path");
     return 1;
 }
@@ -44,25 +43,13 @@ sub execute {
 sub _validate_file {
     my $self = shift;
     my $file_path = shift;
+    my ($filename, $dir) = File::Basename::fileparse($file_path);
+    $dir =~ s!/$!!;
+    unless ($dir eq $ENV{'GENOME_ANALYSIS_PROJECT_DEFAULTS'}){
+        return 0;
+    }
 #TODO: once an actual validator for these files is written, swap this out for a call to that tool
     return -s $file_path;
-}
-
-sub _copy_file_to_allocation {
-    my $self = shift;
-    my $original_file = shift;
-    my $destination = File::Spec->join($ENV{GENOME_ANALYSIS_PROJECT_DEFAULTS}, $self->_determine_file_name($original_file));
-    unless( Genome::Sys->copy_file($original_file, $destination) ){
-        die $self->error_message("Failed to copy $original_file to $destination : $@");
-    }
-    return $destination;
-}
-
-sub _determine_file_name {
-    my $self = shift;
-    my $file = shift;
-    my ($file_name, undef, undef) = File::Basename::fileparse($file);
-    return join('_', time, $file_name);
 }
 
 1;

--- a/lib/perl/Genome/Config/AnalysisMenu/Command/Item/Create.t
+++ b/lib/perl/Genome/Config/AnalysisMenu/Command/Item/Create.t
@@ -8,9 +8,27 @@ BEGIN {
 }
 
 use above 'Genome';
-use Test::More tests => 1;
+use Test::More tests => 6;
+use Test::Exception;
 
 my $class = 'Genome::Config::AnalysisMenu::Command::Item::Create';
 use_ok($class);
+
+my $name = "TestMenuItemWithCheese";
+my $description = "MEAT AND CHEESE FOR THE MEAT AND CHEESE GODS!";
+my $tmp_dir = Genome::Sys->create_temp_directory;
+my $file_path = File::Spec->join($tmp_dir, 'test_menu_item.yml');
+Genome::Sys->write_file($file_path, "2 all beef patties");
+
+local $ENV{'GENOME_ANALYSIS_PROJECT_DEFAULTS'} = '/dev/null';
+my $cmd = $class->create(description => $description, file_path => $file_path, name => $name);
+ok($cmd, "Successfully created the command");
+dies_ok(sub{$cmd->execute}, 'Command fails when file is not in menu directory');
+
+local $ENV{'GENOME_ANALYSIS_PROJECT_DEFAULTS'} = $tmp_dir;
+my $cmd2 = $class->create(description => $description, file_path => $file_path, name => $name);
+ok($cmd2, "Successfully created the command");
+ok($cmd2->execute, 'Successfully executed the command');
+ok(Genome::Config::AnalysisMenu::Item->get(file_path => $file_path), 'Successfully found the Menu Item');
 
 1;


### PR DESCRIPTION
AnalysisMenu::Item->create now requires a pull request for the menu item repo to be merged and the 'Update Analysis Menu Items' jenkins job to have run before this command can be used to create a menu item.  If the file being used for menu item creation has not be added this way, this command will fail.