### PR TITLE
fixes for tests that broke when apipe-tester config changed

### DIFF
--- a/lib/perl/Genome/Model/RnaSeq.t
+++ b/lib/perl/Genome/Model/RnaSeq.t
@@ -57,6 +57,11 @@ $workflow->save_to_xml(OutputFile => $xml_file);
 
 ok(-s $expected_xml_file, "Expected xml file exists at $expected_xml_file");
 ok(-s $xml_file, "Current xml file exists at $xml_file");
-compare_ok($expected_xml_file, $xml_file, "Xml file is as expected for the workflow");
+compare_ok($expected_xml_file, $xml_file, name => "Xml file is as expected for the workflow",
+    replace => [
+        [qr(lsfQueue="apipe"), q(lsfQueue="GENOME_LSF_QUEUE_BUILD_WORKER_ALT")],
+        [qr(lsfQueue="apipe-pd"), q(lsfQueue="GENOME_LSF_QUEUE_BUILD_WORKER_ALT")],
+    ],
+);
 
 done_testing();

--- a/lib/perl/Genome/WorkflowBuilder/Test/Command.t
+++ b/lib/perl/Genome/WorkflowBuilder/Test/Command.t
@@ -115,11 +115,12 @@ subtest 'specified_operation_type_attributes' => sub {
         name => 'some op',
         command => 'Genome::WorkflowBuilder::Test::DummyCommand',
     );
-    $op->lsf_queue('not apipe');
+    my $queue = 'not apipe';
+    $op->lsf_queue($queue);
     $op->lsf_project('specified project');
     my %got = $op->operation_type_attributes;
     my %expected = (
-        lsfQueue => "not $ENV{GENOME_LSF_QUEUE_BUILD_WORKER_ALT}",
+        lsfQueue => $queue,
         lsfResource => "-M 25000000 -R 'select[mem>25000] rusage[mem=25000]'",
         lsfProject => 'specified project',
         commandClass => 'Genome::WorkflowBuilder::Test::DummyCommand',

--- a/lib/perl/Genome/WorkflowBuilder/Test/DAG.t
+++ b/lib/perl/Genome/WorkflowBuilder/Test/DAG.t
@@ -303,7 +303,7 @@ subtest 'Nested DAG with constant input' => sub {
       <outputproperty>output</outputproperty>
     </operationtype>
     <operation name="some op">
-      <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="apipe" lsfResource="-M 25000000 -R 'select[mem&gt;25000] rusage[mem=25000]'" commandClass="Genome::WorkflowBuilder::Test::DummyCommand">
+      <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="$ENV{GENOME_LSF_QUEUE_BUILD_WORKER_ALT}" lsfResource="-M 25000000 -R 'select[mem&gt;25000] rusage[mem=25000]'" commandClass="Genome::WorkflowBuilder::Test::DummyCommand">
         <inputproperty>input</inputproperty>
         <outputproperty>many_output</outputproperty>
         <outputproperty>result</outputproperty>


### PR DESCRIPTION
These tests broke when we change apipe-tester's config to use the "pd" queues.