### PR TITLE
Split entry_sources of MergeReports into base_report_source and supplemental_report_source

### DIFF
--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/Trio.pm
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/Trio.pm
@@ -213,6 +213,7 @@ sub add_merge_discovery_and_followup_reports_to_workflow {
                     destination => $merge_op,
                     destination_property => 'base_report',
                 );
+                $merge_op->declare_constant(base_report_source => 'discovery');
 
                 my $followup_dag = $dag->operation_named(sub_dag_name(
                         $roi_name, 'followup'));
@@ -222,6 +223,7 @@ sub add_merge_discovery_and_followup_reports_to_workflow {
                     destination => $merge_op,
                     destination_property => 'supplemental_report',
                 );
+                $merge_op->declare_constant(supplemental_report_source => 'followup');
 
                 $merge_op->declare_constant(
                     label => 'report:' . to_json({

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/Trio.t.d/expected.xml
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/Trio.t.d/expected.xml
@@ -127,15 +127,21 @@
     <inputproperty>Create Snvs, Indels, and Merged Reports (test roi-germline).Variant Reporting (snvs).input_vcf</inputproperty>
     <inputproperty>Create Snvs, Indels, and Merged Reports (test roi-germline).Variant Reporting (snvs).plan_json</inputproperty>
     <inputproperty>Create Snvs, Indels, and Merged Reports (test roi-germline).Variant Reporting (snvs).variant_type</inputproperty>
+    <inputproperty>Merge Discovery and Followup Reports (bed).base_report_source</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (bed).contains_header</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (bed).label</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (bed).sort_columns</inputproperty>
+    <inputproperty>Merge Discovery and Followup Reports (bed).supplemental_report_source</inputproperty>
+    <inputproperty>Merge Discovery and Followup Reports (full).base_report_source</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (full).contains_header</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (full).label</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (full).sort_columns</inputproperty>
+    <inputproperty>Merge Discovery and Followup Reports (full).supplemental_report_source</inputproperty>
+    <inputproperty>Merge Discovery and Followup Reports (simple).base_report_source</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (simple).contains_header</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (simple).label</inputproperty>
     <inputproperty>Merge Discovery and Followup Reports (simple).sort_columns</inputproperty>
+    <inputproperty>Merge Discovery and Followup Reports (simple).supplemental_report_source</inputproperty>
     <inputproperty>process_id</inputproperty>
     <outputproperty>Alignment stats result</outputproperty>
     <outputproperty>Coverage stats result</outputproperty>
@@ -2968,16 +2974,22 @@
   <link fromOperation="input connector" fromProperty="Create Snvs, Indels, and Merged Reports (test roi-germline).Variant Reporting (snvs).plan_json" toOperation="Create Snvs, Indels, and Merged Reports (test roi-germline)" toProperty="Variant Reporting (snvs).plan_json"/>
   <link fromOperation="input connector" fromProperty="Create Snvs, Indels, and Merged Reports (test roi-germline).Variant Reporting (snvs).variant_type" toOperation="Create Snvs, Indels, and Merged Reports (test roi-germline)" toProperty="Variant Reporting (snvs).variant_type"/>
   <link fromOperation="input connector" fromProperty="process_id" toOperation="Create Snvs, Indels, and Merged Reports (test roi-germline)" toProperty="process_id"/>
+  <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (bed).base_report_source" toOperation="Merge Discovery and Followup Reports (bed)" toProperty="base_report_source"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (bed).contains_header" toOperation="Merge Discovery and Followup Reports (bed)" toProperty="contains_header"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (bed).label" toOperation="Merge Discovery and Followup Reports (bed)" toProperty="label"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (bed).sort_columns" toOperation="Merge Discovery and Followup Reports (bed)" toProperty="sort_columns"/>
+  <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (bed).supplemental_report_source" toOperation="Merge Discovery and Followup Reports (bed)" toProperty="supplemental_report_source"/>
   <link fromOperation="input connector" fromProperty="process_id" toOperation="Merge Discovery and Followup Reports (bed)" toProperty="process_id"/>
+  <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (full).base_report_source" toOperation="Merge Discovery and Followup Reports (full)" toProperty="base_report_source"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (full).contains_header" toOperation="Merge Discovery and Followup Reports (full)" toProperty="contains_header"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (full).label" toOperation="Merge Discovery and Followup Reports (full)" toProperty="label"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (full).sort_columns" toOperation="Merge Discovery and Followup Reports (full)" toProperty="sort_columns"/>
+  <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (full).supplemental_report_source" toOperation="Merge Discovery and Followup Reports (full)" toProperty="supplemental_report_source"/>
   <link fromOperation="input connector" fromProperty="process_id" toOperation="Merge Discovery and Followup Reports (full)" toProperty="process_id"/>
+  <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (simple).base_report_source" toOperation="Merge Discovery and Followup Reports (simple)" toProperty="base_report_source"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (simple).contains_header" toOperation="Merge Discovery and Followup Reports (simple)" toProperty="contains_header"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (simple).label" toOperation="Merge Discovery and Followup Reports (simple)" toProperty="label"/>
   <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (simple).sort_columns" toOperation="Merge Discovery and Followup Reports (simple)" toProperty="sort_columns"/>
+  <link fromOperation="input connector" fromProperty="Merge Discovery and Followup Reports (simple).supplemental_report_source" toOperation="Merge Discovery and Followup Reports (simple)" toProperty="supplemental_report_source"/>
   <link fromOperation="input connector" fromProperty="process_id" toOperation="Merge Discovery and Followup Reports (simple)" toProperty="process_id"/>
 </operation>

--- a/lib/perl/Genome/VariantReporting/Framework/Component/Report/MergedReport.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Report/MergedReport.pm
@@ -38,8 +38,11 @@ class Genome::VariantReporting::Framework::Component::Report::MergedReport {
         separator => {
             is => 'Text',
         },
-        entry_sources => {
-            is_many => 'Text',
+        base_report_source => {
+            is => 'Text',
+            is_optional => 1,
+        },
+        supplemental_report_source => {
             is => 'Text',
             is_optional => 1,
         },
@@ -175,7 +178,8 @@ sub merge_files {
 
     my $merged_file = Genome::Sys->create_temp_file_path;
 
-    for my $report ($self->report_results) {
+    for my $report_name ('base_report', 'supplemental_report') {
+        my $report = $self->$report_name;
         next unless $report->has_size;
         my $file_to_merge;
         if ($self->contains_header) {
@@ -196,7 +200,15 @@ sub merge_files {
         } else {
             $file_to_merge = $report->report_path;
         }
-        my $with_source = $self->add_source($report->report_path, $file_to_merge);
+        my $report_source_accessor = $report_name . '_source';
+        my $report_source = $self->$report_source_accessor,
+        my $with_source;
+        if ($report_source) {
+            $with_source = $self->add_source($report->report_path, $file_to_merge, $report_source);
+        }
+        else {
+            $with_source = $file_to_merge;
+        }
         my $merge_command = 'cat %s >> %s';
         Genome::Sys->shellcmd(cmd => sprintf($merge_command, $with_source, $merged_file));
     }
@@ -204,11 +216,7 @@ sub merge_files {
 }
 
 sub add_source {
-    my ($self, $report, $file) = @_;
-    unless ($self->has_entry_sources) {
-        return $file;
-    }
-    my $tag = $self->get_entry_source($report);
+    my ($self, $report, $file, $tag) = @_;
     my $out_file = Genome::Sys->create_temp_file_path;
     my $out = Genome::Sys->open_file_for_writing($out_file);
     my $in = Genome::Sys->open_file_for_reading($file);
@@ -294,6 +302,15 @@ sub validate {
         die $self->error_message('The sort columns (%s) are not contained within the first header (%s)', $sort_columns, $master_header);
     }
 
+    if ($self->base_report_source || $self->supplemental_report_source) {
+        unless ($self->base_report_source) {
+            die $self->error_message("No entry source for base report: base_report_source needs to be set.");
+        }
+        unless ($self->supplemental_report_source) {
+            die $self->error_message("No entry source for supplemental report: supplemental_report_source needs to be set.");
+        }
+    }
+
     return 1;
 }
 
@@ -365,28 +382,13 @@ sub get_header {
 
 sub has_entry_sources {
     my $self = shift;
-    my @entry_sources = $self->entry_sources;
-    return scalar(@entry_sources);
+    return ($self->base_report_source && $self->supplemental_report_source);
 }
 
 sub has_sort_columns {
     my $self = shift;
     my @sort_columns = $self->sort_columns;
     return scalar(@sort_columns);
-}
-
-sub get_entry_source {
-    my ($self, $report) = validate_pos(@_, 1, 1);
-
-    for my $entry_source ($self->entry_sources) {
-        my ($report_id, $tag) = split(/\|/, $entry_source);
-        my $report_result = Genome::VariantReporting::Framework::Component::Report::MergeCompatible->get($report_id);
-
-        if ($report_result->report_path eq $report) {
-            return $tag;
-        }
-    }
-    die sprintf("No entry source for report (%s)", $report);
 }
 
 sub category {

--- a/lib/perl/Genome/VariantReporting/Framework/Component/Report/MergedReport.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Report/MergedReport.pm
@@ -201,7 +201,7 @@ sub merge_files {
             $file_to_merge = $report->report_path;
         }
         my $report_source_accessor = $report_name . '_source';
-        my $report_source = $self->$report_source_accessor,
+        my $report_source = $self->$report_source_accessor;
         my $with_source;
         if ($report_source) {
             $with_source = $self->add_source($report->report_path, $file_to_merge, $report_source);

--- a/lib/perl/Genome/VariantReporting/Framework/Component/Report/MergedReport.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Report/MergedReport.pm
@@ -302,11 +302,11 @@ sub validate {
         die $self->error_message('The sort columns (%s) are not contained within the first header (%s)', $sort_columns, $master_header);
     }
 
-    if ($self->base_report_source || $self->supplemental_report_source) {
-        unless ($self->base_report_source) {
+    if (defined($self->base_report_source) || defined($self->supplemental_report_source)) {
+        unless (defined($self->base_report_source)) {
             die $self->error_message("No entry source for base report: base_report_source needs to be set.");
         }
-        unless ($self->supplemental_report_source) {
+        unless (defined($self->supplemental_report_source)) {
             die $self->error_message("No entry source for supplemental report: supplemental_report_source needs to be set.");
         }
     }
@@ -382,7 +382,7 @@ sub get_header {
 
 sub has_entry_sources {
     my $self = shift;
-    return ($self->base_report_source && $self->supplemental_report_source);
+    return (defined($self->base_report_source) && defined($self->supplemental_report_source));
 }
 
 sub has_sort_columns {

--- a/lib/perl/Genome/VariantReporting/Framework/MergeReports.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/MergeReports.pm
@@ -31,11 +31,15 @@ class Genome::VariantReporting::Framework::MergeReports {
             default => "\t",
             doc => 'Field separator for the reports',
         },
-        entry_sources => {
-            is_many => 'Text',
+        base_report_source => {
             is => 'Text',
             is_optional => 1,
-            doc => "An array of strings of the format <Report ID>|<TAG>",
+            doc => "A tag to identify which entries came from the base report.",
+        },
+        supplemental_report_source => {
+            is => 'Text',
+            is_optional => 1,
+            doc => "A tag to identify which entries came from the supplemental report.",
         },
         process_id => {
             is => 'Text',

--- a/lib/perl/Genome/VariantReporting/Framework/MergeReports.t
+++ b/lib/perl/Genome/VariantReporting/Framework/MergeReports.t
@@ -95,10 +95,8 @@ subtest "test with headers with source" => sub {
         supplemental_report => $result_b,
         sort_columns => ['chr', 'pos'],
         contains_header => 1,
-        entry_sources => [
-            sprintf("%s|%s", $result_a->id, 'report_a'),
-            sprintf("%s|%s", $result_b->id, 'report_b'),
-        ],
+        base_report_source => 'report_a',
+        supplemental_report_source => 'report_b',
         process_id => $process->id,
         label => 'results',
     );
@@ -155,10 +153,8 @@ subtest "test without headers with source" => sub {
         supplemental_report => $result_b,
         sort_columns => ['1', '2'],
         contains_header => 0,
-        entry_sources => [
-            sprintf("%s|%s", $result_a->id, 'report_a'),
-            sprintf("%s|%s", $result_b->id, 'report_b'),
-        ],
+        base_report_source => 'report_a',
+        supplemental_report_source => 'report_b',
         process_id => $process->id,
         label => 'results',
     );
@@ -178,14 +174,12 @@ subtest "Source tags must be defined" => sub {
         supplemental_report => $result_b,
         sort_columns => ['1', '2'],
         contains_header => 0,
-        entry_sources => [
-            sprintf("%s|%s", $result_b->id, 'report_b'),
-        ],
+        supplemental_report_source => 'report_b',
         process_id => $process->id,
         label => 'results',
     );
     ok(!$cmd->execute, "Execute returns false value");
-    ok($cmd->error_message =~ qr/No entry source for report/,
+    ok($cmd->error_message =~ qr/No entry source for/,
         "Error if source tag is not defined for one report");
 };
 


### PR DESCRIPTION
Now that MergeReports only support two report inputs and report sources has been split into base_report and supplemental_report we don't need entry_sources to be is_many anymore. Instead this PR splits it into a base_report_source and a supplemental_report_source. 

This is to finish up https://jira.gsc.wustl.edu/browse/AT-678.