### PR TITLE
improvements to genome-env-tests

### DIFF
--- a/genome-env-tests/basic.bats
+++ b/genome-env-tests/basic.bats
@@ -22,26 +22,26 @@ function teardown {
 
 @test "basic test: genome-env-next -U" {
     export PERL5LIB="$WORKSPACE/ur/lib:$PERL5LIB"
-    $BATS_TEST_DIRNAME/../bin/genome-env-next -U "$BATS_TEST_DIRNAME/testexec/U.sh"
+    $BATS_TEST_DIRNAME/../bin/genome-env-next -D -U "$BATS_TEST_DIRNAME/testexec/U.sh"
 }
 
 @test "basic test: genome-env-next -u" {
-    $BATS_TEST_DIRNAME/../bin/genome-env-next -u $WORKSPACE/ur "$BATS_TEST_DIRNAME/testexec/U.sh"
+    $BATS_TEST_DIRNAME/../bin/genome-env-next -D -u $WORKSPACE/ur "$BATS_TEST_DIRNAME/testexec/U.sh"
 }
 
 @test "basic test: genome-env-next -W" {
     export PERL5LIB="$WORKSPACE/workflow/lib:$PERL5LIB"
-    $BATS_TEST_DIRNAME/../bin/genome-env-next -W "$BATS_TEST_DIRNAME/testexec/W.sh"
+    $BATS_TEST_DIRNAME/../bin/genome-env-next -D -W "$BATS_TEST_DIRNAME/testexec/W.sh"
 }
 
 @test "basic test: genome-env-next -w" {
-    $BATS_TEST_DIRNAME/../bin/genome-env-next -w $WORKSPACE/workflow "$BATS_TEST_DIRNAME/testexec/W.sh"
+    $BATS_TEST_DIRNAME/../bin/genome-env-next -D -w $WORKSPACE/workflow "$BATS_TEST_DIRNAME/testexec/W.sh"
 }
 
 @test "basic test: genome-env-next -M" {
-    $BATS_TEST_DIRNAME/../bin/genome-env-next -M "$BATS_TEST_DIRNAME/testexec/M.sh"
+    $BATS_TEST_DIRNAME/../bin/genome-env-next -D -M "$BATS_TEST_DIRNAME/testexec/M.sh"
 }
 
 @test "basic test: genome-env-next -m" {
-    $BATS_TEST_DIRNAME/../bin/genome-env-next -m $WORKSPACE/genome-sqitch "$BATS_TEST_DIRNAME/testexec/M.sh"
+    $BATS_TEST_DIRNAME/../bin/genome-env-next -m $WORKSPACE/genome-sqitch "$BATS_TEST_DIRNAME/testexec/migration.sh"
 }

--- a/genome-env-tests/basic.bats
+++ b/genome-env-tests/basic.bats
@@ -12,6 +12,10 @@ function teardown {
     rm_workspace
 }
 
+@test "basic test: genome-env-next" {
+    $BATS_TEST_DIRNAME/../bin/genome-env-next "$BATS_TEST_DIRNAME/testexec/default.sh"
+}
+
 @test "basic test: genome-env-next -D" {
     $BATS_TEST_DIRNAME/../bin/genome-env-next -D "$BATS_TEST_DIRNAME/testexec/D.sh"
 }

--- a/genome-env-tests/basic.bats
+++ b/genome-env-tests/basic.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load test_helper
+export BATS_TEST_DIRNAME
 
 function setup {
     init_workspace

--- a/genome-env-tests/test_helper.bash
+++ b/genome-env-tests/test_helper.bash
@@ -93,3 +93,12 @@ function apipe_test_db_is_not_used {
         exit 1
     fi
 }
+
+function module_loaded_from_submodule {
+    local SUBMODULE="${1,,}"
+    if test "$WORKSPACE/genome/$SUBMODULE/lib/$1.pm" != "$(perl -M$1 -e "print \$INC{q($1.pm)}, qq(\\n)")"
+    then
+        echo "$1 should be loaded from submodule" >&2
+        exit 1
+    fi
+}

--- a/genome-env-tests/test_helper.bash
+++ b/genome-env-tests/test_helper.bash
@@ -53,3 +53,11 @@ function rm_workspace {
         rm -rf "$WORKSPACE"
     fi
 }
+
+function submodule_is_clean {
+    if ! git diff --exit-code $1
+    then
+        echo "submodule should be clean: $1" >&2
+        exit 1
+    fi
+}

--- a/genome-env-tests/test_helper.bash
+++ b/genome-env-tests/test_helper.bash
@@ -61,3 +61,11 @@ function submodule_is_clean {
         exit 1
     fi
 }
+
+function submodule_is_initialized {
+    if git submodule status $1 | grep -q '^-'
+    then
+        echo "submodule should be initialized: $1" >&2
+        exit 1
+    fi
+}

--- a/genome-env-tests/test_helper.bash
+++ b/genome-env-tests/test_helper.bash
@@ -85,3 +85,11 @@ function apipe_test_db_is_used {
         exit 1
     fi
 }
+
+function apipe_test_db_is_not_used {
+    if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
+    then
+        echo "GENOME_DS_GMSCHEMA_SERVER should not refer to apipe-test-db" >&2
+        exit 1
+    fi
+}

--- a/genome-env-tests/test_helper.bash
+++ b/genome-env-tests/test_helper.bash
@@ -69,3 +69,11 @@ function submodule_is_initialized {
         exit 1
     fi
 }
+
+function submodule_is_not_initialized {
+    if git submodule status $1 | grep -qv '^-'
+    then
+        echo "submodule should be not initialized: $1" >&2
+        exit 1
+    fi
+}

--- a/genome-env-tests/test_helper.bash
+++ b/genome-env-tests/test_helper.bash
@@ -102,3 +102,12 @@ function module_loaded_from_submodule {
         exit 1
     fi
 }
+
+function module_not_loaded_from_submodule {
+    local SUBMODULE="${1,,}"
+    if test "$WORKSPACE/genome/$SUBMODULE/lib/$1.pm" == "$(perl -M$1 -e "print \$INC{q($1.pm)}, qq(\\n)")"
+    then
+        echo "$1 should not be loaded from submodule" >&2
+        exit 1
+    fi
+}

--- a/genome-env-tests/test_helper.bash
+++ b/genome-env-tests/test_helper.bash
@@ -77,3 +77,11 @@ function submodule_is_not_initialized {
         exit 1
     fi
 }
+
+function apipe_test_db_is_used {
+    if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -qv 'apipe-test-db'
+    then
+        echo "GENOME_DS_GMSCHEMA_SERVER should refer to apipe-test-db" >&2
+        exit 1
+    fi
+}

--- a/genome-env-tests/testexec/D.sh
+++ b/genome-env-tests/testexec/D.sh
@@ -12,11 +12,7 @@ for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
 
-if git submodule status sqitch/genome | grep -qv '^-'
-then
-    echo "submodule should not be initialized: sqitch/genome" >&2
-    exit 1
-fi
+submodule_is_not_initialized sqitch/genome
 
 if test "$WORKSPACE/genome/ur/lib/UR.pm" != "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"
 then

--- a/genome-env-tests/testexec/D.sh
+++ b/genome-env-tests/testexec/D.sh
@@ -28,8 +28,4 @@ then
     exit 1
 fi
 
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
-then
-    echo "GENOME_DS_GMSCHEMA_SERVER should not refer to apipe-test-db" >&2
-    exit 1
-fi
+apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/D.sh
+++ b/genome-env-tests/testexec/D.sh
@@ -11,21 +11,7 @@ fi
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
-
 submodule_is_not_initialized sqitch/genome
-
-if test "$WORKSPACE/genome/ur/lib/UR.pm" != "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"
-then
-    echo "$WORKSPACE/genome/ur/lib/UR.pm" >&2
-    perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)' >&2
-    echo "UR should be loaded from submodule" >&2
-    exit 1
-fi
-
-if test "$WORKSPACE/genome/workflow/lib/Workflow.pm" != "$(perl -MWorkflow -e 'print $INC{q(Workflow.pm)}, qq(\n)')"
-then
-    echo "Workflow should be loaded from submodule" >&2
-    exit 1
-fi
-
+module_loaded_from_submodule UR
+module_loaded_from_submodule Workflow
 apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/D.sh
+++ b/genome-env-tests/testexec/D.sh
@@ -9,11 +9,7 @@ then
 fi
 
 for M in sqitch/genome ur workflow ; do
-    if ! git diff --exit-code $M
-    then
-        echo "submodule should be clean: $M" >&2
-        exit 1
-    fi
+    submodule_is_clean $M
 done
 
 if git submodule status sqitch/genome | grep -qv '^-'

--- a/genome-env-tests/testexec/D.sh
+++ b/genome-env-tests/testexec/D.sh
@@ -8,6 +8,8 @@ then
     exit 1
 fi
 
+source "$BATS_TEST_DIRNAME/test_helper.bash"
+
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done

--- a/genome-env-tests/testexec/M.sh
+++ b/genome-env-tests/testexec/M.sh
@@ -11,7 +11,5 @@ fi
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
-
 submodule_is_not_initialized sqitch/genome
-
 apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/M.sh
+++ b/genome-env-tests/testexec/M.sh
@@ -12,11 +12,7 @@ for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
 
-if git submodule status sqitch/genome | grep -qv '^-'
-then
-    echo "submodule should not be initialized: sqitch/genome" >&2
-    exit 1
-fi
+submodule_is_not_initialized sqitch/genome
 
 if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
 then

--- a/genome-env-tests/testexec/M.sh
+++ b/genome-env-tests/testexec/M.sh
@@ -9,11 +9,7 @@ then
 fi
 
 for M in sqitch/genome ur workflow ; do
-    if ! git diff --exit-code $M
-    then
-        echo "submodule should be clean: $M" >&2
-        exit 1
-    fi
+    submodule_is_clean $M
 done
 
 if git submodule status sqitch/genome | grep -qv '^-'

--- a/genome-env-tests/testexec/M.sh
+++ b/genome-env-tests/testexec/M.sh
@@ -8,6 +8,8 @@ then
     exit 1
 fi
 
+source "$BATS_TEST_DIRNAME/test_helper.bash"
+
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done

--- a/genome-env-tests/testexec/M.sh
+++ b/genome-env-tests/testexec/M.sh
@@ -14,8 +14,4 @@ done
 
 submodule_is_not_initialized sqitch/genome
 
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
-then
-    echo "GENOME_DS_GMSCHEMA_SERVER should not refer to apipe-test-db" >&2
-    exit 1
-fi
+apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/U.sh
+++ b/genome-env-tests/testexec/U.sh
@@ -11,14 +11,7 @@ fi
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
-
 submodule_is_not_initialized ur
-
-if test "$WORKSPACE/genome/ur/lib/UR.pm" == "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"
-then
-    echo "UR should not be loaded from submodule" >&2
-    exit 1
-fi
-
+module_not_loaded_from_submodule UR
 module_loaded_from_submodule Workflow
 apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/U.sh
+++ b/genome-env-tests/testexec/U.sh
@@ -9,11 +9,7 @@ then
 fi
 
 for M in sqitch/genome ur workflow ; do
-    if ! git diff --exit-code $M
-    then
-        echo "submodule should be clean: $M" >&2
-        exit 1
-    fi
+    submodule_is_clean $M
 done
 
 if git submodule status ur | grep -qv '^-'

--- a/genome-env-tests/testexec/U.sh
+++ b/genome-env-tests/testexec/U.sh
@@ -26,8 +26,4 @@ then
     exit 1
 fi
 
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
-then
-    echo "GENOME_DS_GMSCHEMA_SERVER should not refer to apipe-test-db" >&2
-    exit 1
-fi
+apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/U.sh
+++ b/genome-env-tests/testexec/U.sh
@@ -12,11 +12,7 @@ for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
 
-if git submodule status ur | grep -qv '^-'
-then
-    echo "submodule should not be initialized: ur" >&2
-    exit 1
-fi
+submodule_is_not_initialized ur
 
 if test "$WORKSPACE/genome/ur/lib/UR.pm" == "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"
 then

--- a/genome-env-tests/testexec/U.sh
+++ b/genome-env-tests/testexec/U.sh
@@ -20,10 +20,5 @@ then
     exit 1
 fi
 
-if test "$WORKSPACE/genome/workflow/lib/Workflow.pm" != "$(perl -MWorkflow -e 'print $INC{q(Workflow.pm)}, qq(\n)')"
-then
-    echo "Workflow should be loaded from submodule" >&2
-    exit 1
-fi
-
+module_loaded_from_submodule Workflow
 apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/U.sh
+++ b/genome-env-tests/testexec/U.sh
@@ -34,8 +34,8 @@ then
     exit 1
 fi
 
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -qv 'apipe-test-db'
+if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
 then
-    echo "GENOME_DS_GMSCHEMA_SERVER should refer to apipe-test-db" >&2
+    echo "GENOME_DS_GMSCHEMA_SERVER should not refer to apipe-test-db" >&2
     exit 1
 fi

--- a/genome-env-tests/testexec/U.sh
+++ b/genome-env-tests/testexec/U.sh
@@ -8,6 +8,8 @@ then
     exit 1
 fi
 
+source "$BATS_TEST_DIRNAME/test_helper.bash"
+
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done

--- a/genome-env-tests/testexec/W.sh
+++ b/genome-env-tests/testexec/W.sh
@@ -26,8 +26,4 @@ then
     exit 1
 fi
 
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
-then
-    echo "GENOME_DS_GMSCHEMA_SERVER should not refer to apipe-test-db" >&2
-    exit 1
-fi
+apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/W.sh
+++ b/genome-env-tests/testexec/W.sh
@@ -9,11 +9,7 @@ then
 fi
 
 for M in sqitch/genome ur workflow ; do
-    if ! git diff --exit-code $M
-    then
-        echo "submodule should be clean: $M" >&2
-        exit 1
-    fi
+    submodule_is_clean $M
 done
 
 if git submodule status workflow | grep -qv '^-'

--- a/genome-env-tests/testexec/W.sh
+++ b/genome-env-tests/testexec/W.sh
@@ -35,8 +35,8 @@ then
     exit 1
 fi
 
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -qv 'apipe-test-db'
+if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
 then
-    echo "GENOME_DS_GMSCHEMA_SERVER should refer to apipe-test-db" >&2
+    echo "GENOME_DS_GMSCHEMA_SERVER should not refer to apipe-test-db" >&2
     exit 1
 fi

--- a/genome-env-tests/testexec/W.sh
+++ b/genome-env-tests/testexec/W.sh
@@ -14,11 +14,7 @@ done
 
 submodule_is_not_initialized workflow
 
-if test "$WORKSPACE/genome/ur/lib/UR.pm" != "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"
-then
-    echo "UR should be loaded from submodule" >&2
-    exit 1
-fi
+module_loaded_from_submodule UR
 
 if test "$WORKSPACE/genome/workflow/lib/Workflow.pm" == "$(perl -MWorkflow -e 'print $INC{q(Workflow.pm)}, qq(\n)')"
 then

--- a/genome-env-tests/testexec/W.sh
+++ b/genome-env-tests/testexec/W.sh
@@ -11,15 +11,7 @@ fi
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
-
 submodule_is_not_initialized workflow
-
 module_loaded_from_submodule UR
-
-if test "$WORKSPACE/genome/workflow/lib/Workflow.pm" == "$(perl -MWorkflow -e 'print $INC{q(Workflow.pm)}, qq(\n)')"
-then
-    echo "Workflow should not be loaded from submodule" >&2
-    exit 1
-fi
-
+module_not_loaded_from_submodule Workflow
 apipe_test_db_is_not_used

--- a/genome-env-tests/testexec/W.sh
+++ b/genome-env-tests/testexec/W.sh
@@ -8,6 +8,8 @@ then
     exit 1
 fi
 
+source "$BATS_TEST_DIRNAME/test_helper.bash"
+
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done

--- a/genome-env-tests/testexec/W.sh
+++ b/genome-env-tests/testexec/W.sh
@@ -12,12 +12,7 @@ for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
 
-if git submodule status workflow | grep -qv '^-'
-then
-    git submodule status workflow
-    echo "submodule should not be initialized: workflow" >&2
-    exit 1
-fi
+submodule_is_not_initialized workflow
 
 if test "$WORKSPACE/genome/ur/lib/UR.pm" != "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"
 then

--- a/genome-env-tests/testexec/default.sh
+++ b/genome-env-tests/testexec/default.sh
@@ -12,19 +12,6 @@ for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
     submodule_is_initialized $M
 done
-
-if test "$WORKSPACE/genome/ur/lib/UR.pm" != "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"
-then
-    echo "$WORKSPACE/genome/ur/lib/UR.pm" >&2
-    perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)' >&2
-    echo "UR should be loaded from submodule" >&2
-    exit 1
-fi
-
-if test "$WORKSPACE/genome/workflow/lib/Workflow.pm" != "$(perl -MWorkflow -e 'print $INC{q(Workflow.pm)}, qq(\n)')"
-then
-    echo "Workflow should be loaded from submodule" >&2
-    exit 1
-fi
-
+module_loaded_from_submodule UR
+module_loaded_from_submodule Workflow
 apipe_test_db_is_used

