### PR TITLE
try to disable Term::ReadKey warning

### DIFF
--- a/lib/perl/Genome/Command/Viewer.pm
+++ b/lib/perl/Genome/Command/Viewer.pm
@@ -19,6 +19,7 @@ sub write_report {
 
 sub get_terminal_width {
     # GetTerminalSize() returns an empty array if unsupported, e.g. in apipe-ci logs.
+    no warnings;
     my ($screen_width) = GetTerminalSize();
     $screen_width ||= 80;
     return $screen_width;

--- a/lib/perl/Genome/Command/Viewer.pm
+++ b/lib/perl/Genome/Command/Viewer.pm
@@ -19,7 +19,7 @@ sub write_report {
 
 sub get_terminal_width {
     # GetTerminalSize() returns an empty array if unsupported, e.g. in apipe-ci logs.
-    no warnings;
+    local $SIG{__WARN__} = sub { };
     my ($screen_width) = GetTerminalSize();
     $screen_width ||= 80;
     return $screen_width;


### PR DESCRIPTION
I don't know of a way to test this easily so I don't know that this works. 
I'm trying to disable the warnings that shows up on apipe-ci logs,

> 13:40:44 Unable to get Terminal Size. The TIOCGWINSZ ioctl didn't
> work. The COLUMNS and LINES environment variables didn't work. The
> resize program didn't work. at /usr/lib/perl5/Term/ReadKey.pm line
> 362.