### PR TITLE
Add option to vep expert to use use short_name instead of name column in feature list

### DIFF
--- a/lib/perl/Genome/FeatureList.pm
+++ b/lib/perl/Genome/FeatureList.pm
@@ -510,12 +510,18 @@ sub resolve_bed_for_reference {
 
 sub get_tabix_and_gzipped_bed_file {
     my $self = shift;
+    my %args = @_;
+
+    my $short_name = delete($args{short_name});
+    unless (defined($short_name)) {
+        $short_name = 0;
+    }
 
     if ($self->format eq 'unknown') {
         die $self->error_message("Cannot convert format of BED file with unknown format");
     }
 
-    my $processed_bed = $self->processed_bed_file(short_name => 0);
+    my $processed_bed = $self->processed_bed_file(short_name => $short_name);
     my $sorted_processed_bed = Genome::Sys->create_temp_file_path;
     Genome::Model::Tools::Joinx::Sort->execute(
         input_files => [$processed_bed],

--- a/lib/perl/Genome/VariantReporting/Command/CreateMergedReports.t.d/snvs_plan.yaml
+++ b/lib/perl/Genome/VariantReporting/Command/CreateMergedReports.t.d/snvs_plan.yaml
@@ -8,6 +8,7 @@ experts:
         joinx_version: 1.8
         plugins: []
         plugins_version: 1
+        short_name: 0
 reports:
     bed:
         interpreters:

--- a/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/experts/vep
+++ b/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/experts/vep
@@ -20,6 +20,10 @@ Annotate vcf with results from Ensembl VEP (Variant Effect Predictor)
   [1mreference_fasta[0m   Path
     Reference fasta file
     This is a translated property.
+  [1mshort_name[0m   Bool
+    Turn on the short_name option in Genome::FeatureList::processed_bed_file_content. This replaces
+    the content of the bed file name column with region numbers. Useful if the name column contains
+    special characters.
   [1mspecies[0m   Text
     Species to use
 

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/Expert.t.d/plan.yaml
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/Expert.t.d/plan.yaml
@@ -8,6 +8,7 @@ experts:
         joinx_version: 1.8
         plugins: []
         plugins_version: 1
+        short_name: 0
 reports:
     report_alpha:
         interpreters:

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/Run.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/Run.pm
@@ -45,6 +45,10 @@ class Genome::VariantReporting::Suite::Vep::Run {
             is => 'String',
             doc => 'Version of the vepplugins package to use',
         },
+        short_name => {
+            is => 'Bool',
+            doc => 'Turn on the short_name option in Genome::FeatureList::processed_bed_file_content. This replaces the content of the bed file name column with region numbers. Useful if the name column contains special characters.',
+        },
     ],
     has_structural_param => [
         lsf_resource => {

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/Run.t.d/plan.yaml
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/Run.t.d/plan.yaml
@@ -8,6 +8,7 @@ experts:
         joinx_version: 1.8
         plugins: []
         plugins_version: 1
+        short_name: 0
 reports:
     report_alpha:
         interpreters:

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -31,6 +31,11 @@ class Genome::VariantReporting::Suite::Vep::RunResult {
             is => 'String',
         },
         reference_fasta_lookup => {is => 'Path'},
+        short_name => {
+            is => 'Bool',
+            doc => 'Turn on the short_name option in Genome::FeatureList::processed_bed_file_content. This replaces the content of the bed file name column with region numbers. Useful if the name column contains special characters.',
+            default => 0,
+        },
     ],
     has_param => [
         plugins => {is => 'String',
@@ -184,7 +189,7 @@ sub _user_params {
 sub _get_file_path_for_feature_list {
     my ($self, $id) = @_;
     my $feature_list = Genome::FeatureList->get($id);
-    return $feature_list->get_tabix_and_gzipped_bed_file;
+    return $feature_list->get_tabix_and_gzipped_bed_file(short_name => $self->short_name);
 }
 Memoize::memoize("_get_file_path_for_feature_list", LIST_CACHE => 'MERGE');
 

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -95,7 +95,7 @@ sub _validate_feature_lists {
         );
         #Only check the first 10 lines to reduce computational cost
         #Typically, invalid characters will be present on every line
-        for my $line (1..10) {
+        for my $line (1..100) {
             my $bed_entry = $bed_reader->next;
             next TAG unless defined($bed_entry);
             my $invalid_characters_string = join('', @INVALID_FEATURE_LIST_CHARACTERS);

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -68,7 +68,9 @@ sub output_filename {
 sub _run {
     my $self = shift;
 
-    $self->_validate_feature_lists;
+    unless ($self->short_name) {
+        $self->_validate_feature_lists;
+    }
     $self->_sort_input_vcf;
     $self->_strip_input_vcf;
     $self->_split_alternate_alleles;

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -68,7 +68,6 @@ sub output_filename {
 sub _run {
     my $self = shift;
 
-    $self->_validate_feature_lists;
     $self->_sort_input_vcf;
     $self->_strip_input_vcf;
     $self->_split_alternate_alleles;
@@ -79,31 +78,6 @@ sub _run {
     $self->_zip;
 
     return;
-}
-
-my @INVALID_FEATURE_LIST_CHARACTERS = qw/;/;
-
-sub _validate_feature_lists {
-    my $self = shift;
-
-    TAG: for my $tag ($self->custom_annotation_tags) {
-        my $id = $self->decoded_feature_list_ids->{$tag};
-        my $feature_list_file_path = $self->_get_processed_file_path_for_feature_list($id);
-        my $bed_reader = Genome::Utility::IO::BedReader->create(
-            input => $feature_list_file_path,
-            headers => [qw/chr start end annotation/],
-        );
-        #Only check the first 10 lines to reduce computational cost
-        #Typically, invalid characters will be present on every line
-        for my $line (1..10) {
-            my $bed_entry = $bed_reader->next;
-            next TAG unless defined($bed_entry);
-            my $invalid_characters_string = join('', @INVALID_FEATURE_LIST_CHARACTERS);
-            if (my @invalid_characters_captured = $bed_entry->{annotation} =~ m/([\Q$invalid_characters_string\E])/g) {
-                die $self->error_message("Feature list (%s) contains the following invalid characters (%s) in the 4th column on line (%s).", $id, join(' ', uniq @invalid_characters_captured), $line);
-            }
-        }
-    }
 }
 
 sub _sort_input_vcf {
@@ -192,13 +166,6 @@ sub _get_file_path_for_feature_list {
     return $feature_list->get_tabix_and_gzipped_bed_file(short_name => $self->short_name);
 }
 Memoize::memoize("_get_file_path_for_feature_list", LIST_CACHE => 'MERGE');
-
-sub _get_processed_file_path_for_feature_list {
-    my ($self, $id) = @_;
-    my $feature_list = Genome::FeatureList->get($id);
-    return $feature_list->processed_bed_file(short_name => 0),
-}
-Memoize::memoize("_get_processed_file_path_for_feature_list", LIST_CACHE => 'MERGE');
 
 sub custom_annotation_inputs {
     my $self = shift;

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -100,7 +100,10 @@ sub _validate_feature_lists {
             next TAG unless defined($bed_entry);
             my $invalid_characters_string = join('', @INVALID_FEATURE_LIST_CHARACTERS);
             if (my @invalid_characters_captured = $bed_entry->{annotation} =~ m/([\Q$invalid_characters_string\E])/g) {
-                die $self->error_message("Feature list (%s) contains the following invalid characters (%s) in the 4th column on line (%s).", $id, join(' ', uniq @invalid_characters_captured), $line);
+                die $self->error_message(
+                    "Feature list (%s) contains the following invalid characters (%s) in the name column on line (%s). Use the short_name option to annotate with region numbers instead or re-import a sanitized feature list.",
+                    $id, join(' ', uniq @invalid_characters_captured), $line
+                );
             }
         }
     }

--- a/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/RunResult.pm
@@ -68,6 +68,7 @@ sub output_filename {
 sub _run {
     my $self = shift;
 
+    $self->_validate_feature_lists;
     $self->_sort_input_vcf;
     $self->_strip_input_vcf;
     $self->_split_alternate_alleles;
@@ -78,6 +79,31 @@ sub _run {
     $self->_zip;
 
     return;
+}
+
+my @INVALID_FEATURE_LIST_CHARACTERS = qw/;/;
+
+sub _validate_feature_lists {
+    my $self = shift;
+
+    TAG: for my $tag ($self->custom_annotation_tags) {
+        my $id = $self->decoded_feature_list_ids->{$tag};
+        my $feature_list_file_path = $self->_get_processed_file_path_for_feature_list($id);
+        my $bed_reader = Genome::Utility::IO::BedReader->create(
+            input => $feature_list_file_path,
+            headers => [qw/chr start end annotation/],
+        );
+        #Only check the first 10 lines to reduce computational cost
+        #Typically, invalid characters will be present on every line
+        for my $line (1..10) {
+            my $bed_entry = $bed_reader->next;
+            next TAG unless defined($bed_entry);
+            my $invalid_characters_string = join('', @INVALID_FEATURE_LIST_CHARACTERS);
+            if (my @invalid_characters_captured = $bed_entry->{annotation} =~ m/([\Q$invalid_characters_string\E])/g) {
+                die $self->error_message("Feature list (%s) contains the following invalid characters (%s) in the 4th column on line (%s).", $id, join(' ', uniq @invalid_characters_captured), $line);
+            }
+        }
+    }
 }
 
 sub _sort_input_vcf {
@@ -166,6 +192,13 @@ sub _get_file_path_for_feature_list {
     return $feature_list->get_tabix_and_gzipped_bed_file(short_name => $self->short_name);
 }
 Memoize::memoize("_get_file_path_for_feature_list", LIST_CACHE => 'MERGE');
+
+sub _get_processed_file_path_for_feature_list {
+    my ($self, $id) = @_;
+    my $feature_list = Genome::FeatureList->get($id);
+    return $feature_list->processed_bed_file(short_name => 0),
+}
+Memoize::memoize("_get_processed_file_path_for_feature_list", LIST_CACHE => 'MERGE');
 
 sub custom_annotation_inputs {
     my $self = shift;

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_indels.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_germline_report_snvs.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_indels_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_indels_report.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_snvs_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_snvs_report.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/example_snvs_plan.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/example_snvs_plan.yaml
@@ -16,6 +16,7 @@ experts:
         plugins: []
         joinx_version: 1.9
         plugins_version: 1
+        short_name: 0
 reports:
     simple:
         filters:

--- a/lib/perl/Genome/VariantReporting/plan_files/flanking_fasta_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/flanking_fasta_indels.yaml
@@ -20,6 +20,7 @@ experts:
         plugins: []
         joinx_version: 1.9
         plugins_version: 1
+        short_name: 0
 reports:
     fasta:
         filters:

--- a/lib/perl/Genome/VariantReporting/plan_files/flanking_fasta_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/flanking_fasta_snvs.yaml
@@ -20,6 +20,7 @@ experts:
         plugins: []
         joinx_version: 1.9
         plugins_version: 1
+        short_name: 0
 reports:
     fasta:
         filters:

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_indels.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_germline_report_snvs.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_indels.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/gold_somatic_report_snvs.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/rnaseq_variants_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/rnaseq_variants_snvs.yaml
@@ -16,6 +16,7 @@ experts:
         plugins: []
         joinx_version: 1.8
         plugins_version: 1
+        short_name: 0
     fpkm:
         sample_name: tumor
         fpkm_file: fpkm_file

--- a/lib/perl/Genome/VariantReporting/plan_files/somatic_indels_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/somatic_indels_report.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/somatic_snvs_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/somatic_snvs_report.yaml
@@ -20,6 +20,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'

--- a/lib/perl/Genome/VariantReporting/plan_files/tumor_only.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/tumor_only.yaml
@@ -18,6 +18,7 @@ experts:
             - Condel@PLUGIN_DIR@b@2
         plugins_version: 1
         joinx_version: 1.9
+        short_name: 0
     dbsnp:
         joinx_version: 1.10
         info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'


### PR DESCRIPTION
Sometimes our feature lists contain special characters in the name column which makes joinx choke when it tries to run vcf-merge on a vep annotated vcf in the vep expert. This has previously been addressed here https://github.com/genome/genome/pull/471 by making the vep expert fail early with a helpful error message. In order to get the vep expert to run it would've been necessary to sanitize and reimport the feature list.

In RT https://rt.gsc.wustl.edu/Ticket/Display.html?id=104483 it has been requested that we find an option that doesn't require manual user intervention. This PR makes it so that the user can specify the short_name option in the vep expert which will result in the name column being replaced with region numbers. This works for all of our current reports because the reports don't actually use the content of the name columns that are getting annotated. For possible future reports that will use the annotations it would still be necessary to manually sanitize and reimport the feature list.