### PR TITLE
More SR User Locking Improvements

### DIFF
--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -167,14 +167,14 @@ sub _resolve_lock_name {
     my $class = shift;
     my $params = shift;
 
-    my $label = $params->{label};
-    if(length($label) >= 32) {
-        $label = Genome::Sys->md5sum_data($label);
+    my $lock_name = Genome::Utility::Text::sanitize_string_for_filesystem(
+        join('_', $params->{label}, $params->{user}->id, $params->{software_result}->id)
+    );
+    if (length($lock_name) > 255) {
+        $lock_name = Genome::Sys->md5sum_data($lock_name);
     }
 
-    return 'genome/software-result-user/' . Genome::Utility::Text::sanitize_string_for_filesystem(
-        join('_', $label, $params->{user}->id, $params->{software_result}->id)
-    );
+    return 'genome/software-result-user/' . $lock_name;
 }
 
 sub _role_for_type {

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -168,7 +168,7 @@ sub _resolve_lock_name {
     my $params = shift;
 
     return 'genome/software-result-user/' . Genome::Utility::Text::sanitize_string_for_filesystem(
-        join('_', $params->{label}, $params->{user}->id, $params->{software_result}->id)
+        join('_', Genome::Sys->md5sum_data($params->{label}), $params->{user}->id, $params->{software_result}->id)
     );
 }
 

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -167,8 +167,13 @@ sub _resolve_lock_name {
     my $class = shift;
     my $params = shift;
 
+    my $label = $params->{label};
+    if(length($label) >= 32) {
+        $label = Genome::Sys->md5sum_data($label);
+    }
+
     return 'genome/software-result-user/' . Genome::Utility::Text::sanitize_string_for_filesystem(
-        join('_', Genome::Sys->md5sum_data($params->{label}), $params->{user}->id, $params->{software_result}->id)
+        join('_', $label, $params->{user}->id, $params->{software_result}->id)
     );
 }
 


### PR DESCRIPTION
* Use the new `once => 1` for observers.
* Don't let lock names get too long by including the whole label.  (Another approach might be to `substr` the label instead.  That would preserve backwards compatibility with most existing locks, but it could lead to collisions that cause deadlocks.)