### PR TITLE
Revert "Only hash the lock name if we're going to exceed the length limit."

### DIFF
--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -167,14 +167,14 @@ sub _resolve_lock_name {
     my $class = shift;
     my $params = shift;
 
-    my $lock_name = Genome::Utility::Text::sanitize_string_for_filesystem(
-        join('_', $params->{label}, $params->{user}->id, $params->{software_result}->id)
-    );
-    if (length($lock_name) > 255) {
-        $lock_name = Genome::Sys->md5sum_data($lock_name);
+    my $label = $params->{label};
+    if(length($label) >= 32) {
+        $label = Genome::Sys->md5sum_data($label);
     }
 
-    return 'genome/software-result-user/' . $lock_name;
+    return 'genome/software-result-user/' . Genome::Utility::Text::sanitize_string_for_filesystem(
+        join('_', $label, $params->{user}->id, $params->{software_result}->id)
+    );
 }
 
 sub _role_for_type {


### PR DESCRIPTION
This reverts commit 1a8c5df57c9de933a8eb555867aa1fc8347a129e.  That
commit was pretty optimistic about length limits.  The exact limit is
not knowable in advance, so go back to the probably-fine level of 32 :)

A better solution would involve one or more of the following:
1) file locks knowing their own limits in general
2) switching to Nessy :)
3) not storing complex information in labels

[The commit being reverted was previously part of #514.  I remain under the impression that what it reverts to isn't anyone's first choice for what should happen, but I also believe it is more likely to work!]