### PR TITLE
Created methylation_ratio

### DIFF
--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
@@ -29,7 +29,7 @@ class Genome::Model::Tools::Bsmap::MethylationRatio {
         },
         threads => {
             is => 'Text',
-            doc => 'Numer of threads (2 minimum: one for reading and one for writing; additional threads beyond 2 will be allocated for reading; recommended number is 5)',
+            doc => 'Number of threads (2 minimum: one for reading and one for writing; additional threads beyond 2 will be allocated for reading; recommended number is 5)',
             is_output => 0,
             is_input => 1,
             default_value => '2',

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
@@ -9,75 +9,91 @@ use Genome::Utility::Text qw(sanitize_string_for_filesystem);
 use File::Spec;
 use File::Basename qw();
 
-my (undef, $dir) = File::Basename::fileparse(__FILE__);
-my $METHRATIO_COMMAND = File::Spec->join($dir, 'methylation_ratio.py');
-
+my ( undef, $dir ) = File::Basename::fileparse(__FILE__);
+my $METHRATIO_COMMAND = File::Spec->join( $dir, 'methylation_ratio.py' );
 
 class Genome::Model::Tools::Bsmap::MethylationRatio {
-    is => 'Command',
-    has => [
-        bam_file => {
-            is => 'Text',
-            doc => 'An indexed bam file',
-            is_input => 1,
-        },
-        output_file => {
-            is => 'Text',
-            doc => 'File name for methyl counts (a .bgz extension will be added automatically)',
-            is_output => 1,
-            is_input => 1,
-            default_value => 'methylation',
-        },
-        threads => {
-            is => 'Text',
-            doc => 'Number of threads (2 minimum: one for reading and one for writing; additional threads beyond 2 will be allocated for reading; recommended number is 5)',
-            is_output => 0,
-            is_input => 1,
-            default_value => '2',
-        },
-        output_directory => {
-            is => 'Text',
-            doc => 'Where to output the methyl counts',
-            is_output => 1,
-            is_input => 1,
-        },
+	is  => 'Command',
+	has => [
+		bam_file => {
+			is       => 'Text',
+			doc      => 'An indexed bam file',
+			is_input => 1,
+		},
+		output_file => {
+			is => 'Text',
+			doc =>
+'File name for methyl counts (a .bgz extension will be added automatically)',
+			is_output     => 1,
+			is_input      => 1,
+			default_value => 'methylation',
+		},
+		threads => {
+			is => 'Text',
+			doc =>
+'Number of threads (2 minimum: one for reading and one for writing; additional threads beyond 2 will be allocated for reading; recommended number is 5)',
+			is_output     => 0,
+			is_input      => 1,
+			default_value => '2',
+		},
+		output_directory => {
+			is        => 'Text',
+			doc       => 'Where to output the methyl counts',
+			is_output => 1,
+			is_input  => 1,
+		},
 		reference => {
-		  is => 'Genome::Model::Build::ReferenceSequence',
-		  is_input => 1,
-		  doc => 'Specify reference build',
-		};
-    ],
+			is       => 'Text',
+			is_input => 1,
+			doc =>
+'Provide a path to the genome fasta file. Alternatively, specify 36 or 37 for human build 36 and 37, respecitively',
+		},
+	],
 };
 
 sub _reference_fasta {
-  my ($self) = @_;
-  return $self->reference->cached_full_consensus_path('fa');
+
+	my ($self) = @_;
+
+	my %mapping = (
+		36 => 'NCBI-human-build36',
+		37 => 'GRCh37-lite-build37',
+	);
+
+	my $reference = $self->reference;
+
+	if ( exists $mapping{$reference} ) {
+		my $reference_build =
+		  Genome::Model::Build::ReferenceSequence->get(
+			name => $mapping{$reference} );
+		$reference = $reference_build->cached_full_consensus_path('fa');
+	}
+
+	return $reference;
 }
 
 sub _generate_command_line {
-    my ($self) = @_;
+	my ($self) = @_;
 
-    my @cmd = (
-        'python', $METHRATIO_COMMAND,
-        '-o', File::Spec->join($self->output_directory, $self->output_file),
-        '-d', $self->_reference_fasta,
-        '-t', $self->threads
-    );
-    
+	my @cmd = (
+		'python', $METHRATIO_COMMAND, '-o',
+		File::Spec->join( $self->output_directory, $self->output_file ),
+		'-d', $self->_reference_fasta, '-t', $self->threads
+	);
 
-    push @cmd, $self->bam_file;
+	push @cmd, $self->bam_file;
 
-    return join ' ', @cmd;
+	return join ' ', @cmd;
 }
 
 sub execute {
-    my ($self) = @_;
-    Genome::Sys->shellcmd(
-        cmd => $self->_generate_command_line,
-        input_files => [$self->bam_file, $self->_reference_fasta],
-    );
+	my ($self) = @_;
+	Genome::Sys->shellcmd(
+		cmd         => $self->_generate_command_line,
+		input_files => [ $self->bam_file, $self->_reference_fasta ],
+	);
 
-    return 1;
+	return 1;
 }
 
 1;

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
@@ -7,8 +7,10 @@ use Genome;
 
 use Genome::Utility::Text qw(sanitize_string_for_filesystem);
 use File::Spec;
