### PR TITLE
Process needs to be accessible by workflow step

### DIFF
--- a/lib/perl/Genome/Db/Ensembl/Command/Run/Base.pm
+++ b/lib/perl/Genome/Db/Ensembl/Command/Run/Base.pm
@@ -291,8 +291,11 @@ sub execute {
         my $workflow = $self->workflow;
         my $workflow_inputs = $self->workflow_inputs;
         $workflow_inputs->{analysis_process} = $process;
+        my $no_lsf = $ENV{NO_LSF};
+        $ENV{NO_LSF} = 1;
         $process->run_and_wait(workflow_xml => $workflow->get_xml,
                                workflow_inputs => $workflow_inputs);
+        $ENV{NO_LSF} = $no_lsf;
     }
 
     return 1;

--- a/lib/perl/Genome/Db/Ensembl/Command/Run/Base.pm
+++ b/lib/perl/Genome/Db/Ensembl/Command/Run/Base.pm
@@ -291,11 +291,9 @@ sub execute {
         my $workflow = $self->workflow;
         my $workflow_inputs = $self->workflow_inputs;
         $workflow_inputs->{analysis_process} = $process;
-        my $no_lsf = $ENV{NO_LSF};
-        $ENV{NO_LSF} = 1;
+        local $ENV{NO_LSF} = 1;
         $process->run_and_wait(workflow_xml => $workflow->get_xml,
                                workflow_inputs => $workflow_inputs);
-        $ENV{NO_LSF} = $no_lsf;
     }
 
     return 1;


### PR DESCRIPTION
The process hasn't been committed yet, so shelling out for the
workflow steps will fail.  By setting NO_LSF, the workflow will
be run in the same context and the process will be accessible.