### PR TITLE
New Command to Define an AnalysisProject Template.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/DefineTemplate.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/DefineTemplate.pm
@@ -1,0 +1,37 @@
+package Genome::Config::AnalysisProject::Command::DefineTemplate;
+
+use strict;
+use warnings;
+
+class Genome::Config::AnalysisProject::Command::DefineTemplate {
+    is => 'Genome::Config::AnalysisProject::Command::Create',
+};
+
+sub help_brief {
+    return 'Define a template for an analysis-project';
+}
+
+sub help_synopsis {
+    return 'genome config analysis-project define-template "my-template"';
+}
+
+sub help_detail {
+    return <<EOS;
+Setup a new "template" analysis project.  This will not process
+instrument data, but can be used to store a collection of configuration
+to be copied later.
+EOS
+}
+
+sub execute {
+    my $self = shift;
+
+    my $project = $self->SUPER::_execute_body;
+    return unless $project;
+
+    $project->status('Template');
+    $self->status_message('Converted new project to a Template. It cannot be used to create models.');
+    return $project;
+}
+
+1;

--- a/lib/perl/Genome/Config/AnalysisProject/Command/DefineTemplate.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/DefineTemplate.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+
+use Test::More tests => 4;
+
+my $pkg = 'Genome::Config::AnalysisProject::Command::DefineTemplate';
+use_ok($pkg);
+
+my $cmd = $pkg->create(
+    name => 'test of ' . $pkg,
+    environment => 'ad-hoc',
+    no_config => 1,
+);
+isa_ok($cmd, $pkg, 'created command');
+my $template = $cmd->execute;
+isa_ok($template, 'Genome::Config::AnalysisProject');
+is($template->status, 'Template', 'template is a template');


### PR DESCRIPTION
Once upon a time we added support for Analysis Projects that were "templates".  They would let someone store a set of configurations in one place for easy copying using `genome analysis-project copy-config`.  However, there was no way to create one... until now!