+use File::Basename qw();
 
-my $METHRATIO_COMMAND = File::Spec->join(getcwd, 'methylation_ratio.py');
+my (undef, $dir) = File::Basename::fileparse(__FILE__);
+my $METHRATIO_COMMAND = File::Spec->join($dir, 'methylation_ratio.py');
 
 class Genome::Model::Tools::Bsmap::MethylationRatio {
     is => 'Command',

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
@@ -12,11 +12,6 @@ use File::Basename qw();
 my (undef, $dir) = File::Basename::fileparse(__FILE__);
 my $METHRATIO_COMMAND = File::Spec->join($dir, 'methylation_ratio.py');
 
-reference => {
-  is => 'Genome::Model::Build::ReferenceSequence',
-  is_input => 1,
-  doc => ...,
-};
 
 class Genome::Model::Tools::Bsmap::MethylationRatio {
     is => 'Command',
@@ -46,34 +41,13 @@ class Genome::Model::Tools::Bsmap::MethylationRatio {
             is_output => 1,
             is_input => 1,
         },
-        reference => {
-            is => 'Text',
-            doc => '36, 37, or a path to the reference fasta',
-            is_input => 1,
-        },
+		reference => {
+		  is => 'Genome::Model::Build::ReferenceSequence',
+		  is_input => 1,
+		  doc => 'Specify reference build',
+		};
     ],
 };
