### PR TITLE
Sys: Do not close the fh in write_file if writing to STDOUT

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1025,7 +1025,9 @@ sub write_file {
     for (@content) {
         $fh->print($_) or Carp::croak "Failed to write to file $fname! $!";
     }
-    $fh->close or Carp::croak "Failed to close file $fname! $!";
+    if ( $fname ne '-' ) {
+        $fh->close or Carp::croak "Failed to close file $fname! $!";
+    }
     return $fname;
 }
 

--- a/lib/perl/Genome/Sys.t
+++ b/lib/perl/Genome/Sys.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use above 'Genome';
-use Test::Exception;
 use Test::More;
 
 use Genome::Sys;

--- a/lib/perl/Genome/Sys.t
+++ b/lib/perl/Genome/Sys.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 use above 'Genome';
+use Test::Exception;
 use Test::More;
 
 use Genome::Sys;
@@ -191,6 +192,22 @@ subtest iterate_file_lines => sub {
         plan tests => 4;
         $the_test->(IO::File->new($source_file));
     };
+};
+
+subtest test_write__read_file => sub {
+    plan tests => 2;
+
+    my @lines = map { $_."\n" } ('A'..'C');
+
+    # first write to STDOUT is ok
+    ok(Genome::Sys->write_file('-', @lines), 'first write_file to STDOUT succeeds');
+    # second fails
+    throws_ok(
+        sub{ Genome::Sys->write_file('-', @lines); },
+        qr/Failed to write to file \-\! Bad file descriptor/,
+        'second write_file to STDOUT fails',
+    );
+
 };
 
 done_testing();

--- a/lib/perl/Genome/Sys.t
+++ b/lib/perl/Genome/Sys.t
@@ -201,8 +201,6 @@ subtest test_write__read_file => sub {
     ok(Genome::Sys->write_file('-', @lines), 'first write_file to STDOUT succeeds');
     ok(Genome::Sys->write_file('-', @lines), 'second write_file to STDOUT succeeds');
 
-    select STDOUT;
-
 };
 
 done_testing();

--- a/lib/perl/Genome/Sys.t
+++ b/lib/perl/Genome/Sys.t
@@ -198,15 +198,10 @@ subtest test_write__read_file => sub {
     plan tests => 2;
 
     my @lines = map { $_."\n" } ('A'..'C');
-
-    # first write to STDOUT is ok
     ok(Genome::Sys->write_file('-', @lines), 'first write_file to STDOUT succeeds');
-    # second fails
-    throws_ok(
-        sub{ Genome::Sys->write_file('-', @lines); },
-        qr/Failed to write to file \-\! Bad file descriptor/,
-        'second write_file to STDOUT fails',
-    );
+    ok(Genome::Sys->write_file('-', @lines), 'second write_file to STDOUT succeeds');
+
+    select STDOUT;
 
 };
 


### PR DESCRIPTION
Writing to STDOUT more than once via Sys's write_file causes a crash. This is a PR has tests showing the failure. Should this be fixed?

@brummett please take a look.