### PR TITLE
Print the display name for blessed objects.

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/Update.pm
+++ b/lib/perl/Genome/FeatureList/Command/Update.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Genome;
+use Scalar::Util qw();
 
 class Genome::FeatureList::Command::Update{
     is => 'Command::V2',
@@ -68,7 +69,11 @@ sub execute{
             next if $property eq 'feature_list';
             if ($self->$property){
                 my $new_value = $self->$property;
-                $self->status_message("setting $property to $new_value\n");
+                my $display_value = $new_value;
+                if (defined Scalar::Util::blessed($new_value) and $new_value->can('__display_name__')) {
+                    $display_value = $new_value->__display_name__;
+                }
+                $self->status_message('setting %s to %s', $property, $display_value);
                 $feature_list->$property($new_value);
             }
         }


### PR DESCRIPTION
Updating the reference would produce a message like:
```
setting reference to Genome::Model::Build::ImportedReferenceSequence=HASH(0x6e2ef40)
```
Now it will be like:
```
setting reference to human-build38 (a123b4567cd89e01f234a5b67cd89ef0)
```
