### PR TITLE
Retain build-status in metadata if defined

### DIFF
--- a/lib/perl/Genome/Model/Command/Export/Metadata.pm
+++ b/lib/perl/Genome/Model/Command/Export/Metadata.pm
@@ -341,7 +341,7 @@ sub add_to_dump_queue {
     }
 
     if ($obj->isa("Genome::Model::Build")) {
-        $obj->{status} = "Dummy";
+        $obj->{status} = $obj->status || "Dummy";
         $obj->{db_committed}{status} = "Dummy";
         my $e = $obj->the_master_event;
         $e->event_status("Dummy");

--- a/lib/perl/Genome/Model/Command/Export/Metadata.pm
+++ b/lib/perl/Genome/Model/Command/Export/Metadata.pm
@@ -341,8 +341,9 @@ sub add_to_dump_queue {
     }
 
     if ($obj->isa("Genome::Model::Build")) {
-        $obj->{status} = $obj->status || "Dummy";
-        $obj->{db_committed}{status} = "Dummy";
+        unless(defined $obj->status) {
+            die $self->error_message("undefined status for build " . $obj->id);
+        }
         my $e = $obj->the_master_event;
         $e->event_status("Dummy");
         $e->{db_committed}{event_status} = "Dummy";


### PR DESCRIPTION
Annotation builds with status "Dummy" prevent builds being launched on the SGMS. This PR retains the build's current status.