### PR TITLE
Strip priorities from host-group parsing.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwa.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwa.pm
@@ -53,6 +53,7 @@ sub required_rusage {
     else {
         $host_groups =~ s/\/\s+/\ /;
         $host_groups =~ s/^HOSTS:\s+//;
+        $host_groups =~ s/\+\d+//g;
     }
 
     my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $tmp_gb] span[hosts=1]";

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.pm
@@ -46,6 +46,7 @@ sub required_rusage {
     $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
     $host_groups =~ s/\/\s+/\ /;
     $host_groups =~ s/^HOSTS:\s+//;
+    $host_groups =~ s/\+\d+//g;
 
     my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $tmp_gb] span[hosts=1]";
     my $rusage  = "rusage[mem=$mem_mb, gtmp=$tmp_gb]";

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/BwamemStream.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/BwamemStream.pm
@@ -49,6 +49,7 @@ sub required_rusage {
     $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
     $host_groups =~ s/\/\s+/\ /;
     $host_groups =~ s/^HOSTS:\s+//;
+    $host_groups =~ s/\+\d+//g;
 
     my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $tmp_gb] span[hosts=1]";
     my $rusage  = "rusage[mem=$mem_mb, gtmp=$tmp_gb]";

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwasw.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwasw.pm
@@ -46,6 +46,7 @@ sub required_rusage {
     $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
     $host_groups =~ s/\/\s+/\ /;
     $host_groups =~ s/^HOSTS:\s+//;
+    $host_groups =~ s/\+\d+//g;
 
     my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $tmp_gb] span[hosts=1]";
     my $rusage  = "rusage[mem=$mem_mb, gtmp=$tmp_gb]";


### PR DESCRIPTION
This is a quick patch to a problem in production due to an LSF configuration change.  It seems clear from the *four* places I had to edit that this code is suboptimal and should be further improved.

(No bwa reference alignment builds can be started in the current LSF configuration without this change.)