### PR TITLE
Fix DateTime calculation involving DST

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -16,6 +16,8 @@ use DateTime;
 
 our $TESTING_DISK_ALLOCATION = 0;
 
+use constant SECONDS_IN_ONE_YEAR => 365*24*60*60;
+
 class Genome::Disk::Allocation {
     is => 'Genome::Notable',
     table_name => 'disk.allocation',
@@ -1040,7 +1042,7 @@ sub _commit_unless_testing {
 }
 
 sub _default_archive_after_time {
-    DateTime->now(time_zone => 'local')->add(years => 1)->strftime('%F 00:00:00');
+    DateTime->now(time_zone => 'local')->add(seconds => SECONDS_IN_ONE_YEAR)->strftime('%F 00:00:00');
 }
 
 sub _get_trash_folder {


### PR DESCRIPTION
Builds were failing on Mar 13 between 2 and 3AM.
_default_archive_after_time() adds 1 year to the current time.  The 2016 DST
changeover will happen on Mar 13, so 13 Mar 2016 2:45:00 won't exist.  The
error would also occur for any allocations created on Feb 29th.

This change adds an equivalent number of seconds, which DateTime allows, and
automatically adjusts for time changes.

One downside is that when there's a Feb 29th between "now" and the calculated
date, you'll technically have 1 day less than a year before it's archived.
The alternative is to use DateTime's "floating" timezone
(https://metacpan.org/pod/DateTime#Making-Things-Simple) which allows the
calculation to produce an invalid date in the local timezone, but this seems
more hacky.