### PR TITLE
No longer hide build queue in docs.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Queue.pm
+++ b/lib/perl/Genome/Model/Build/Command/Queue.pm
@@ -26,8 +26,6 @@ class Genome::Model::Build::Command::Queue {
 
 };
 
-sub _is_hidden_in_docs { return !Genome::Sys->current_user_is_admin };
-
 sub sub_command_sort_position { 1 }
 
 sub help_synopsis {


### PR DESCRIPTION
Now that "queueing" a build will run it as the run_as user, users can use this to queue their own builds.