--- a/genome-env-tests/testexec/default.sh
+++ b/genome-env-tests/testexec/default.sh
@@ -10,12 +10,7 @@ fi
 
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
-
-    if git submodule status $M | grep -q '^-'
-    then
-        echo "submodule should be initialized: $M" >&2
-        exit 1
-    fi
+    submodule_is_initialized $M
 done
 
 if test "$WORKSPACE/genome/ur/lib/UR.pm" != "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"

--- a/genome-env-tests/testexec/default.sh
+++ b/genome-env-tests/testexec/default.sh
@@ -8,6 +8,8 @@ then
     exit 1
 fi
 
+source "$BATS_TEST_DIRNAME/test_helper.bash"
+
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
     submodule_is_initialized $M

--- a/genome-env-tests/testexec/default.sh
+++ b/genome-env-tests/testexec/default.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+type -p genome-env-next
+
+if test -z "$WORKSPACE"
+then
+    echo "WORKSPACE is not set" >&2
+    exit 1
+fi
+
+for M in sqitch/genome ur workflow ; do
+    if ! git diff --exit-code $M
+    then
+        echo "submodule should be clean: $M" >&2
+        exit 1
+    fi
+
+    if git submodule status $M | grep -q '^-'
+    then
+        echo "submodule should be initialized: $M" >&2
+        exit 1
+    fi
+done
+
+if test "$WORKSPACE/genome/ur/lib/UR.pm" != "$(perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)')"
+then
+    echo "$WORKSPACE/genome/ur/lib/UR.pm" >&2
+    perl -MUR -e 'print $INC{q(UR.pm)}, qq(\n)' >&2
+    echo "UR should be loaded from submodule" >&2
+    exit 1
+fi
+
+if test "$WORKSPACE/genome/workflow/lib/Workflow.pm" != "$(perl -MWorkflow -e 'print $INC{q(Workflow.pm)}, qq(\n)')"
+then
+    echo "Workflow should be loaded from submodule" >&2
+    exit 1
+fi
+
+if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -qv 'apipe-test-db'
+then
+    echo "GENOME_DS_GMSCHEMA_SERVER should refer to apipe-test-db" >&2
+    exit 1
+fi

