### PR TITLE
SUPER::create() may return undef--pass it along.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Microarray/Result/Vcf.pm
+++ b/lib/perl/Genome/InstrumentData/Microarray/Result/Vcf.pm
@@ -30,6 +30,7 @@ sub _error {
 sub create {
     my $class = shift;
     my $self = $class->SUPER::create(@_);
+    return unless $self;
 
     $self->_error("Failed to prepare staging directory") unless $self->_prepare_staging_directory;
     my $vcf = File::Spec->join($self->temp_staging_directory, $self->vcf_file_name);


### PR DESCRIPTION
`get_or_create()` will then try to `get()` one last time (if `create` detected
that the object was made already).  Crashing prevents this from working.