-
-#sub _reference_fasta {
-#    
-#    my ($self) = @_;
-#
-#    my %mapping = (
-#        36 => 'NCBI-human-build36',
-#        37 => 'GRCh37-lite-build37',
-#    );
-#
-#    my $reference = $self->reference;
-#
-#    if (exists $mapping{$reference}) {
-#        my $reference_build = Genome::Model::Build::ReferenceSequence->get(
-#            name => $mapping{$reference}
-#        );
-#        $reference = $reference_build->cached_full_consensus_path('fa');
-#    }
-#
-#    return $reference;
-#}
 
 sub _reference_fasta {
   my ($self) = @_;

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
@@ -12,6 +12,12 @@ use File::Basename qw();
 my (undef, $dir) = File::Basename::fileparse(__FILE__);
 my $METHRATIO_COMMAND = File::Spec->join($dir, 'methylation_ratio.py');
 
+reference => {
+  is => 'Genome::Model::Build::ReferenceSequence',
+  is_input => 1,
+  doc => ...,
+}
+
 class Genome::Model::Tools::Bsmap::MethylationRatio {
     is => 'Command',
     has => [
@@ -48,25 +54,30 @@ class Genome::Model::Tools::Bsmap::MethylationRatio {
     ],
 };
 
+#sub _reference_fasta {
+#    
+#    my ($self) = @_;
+#
+#    my %mapping = (
+#        36 => 'NCBI-human-build36',
+#        37 => 'GRCh37-lite-build37',
+#    );
+#
+#    my $reference = $self->reference;
+#
+#    if (exists $mapping{$reference}) {
+#        my $reference_build = Genome::Model::Build::ReferenceSequence->get(
+#            name => $mapping{$reference}
+#        );
+#        $reference = $reference_build->cached_full_consensus_path('fa');
+#    }
+#
+#    return $reference;
+#}
+
 sub _reference_fasta {
-    
-    my ($self) = @_;
-
-    my %mapping = (
-        36 => 'NCBI-human-build36',
-        37 => 'GRCh37-lite-build37',
-    );
-
-    my $reference = $self->reference;
-
-    if (exists $mapping{$reference}) {
-        my $reference_build = Genome::Model::Build::ReferenceSequence->get(
-            name => $mapping{$reference}
-        );
-        $reference = $reference_build->cached_full_consensus_path('fa');
-    }
-
-    return $reference;
+  my ($self) = @_;
+  return $self->reference->cached_full_consensus_path('fa');
 }
 
 sub _generate_command_line {

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
@@ -1,0 +1,99 @@
+package Genome::Model::Tools::Bsmap::MethylationRatio;
+
+use strict;
+use warnings;
+use Cwd;
+use Genome;
+
+use Genome::Utility::Text qw(sanitize_string_for_filesystem);
+use File::Spec;
+
+my $METHRATIO_COMMAND = File::Spec->join(getcwd, 'methylation_ratio.py');
+
+class Genome::Model::Tools::Bsmap::MethylationRatio {
+    is => 'Command',
+    has => [
+        bam_file => {
+            is => 'Text',
+            doc => 'An indexed bam file',
+            is_input => 1,
+        },
+        output_file => {
+            is => 'Text',
+            doc => 'File name for methyl counts (a .bgz extension will be added automatically)',
+            is_output => 1,
+            is_input => 1,
+            default_value => 'methylation',
+        },
+        threads => {
+            is => 'Text',
+            doc => 'Numer of threads (2 minimum: one for reading and one for writing; additional threads beyond 2 will be allocated for reading; recommended number is 5)',
+            is_output => 0,
+            is_input => 1,
+            default_value => '2',
+        },
+        output_directory => {
+            is => 'Text',
+            doc => 'Where to output the methyl counts',
+            is_output => 1,
+            is_input => 1,
+        },
+        reference => {
+            is => 'Text',
+            doc => '36, 37, or a path to the reference fasta',
+            is_input => 1,
+        },
+    ],
+};
+
+sub _reference_fasta {
+    
+    my ($self) = @_;
+
+    my %mapping = (
+        36 => 'NCBI-human-build36',
+        37 => 'GRCh37-lite-build37',
+    );
+
+    my $reference = $self->reference;
+
+    if (exists $mapping{$reference}) {
+        my $reference_build = Genome::Model::Build::ReferenceSequence->get(
+            name => $mapping{$reference}
+        );
+        $reference = $reference_build->cached_full_consensus_path('fa');
+    }
+
+    return $reference;
+}
+
+sub _generate_command_line {
+    my ($self) = @_;
+
+    my @cmd = (
+        'python', $METHRATIO_COMMAND,
+        '-o', File::Spec->join($self->output_directory, $self->output_file),
+        '-d', $self->_reference_fasta,
+        '-t', $self->threads
+    );
+    
+
+    push @cmd, $self->bam_file;
+
+    return join ' ', @cmd;
+}
+
+sub execute {
+    my ($self) = @_;
+    my $return = Genome::Sys->shellcmd(
+        cmd => $self->_generate_command_line,
+        input_files => [$self->bam_file, $self->_reference_fasta],
+    );
+
+    unless ($return) {
+        die $self->error_message('Failed to execute: returned %s', $return);
+    }
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.pm
@@ -16,7 +16,7 @@ reference => {
   is => 'Genome::Model::Build::ReferenceSequence',
   is_input => 1,
   doc => ...,
-}
+};
 
 class Genome::Model::Tools::Bsmap::MethylationRatio {
     is => 'Command',
@@ -98,14 +98,11 @@ sub _generate_command_line {
 
 sub execute {
     my ($self) = @_;
-    my $return = Genome::Sys->shellcmd(
+    Genome::Sys->shellcmd(
         cmd => $self->_generate_command_line,
         input_files => [$self->bam_file, $self->_reference_fasta],
     );
 
-    unless ($return) {
-        die $self->error_message('Failed to execute: returned %s', $return);
-    }
     return 1;
 }
 

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.t
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.t
@@ -7,13 +7,13 @@ use above 'Genome';
 use File::Slurp;
 use File::Compare;
 use List::AllUtils qw(max);
+use Genome::Utility::Test;
 use Test::More tests => 3;
 
 my $class = 'Genome::Model::Tools::Bsmap::MethylationRatio';
 use_ok($class);
 
-my $test_root = File::Spec->join($ENV{GENOME_TEST_INPUTS},
-    qw(Genome-Model-Tools-Bsmap-MethylationRatio v1));
+my $test_root = Genome::Utility::Test->data_dir($class, 'v1');
 
 sub fasta_for_reference {
     my ($name, $version) = @_;

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.t
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.t
@@ -1,0 +1,88 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+use above 'Genome';
+use File::Slurp;
+use File::Compare;
+use List::AllUtils qw(max);
+use Test::More tests => 3;
+
+my $class = 'Genome::Model::Tools::Bsmap::MethylationRatio';
+use_ok($class);
+
+my $test_root = File::Spec->join($ENV{GENOME_TEST_INPUTS},
+    qw(Genome-Model-Tools-Bsmap-MethylationRatio v1));
+
+sub fasta_for_reference {
+    my ($name, $version) = @_;
+    return Genome::Model::ImportedReferenceSequence->get(
+        name => $name
+    )->build_by_version($version)->fasta_file();
+}
+
+sub create_test_object {
+    my $temp_output_dir = Genome::Sys->create_temp_directory();
+    
+    my $bam_file = File::Spec->join($test_root, 'input', 'all_sequences.bam');
+    my $reference = fasta_for_reference('TEST-human', '1');
+
+    return $class->create(
+        bam_file => $bam_file,
+        output_directory => $temp_output_dir,
+        reference => $reference
+    );
+}
+
+subtest 'Dereference reference sequence' => sub {
+    plan tests => 2;
+
+    my $test_obj = create_test_object();
+
+    my %mapping = (
+        36 => 'NCBI-human-build36',
+        37 => 'GRCh37-lite-build37'
+    );
+
+    for my $ref_short_name (keys %mapping) {
+        $test_obj->reference($ref_short_name);
+
+        my $fasta = Genome::Model::Build::ReferenceSequence->get(
+            name => $mapping{$ref_short_name}
+        )->cached_full_consensus_path('fa');
+	
+        is($test_obj->_reference_fasta, $fasta, 'Got correct fasta object');
+    }
+};
+
+subtest 'Execute' => sub {
+    plan tests => 6;
+
+    my $test_obj = create_test_object();
+
+    is($test_obj->output_file, 'methylation', 'has correct default output_file');
+
+
+    my $expected_path = File::Spec->join(
+        $test_root, 'expected', 'methylation.bgz');
+     my $expected_path_index = File::Spec->join(
+        $test_root, 'expected', 'methylation.bgz.tbi');
+    
+    my $actual_path = File::Spec->join(
+        $test_obj->output_directory, 'methylation.bgz');
+    my $actual_path_index = File::Spec->join(
+        $test_obj->output_directory, 'methylation.bgz.tbi');
+        
+
+    ok($test_obj->execute(), 'Command executes');
+
+    ok(-s $actual_path, "Output $actual_path exists");
+    
+    ok(-s $actual_path, "Output $actual_path_index exists");
+    is(compare($expected_path, $actual_path), 0,
+        'Expected and derived files are equal');
+    
+    is(compare($expected_path_index, $actual_path_index), 0,
+        'Expected and derived files indices are equal');
+};

--- a/lib/perl/Genome/Model/Tools/Bsmap/methylation_ratio.py
+++ b/lib/perl/Genome/Model/Tools/Bsmap/methylation_ratio.py
@@ -140,8 +140,10 @@ if __name__ == '__main__':
     if len(options.reffile) == 0: parser.error("Missing reference file, use -d or --ref option.")
     if len(options.outfile) == 0: parser.error("Missing output file name, use -o or --out option.")
     if len(infile) == 0: parser.error("Require at least one BSMAP_MAPPING_FILE.")
+    if len(infile) > 1: parser.error("Could not parse all arguments. Likely that your outfile parameter name contained a space.")
     
-    
+    if " " in options.outfile:
+        parser.error("outfile parameter cannot contain spaces.")    
     step = 100000
     genome = pysam.FastaFile(options.reffile)
     work_queue = Queue()

--- a/lib/perl/Genome/Model/Tools/Bsmap/methylation_ratio.py
+++ b/lib/perl/Genome/Model/Tools/Bsmap/methylation_ratio.py
@@ -55,9 +55,9 @@ def isOnWatsonStrand(tags):
 
 
 def process_region_pileup(i, bam_file_path, fasta_path, work_queue, out_queue):
-    bam_file = pysam.AlignmentFile(bam_file_path, 'rb')
+    bam_file = pysam.Samfile(bam_file_path, 'rb')
 
-    genome = pysam.FastaFile(fasta_path)
+    genome = pysam.Fastafile(fasta_path)
     nuc_A = 'A'
     nuc_T = 'T'
     nuc_C = 'C'
@@ -85,14 +85,15 @@ def process_region_pileup(i, bam_file_path, fasta_path, work_queue, out_queue):
                 for pileupread in pileupcolumn.pileups:          
                     read = pileupread.alignment
                     watson_strand = isOnWatsonStrand(read.tags)
-                    if read.query_sequence[pileupread.query_position] == ref_seq[ref_seq_offset]:
+                    # qpos became query_position in later releases of pysam
+                    if read.seq[pileupread.qpos] == ref_seq[ref_seq_offset]:
                         if ref_seq[ref_seq_offset] == nuc_C and watson_strand:
                             meth_cov += 1
                         elif ref_seq[ref_seq_offset] == nuc_G and watson_strand is False:
                             meth_cov += 1
-                    elif ref_seq[ref_seq_offset] == nuc_C and watson_strand and read.query_sequence[pileupread.query_position] == nuc_T:
+                    elif ref_seq[ref_seq_offset] == nuc_C and watson_strand and read.seq[pileupread.qpos] == nuc_T:
                         un_meth_cov += 1
-                    elif ref_seq[ref_seq_offset] == nuc_G and watson_strand is False and read.query_sequence[pileupread.query_position] == nuc_A:
+                    elif ref_seq[ref_seq_offset] == nuc_G and watson_strand is False and read.seq[pileupread.qpos] == nuc_A:
                         un_meth_cov += 1           
                 counter[position].set_methylation_coverage(meth_cov)
                 counter[position].set_un_methylation_coverage(un_meth_cov)
@@ -145,11 +146,11 @@ if __name__ == '__main__':
     if " " in options.outfile:
         parser.error("outfile parameter cannot contain spaces.")    
     step = 100000
-    genome = pysam.FastaFile(options.reffile)
+    genome = pysam.Fastafile(options.reffile)
     work_queue = Queue()
     work_units = 0
     for chromosome in genome.references:
-        chr_length = genome.get_reference_length(chromosome)
+        chr_length = genome.getReferenceLength(chromosome)
         start = 0
         end = min(start + step, chr_length)
         while True:

--- a/lib/perl/Genome/Model/Tools/Bsmap/methylation_ratio.py
+++ b/lib/perl/Genome/Model/Tools/Bsmap/methylation_ratio.py
@@ -1,0 +1,181 @@
+'''
+Created on Jan 26, 2015
+
+@author: ygindin
+'''
+import optparse
+import logging
+import time
+import tempfile
+import pysam
+import os
+import pdb
+from multiprocessing import Process, Queue
+
+def write_data(result_queue, out_file, work_units):
+    start = time.clock()
+    fout = open(out_file, 'w')
+    fout.write('chr\tpos\tratio\ttotal_C\tmethy_C\tunmeth_C\n')
+    tab = '\t'
+    new_line = '\n'
+    print 'writer opens shop. waiting for ', work_units, ' work units'
+    work_written = 0
+    logging.basicConfig(level=logging.DEBUG, format='(%(threadName)-10s) %(message)s')
+
+    while work_written < work_units:
+        counter = result_queue.get()
+        work_written += 1
+        for coordinate in counter.keys():
+            depth = float(counter[coordinate].getCoverage())
+            meth_depth = float(counter[coordinate].getMethylationCoverage())
+            un_methylated = float(counter[coordinate].get_un_methylation_coverage())
+            if meth_depth + un_methylated == 0:
+                # it's a mismatch, not a methylation eligible event
+                continue
+            ratio = meth_depth / (meth_depth + un_methylated)
+            chromosome = counter[coordinate].get_chromosome()
+            
+            fout.write(tab.join([chromosome, str(coordinate+1), str(ratio), str(depth), str(meth_depth), 
+                                 str(un_methylated) + new_line]))            
+        
+        logging.debug('wrote %s', ''.join(['work unit ', str(work_written), ' out of ', str(work_units)]))
+    print 'writer calling quits'
+    fout.close()
+    end = time.clock()
+    run_time = end - start
+    print 'Running time: ', run_time, ' seconds'
+
+def isOnWatsonStrand(tags):
+    """ Parses the ZS field to determine if the read is on the Crick strand """
+    for tag in reversed(tags):
+        if 'ZS' in tag:
+            if tag[1].startswith('+'):
+                return True
+            else:
+                return False
+    return None
+
+
+def process_region_pileup(i, bam_file_path, fasta_path, work_queue, out_queue):
+    bam_file = pysam.AlignmentFile(bam_file_path, 'rb')
+    logging.basicConfig(level=logging.DEBUG,
+                        format='(%(threadName)-10s) %(message)s')
+
+    genome = pysam.FastaFile(fasta_path)
+    nuc_A = 'A'
+    nuc_T = 'T'
+    nuc_C = 'C'
+    nuc_G = 'G'
+    cg = ['C', 'G']
+    while True:
+#     while work_queue.qsize() > 0:
+        chromosome, start, end = work_queue.get()      
+        counter = {}
+        ref_seq = None
+        # stepper=all does basic read filtering
+        for pileupcolumn in bam_file.pileup(chromosome, start, end, stepper="all"):
+            if ref_seq is None: 
+                ref_seq = genome.fetch(chromosome, start, end+3)
+            position = pileupcolumn.pos
+            if position < start or position >= end or pileupcolumn.n == 0:
+                continue
+            ref_seq_offset = position-start
+            if ref_seq[ref_seq_offset] in cg:
+                counter[position] = Counter()
+                counter[position].set_coverage(pileupcolumn.n)
+                counter[position].set_chromosome(chromosome)
+                meth_cov = 0
+                un_meth_cov = 0
+                for pileupread in pileupcolumn.pileups:          
+                    read = pileupread.alignment
+                    watson_strand = isOnWatsonStrand(read.tags)
+                    if read.query_sequence[pileupread.query_position] == ref_seq[ref_seq_offset]:
+                        if ref_seq[ref_seq_offset] == nuc_C and watson_strand:
+                            meth_cov += 1
+                        elif ref_seq[ref_seq_offset] == nuc_G and watson_strand is False:
+                            meth_cov += 1
+                    elif ref_seq[ref_seq_offset] == nuc_C and watson_strand and read.query_sequence[pileupread.query_position] == nuc_T:
+                        un_meth_cov += 1
+                    elif ref_seq[ref_seq_offset] == nuc_G and watson_strand is False and read.query_sequence[pileupread.query_position] == nuc_A:
+                        un_meth_cov += 1           
+                counter[position].set_methylation_coverage(meth_cov)
+                counter[position].set_un_methylation_coverage(un_meth_cov)
+        out_queue.put(counter)
+    print 'Quitting work'
+
+class Counter:
+    def __init__(self):
+        self.coverage = 0
+        self.methylation_coverage = 0
+        self.un_methylation_coverage = 0
+    def set_chromosome(self, chr):
+        self.chromosome = chr
+    def set_coverage(self, cov):
+        self.coverage = cov
+    def set_context(self, context):
+        self.context = context
+    def set_methylation_coverage(self, cov):
+        self.methylation_coverage = cov
+    def set_un_methylation_coverage(self, cov):
+        self.un_methylation_coverage = cov
+    def getCoverage(self):
+        return self.coverage
+    def getMethylationCoverage(self):
+        return self.methylation_coverage
+    def get_un_methylation_coverage(self):
+        return self.un_methylation_coverage
+    def get_chromosome(self):
+        return self.chromosome
+    def get_context(self):
+        return self.context
+
+if __name__ == '__main__':
+     
+    do_debug = False
+    usage = "usage: %prog [options] BSMAP_MAPPING_FILES (sorted BAM files)"
+    parser = optparse.OptionParser(usage=usage)
+    parser.add_option("-o", "--out", dest="outfile", metavar="FILE", help="output file name. (required)", default="")
+    parser.add_option("-d", "--ref", dest="reffile", metavar="FILE", help="reference genome fasta file. (required)", default="")
+    parser.add_option("-t", "--threads", dest="threads", metavar="THREADS", help="number of threads", default="1")
+    options, infile = parser.parse_args()
+    
+    if len(options.reffile) == 0: parser.error("Missing reference file, use -d or --ref option.")
+    if len(options.outfile) == 0: parser.error("Missing output file name, use -o or --out option.")
+    if len(infile) == 0: parser.error("Require at least one BSMAP_MAPPING_FILE.")
+    
+    
+    step = 100000
+    genome = pysam.FastaFile(options.reffile)
+    work_queue = Queue()
+    work_units = 0
+    for chromosome in genome.references:
+        chr_length = genome.get_reference_length(chromosome)
+        start = 0
+        end = min(start + step, chr_length)
+        while True:
+            work_queue.put([chromosome, start, end])
+            work_units += 1
+            if end == chr_length: break
+            start += step
+            end = min(start + step, chr_length)
+    
+    num_threads = int(options.threads)
+    write_queue = Queue(100)
+    for i in range(num_threads):
+        worker = Process(target=process_region_pileup, args=(i, infile[0], options.reffile, work_queue, write_queue,))
+        worker.daemon = True
+        worker.start()
+    
+    raw_file = tempfile.NamedTemporaryFile()
+    writer = Process(target=write_data, args=(write_queue, raw_file.name, work_units,))
+    writer.start()
+    writer.join()
+    print "Sorting and compressing reads..."
+    command = ''.join(['tail -n +2 ', raw_file.name, ' | sort -k1V -k2n | bgzip > ', options.outfile, '.bgz'])
+    print(command)
+    os.system(command)
+    
+    print "Indexing..."
+    command = ''.join(['tabix -f -s 1 -b 2 -e 2 ', options.outfile, '.bgz'])
+    print(command)
+    os.system(command)


### PR DESCRIPTION
This pull request adds a replacement for mehRatio.py -- a script that calculates DNA methylation levels from bisulfite-treated, BSMAP-aligned data. The new script, methylation_ratio.py, avoids the exuberant memory requirements associated with the old script. Also new is the ability to multi-thread the wok.