--- a/genome-env-tests/testexec/default.sh
+++ b/genome-env-tests/testexec/default.sh
@@ -9,11 +9,7 @@ then
 fi
 
 for M in sqitch/genome ur workflow ; do
-    if ! git diff --exit-code $M
-    then
-        echo "submodule should be clean: $M" >&2
-        exit 1
-    fi
+    submodule_is_clean $M
 
     if git submodule status $M | grep -q '^-'
     then

--- a/genome-env-tests/testexec/default.sh
+++ b/genome-env-tests/testexec/default.sh
@@ -27,8 +27,4 @@ then
     exit 1
 fi
 
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -qv 'apipe-test-db'
-then
-    echo "GENOME_DS_GMSCHEMA_SERVER should refer to apipe-test-db" >&2
-    exit 1
-fi
+apipe_test_db_is_used

--- a/genome-env-tests/testexec/migration.sh
+++ b/genome-env-tests/testexec/migration.sh
@@ -9,11 +9,7 @@ then
 fi
 
 for M in sqitch/genome ur workflow ; do
-    if ! git diff --exit-code $M
-    then
-        echo "submodule should be clean: $M" >&2
-        exit 1
-    fi
+    submodule_is_clean $M
 done
 
 if git submodule status sqitch/genome | grep -qv '^-'

