### PR TITLE
support importing "new" Nimblegen capture/primary split bed files

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/Import.pm
+++ b/lib/perl/Genome/FeatureList/Command/Import.pm
@@ -272,12 +272,6 @@ sub _create_nimblegen_capture_primary_multitrack_bed_file {
         my ($fh, $name) = @{$_};
         $multitrack_fh->printf(qq(track name=%s\n), $name);
         while (my $line = $fh->getline) {
-
-            # normalize chromosome names...
-            if (index($line, 'chr') == 0) {
-                $line = substr($line, 3);
-            }
-
             $multitrack_fh->print($line);
         }
     }

--- a/lib/perl/Genome/FeatureList/Command/Import.pm
+++ b/lib/perl/Genome/FeatureList/Command/Import.pm
@@ -263,8 +263,8 @@ sub _create_nimblegen_capture_primary_multitrack_bed_file {
     my $pair = shift;
 
     my @data = (
-        [IO::File->new($pair->{capture}, 'r'), 'tiled_region',  (File::Spec->splitpath($pair->{primary}))[2]],
-        [IO::File->new($pair->{primary}, 'r'), 'target_region', (File::Spec->splitpath($pair->{primary}))[2]],
+        [Genome::Sys->open_file_for_reading($pair->{capture}), 'tiled_region',  (File::Spec->splitpath($pair->{primary}))[2]],
+        [Genome::Sys->open_file_for_reading($pair->{primary}), 'target_region', (File::Spec->splitpath($pair->{primary}))[2]],
     );
 
     my ($multitrack_fh, $multitrack_path) = Genome::Sys->create_temp_file();

--- a/lib/perl/Genome/FeatureList/Command/Import.pm
+++ b/lib/perl/Genome/FeatureList/Command/Import.pm
@@ -11,6 +11,7 @@ use Carp qw(croak);
 use File::Spec qw();
 use IO::File qw();
 use Set::Scalar qw();
+use Try::Tiny qw(try);
 
 class Genome::FeatureList::Command::Import {
     is => 'Command::V2',
@@ -249,7 +250,7 @@ sub _nimblegen_capture_primary_pair {
 sub _has_nimblegen_capture_primary_pair {
     my $self = shift;
     my @bed_files = @_;
-    my @pair = eval { $self->_nimblegen_capture_primary_pair(@bed_files) };
+    my @pair = try { $self->_nimblegen_capture_primary_pair(@bed_files) };
     return (@pair > 0);
 }
 

--- a/lib/perl/Genome/FeatureList/Command/Import.pm
+++ b/lib/perl/Genome/FeatureList/Command/Import.pm
@@ -263,14 +263,14 @@ sub _create_nimblegen_capture_primary_multitrack_bed_file {
     my $pair = shift;
 
     my @data = (
-        [Genome::Sys->open_file_for_reading($pair->{capture}), 'tiled_region',  (File::Spec->splitpath($pair->{primary}))[2]],
-        [Genome::Sys->open_file_for_reading($pair->{primary}), 'target_region', (File::Spec->splitpath($pair->{primary}))[2]],
+        [Genome::Sys->open_file_for_reading($pair->{capture}), 'tiled_region'],
+        [Genome::Sys->open_file_for_reading($pair->{primary}), 'target_region'],
     );
 
     my ($multitrack_fh, $multitrack_path) = Genome::Sys->create_temp_file();
     for (@data) {
-        my ($fh, $name, $desc) = @{$_};
-        $multitrack_fh->printf(qq(track name=%s description="%s"\n), $name, $desc);
+        my ($fh, $name) = @{$_};
+        $multitrack_fh->printf(qq(track name=%s\n), $name);
         while (my $line = $fh->getline) {
 
             # normalize chromosome names...

--- a/lib/perl/Genome/FeatureList/Command/Import.t
+++ b/lib/perl/Genome/FeatureList/Command/Import.t
@@ -9,9 +9,13 @@ BEGIN {
 
 use above "Genome";
 
-use Test::More tests => 20;
+use Test::More tests => 23;
 
-use_ok('Genome::FeatureList::Command::Import');
+use File::Copy qw(copy);
+use Genome::Utility::Test qw(compare_ok);
+
+my $class = 'Genome::FeatureList::Command::Import';
+use_ok($class);
 
 my $reference = Genome::Model::Build::ReferenceSequence->get(name => 'NCBI-human-build36');
 
@@ -55,3 +59,77 @@ for my $failing_bed(@test_beds[@should_fail]) {
     my $error = $@;
     ok(!$rv && $error, 'failed to execute');
 }
+
+subtest _nimblegen_capture_primary_pair => sub {
+    plan tests => 2;
+    my @bed_files = qw(
+        150203_HG19_CRC_OID42357_EZ_HX1_capture_targets.bed
+        150203_HG19_CRC_OID42357_EZ_HX1_coverage_summary.txt
+        150203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
+        CRC_nimbegen_design_hg19_v3.bed
+    );
+    my @pair = $class->_nimblegen_capture_primary_pair(@bed_files);
+    is(scalar(@pair), 2, 'two items are returned');
+    isnt($pair[0], $pair[1], 'the items are distinct');
+};
+
+subtest _has_nimblegen_capture_primary_pair => sub {
+    plan tests => 3;
+
+    do {
+        my @bed_files = qw(
+            150203_HG19_CRC_OID42357_EZ_HX1_capture_targets.bed
+            150203_HG19_CRC_OID42357_EZ_HX1_coverage_summary.txt
+            150203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
+            CRC_nimbegen_design_hg19_v3.bed
+        );
+        ok($class->_has_nimblegen_capture_primary_pair(@bed_files),
+            'single match: should have Nimblegen capture/primary pair');
+    };
+
+    do {
+        my @bed_files = qw(
+            150203_HG19_CRC_OID42357_EZ_HX1_coverage_summary.txt
+            150203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
+            CRC_nimbegen_design_hg19_v3.bed
+        );
+        ok(not($class->_has_nimblegen_capture_primary_pair(@bed_files)),
+            'empty match: should not have Nimblegen capture/primary pair');
+    };
+
+    do {
+        my @bed_files = qw(
+            150203_HG19_CRC_OID42357_EZ_HX1_capture_targets.bed
+            150203_HG19_CRC_OID42357_EZ_HX1_coverage_summary.txt
+            150203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
+            250203_HG19_CRC_OID42357_EZ_HX1_capture_targets.bed
+            250203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
+            CRC_nimbegen_design_hg19_v3.bed
+        );
+        ok(not($class->_has_nimblegen_capture_primary_pair(@bed_files)),
+            'multiple match: should not have Nimblegen capture/primary pair');
+    };
+};
+
+subtest 'Nimblegen capture/primary Import' => sub {
+    plan tests => 2;
+
+    my $reference = Genome::Model::Build::ReferenceSequence->get(name => 'NCBI-human-build36');
+    my ($expected_output, @originals) = map { sprintf('%s.d/%s.bed', __FILE__, $_) }
+        qw(X_multitrack X_capture_targets X_primary_targets);
+
+    my $temp_dir = Genome::Sys->create_temp_directory();
+    for (@originals) {
+        copy($_, $temp_dir);
+    }
+
+    my $cmd = $class->create(
+        file_path => $temp_dir,
+        name => 'Nimblegen capture/primary Import Test',
+        reference => $reference,
+    );
+    ok($cmd->execute, 'import executed successfully');
+
+    my $fl = $cmd->new_feature_list;
+    compare_ok($fl->file_path, $expected_output);
+};

--- a/lib/perl/Genome/FeatureList/Command/Import.t
+++ b/lib/perl/Genome/FeatureList/Command/Import.t
@@ -61,16 +61,18 @@ for my $failing_bed(@test_beds[@should_fail]) {
 }
 
 subtest _nimblegen_capture_primary_pair => sub {
-    plan tests => 2;
+    plan tests => 4;
     my @bed_files = qw(
         150203_HG19_CRC_OID42357_EZ_HX1_capture_targets.bed
         150203_HG19_CRC_OID42357_EZ_HX1_coverage_summary.txt
         150203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
         CRC_nimbegen_design_hg19_v3.bed
     );
-    my @pair = $class->_nimblegen_capture_primary_pair(@bed_files);
-    is(scalar(@pair), 2, 'two items are returned');
-    isnt($pair[0], $pair[1], 'the items are distinct');
+    my $pair = $class->_nimblegen_capture_primary_pair(@bed_files);
+    is(scalar(keys %$pair), 2, 'two items are returned');
+    ok($pair->{capture}, 'it has a capture value');
+    ok($pair->{primary}, 'it has a primary value');
+    isnt($pair->{capture}, $pair->{primary}, 'the items are distinct');
 };
 
 subtest _has_nimblegen_capture_primary_pair => sub {

--- a/lib/perl/Genome/FeatureList/Command/Import.t
+++ b/lib/perl/Genome/FeatureList/Command/Import.t
@@ -60,7 +60,7 @@ for my $failing_bed(@test_beds[@should_fail]) {
     ok(!$rv && $error, 'failed to execute');
 }
 
-subtest _nimblegen_capture_primary_pair => sub {
+subtest _nimblegen_pair => sub {
     plan tests => 4;
     my @bed_files = qw(
         150203_HG19_CRC_OID42357_EZ_HX1_capture_targets.bed
@@ -68,14 +68,14 @@ subtest _nimblegen_capture_primary_pair => sub {
         150203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
         CRC_nimbegen_design_hg19_v3.bed
     );
-    my $pair = $class->_nimblegen_capture_primary_pair(@bed_files);
+    my $pair = $class->_nimblegen_pair(@bed_files);
     is(scalar(keys %$pair), 2, 'two items are returned');
-    ok($pair->{capture}, 'it has a capture value');
-    ok($pair->{primary}, 'it has a primary value');
-    isnt($pair->{capture}, $pair->{primary}, 'the items are distinct');
+    ok($pair->{tiled_region}, 'it has a tiled_region value');
+    ok($pair->{target_region}, 'it has a target_region value');
+    isnt($pair->{tiled_region}, $pair->{target_region}, 'the items are distinct');
 };
 
-subtest _has_nimblegen_capture_primary_pair => sub {
+subtest _has_nimblegen_pair => sub {
     plan tests => 3;
 
     do {
@@ -85,7 +85,7 @@ subtest _has_nimblegen_capture_primary_pair => sub {
             150203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
             CRC_nimbegen_design_hg19_v3.bed
         );
-        ok($class->_has_nimblegen_capture_primary_pair(@bed_files),
+        ok($class->_has_nimblegen_pair(@bed_files),
             'single match: should have Nimblegen capture/primary pair');
     };
 
@@ -95,7 +95,7 @@ subtest _has_nimblegen_capture_primary_pair => sub {
             150203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
             CRC_nimbegen_design_hg19_v3.bed
         );
-        ok(not($class->_has_nimblegen_capture_primary_pair(@bed_files)),
+        ok(not($class->_has_nimblegen_pair(@bed_files)),
             'empty match: should not have Nimblegen capture/primary pair');
     };
 
@@ -108,7 +108,7 @@ subtest _has_nimblegen_capture_primary_pair => sub {
             250203_HG19_CRC_OID42357_EZ_HX1_primary_targets.bed
             CRC_nimbegen_design_hg19_v3.bed
         );
-        ok(not($class->_has_nimblegen_capture_primary_pair(@bed_files)),
+        ok(not($class->_has_nimblegen_pair(@bed_files)),
             'multiple match: should not have Nimblegen capture/primary pair');
     };
 };

--- a/lib/perl/Genome/FeatureList/Command/Import.t.d/X_capture_targets.bed
+++ b/lib/perl/Genome/FeatureList/Command/Import.t.d/X_capture_targets.bed
@@ -1,0 +1,2 @@
+chr1	1	100	position1
+chr6	80	179	range1

--- a/lib/perl/Genome/FeatureList/Command/Import.t.d/X_capture_targets.bed
+++ b/lib/perl/Genome/FeatureList/Command/Import.t.d/X_capture_targets.bed
@@ -1,2 +1,2 @@
-chr1	1	100	position1
-chr6	80	179	range1
+1	1	100	position1
+6	80	179	range1

--- a/lib/perl/Genome/FeatureList/Command/Import.t.d/X_multitrack.bed
+++ b/lib/perl/Genome/FeatureList/Command/Import.t.d/X_multitrack.bed
@@ -1,0 +1,6 @@
+track name="probes"
+1	1	100	position1
+6	80	179	range1
+track name="targets"
+1	1	2	position1
+6	100	105	range1

--- a/lib/perl/Genome/FeatureList/Command/Import.t.d/X_primary_targets.bed
+++ b/lib/perl/Genome/FeatureList/Command/Import.t.d/X_primary_targets.bed
@@ -1,2 +1,2 @@
-chr1	1	2	position1
-chr6	100	105	range1
+1	1	2	position1
+6	100	105	range1

--- a/lib/perl/Genome/FeatureList/Command/Import.t.d/X_primary_targets.bed
+++ b/lib/perl/Genome/FeatureList/Command/Import.t.d/X_primary_targets.bed
@@ -1,0 +1,2 @@
+chr1	1	2	position1
+chr6	100	105	range1

--- a/lib/perl/Genome/Utility/Test.pm
+++ b/lib/perl/Genome/Utility/Test.pm
@@ -452,7 +452,7 @@ Genome::Utility::Test
 
 =head1 SYNOPSIS
 
-    use Genome::Utiltiy::Test qw(compare_ok);
+    use Genome::Utility::Test qw(compare_ok);
 
     compare_ok($file_1, $file_1);
 


### PR DESCRIPTION
Add support for importing Nimblegen capture_targets/primary_targets split
bed files.

This feature was requested in [RT#104532][1].

[1]: https://rt.gsc.wustl.edu/Ticket/Display.html?id=104532