### PR TITLE
override default timeout when creating an ephemeral database

### DIFF
--- a/bin/genome-env
+++ b/bin/genome-env
@@ -399,7 +399,7 @@ function setup_test_db {
     fi
 
     echo "=> Creating test database..."
-    eval "$($TESTDB database create --bash --owner $TESTDBSERVER_DB_USER --based-on $DB_SNAPSHOT_NAME)"
+    eval "$($TESTDB database create --timeout 30 --bash --owner $TESTDBSERVER_DB_USER --based-on $DB_SNAPSHOT_NAME)"
     if test -z "$TESTDBSERVER_DB_NAME"
     then
         fatal $BUILD_ERR "failed to create test database"


### PR DESCRIPTION
We've had these errors every once in awhile,

> Got error response 500: SSL read timeout:  at
> /usr/bin/test-db-database-create line 15

Previously we added the `--timeout` option but we didn't think it should be
necessary.  Now I am thinking it may be that the template locks while creating
the new database so contention is what is causing the timeouts. For now I am
just increasing the timeout as a workaround.  We'll need to see if this is
actually what's going on.