--- a/genome-env-tests/testexec/migration.sh
+++ b/genome-env-tests/testexec/migration.sh
@@ -11,11 +11,5 @@ fi
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
-
 submodule_is_not_initialized sqitch/genome
-
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -qv 'apipe-test-db'
-then
-    echo "GENOME_DS_GMSCHEMA_SERVER should refer to apipe-test-db" >&2
-    exit 1
-fi
+apipe_test_db_is_used

--- a/genome-env-tests/testexec/migration.sh
+++ b/genome-env-tests/testexec/migration.sh
@@ -12,11 +12,7 @@ for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done
 
-if git submodule status sqitch/genome | grep -qv '^-'
-then
-    echo "submodule should not be initialized: sqitch/genome" >&2
-    exit 1
-fi
+submodule_is_not_initialized sqitch/genome
 
 if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -qv 'apipe-test-db'
 then

--- a/genome-env-tests/testexec/migration.sh
+++ b/genome-env-tests/testexec/migration.sh
@@ -22,8 +22,8 @@ then
     exit 1
 fi
 
-if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -q 'apipe-test-db'
+if echo "$GENOME_DS_GMSCHEMA_SERVER" | grep -qv 'apipe-test-db'
 then
-    echo "GENOME_DS_GMSCHEMA_SERVER should not refer to apipe-test-db" >&2
+    echo "GENOME_DS_GMSCHEMA_SERVER should refer to apipe-test-db" >&2
     exit 1
 fi

--- a/genome-env-tests/testexec/migration.sh
+++ b/genome-env-tests/testexec/migration.sh
@@ -8,6 +8,8 @@ then
     exit 1
 fi
 
+source "$BATS_TEST_DIRNAME/test_helper.bash"
+
 for M in sqitch/genome ur workflow ; do
     submodule_is_clean $M
 done


### PR DESCRIPTION
First two commits are to reduce the number of ephemeral databases that get
created when running these tests.  The remaining commits are refactors to
deduplicate the testexecs.