### PR TITLE
Make Htseq count to revivify the per lane bam from merged bam

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1649,7 +1649,7 @@ sub revivified_alignment_bam_file_paths {
     my $cmd = Genome::InstrumentData::AlignmentResult::Command::RecreatePerLaneBam->create(
         merged_bam          => $merged_bam,
         per_lane_bam        => $revivified_bam,
-        instrument_data_id  => $self->instrument_data_id,
+        instrument_data_id  => $self->read_and_platform_group_tag_id,
         samtools_version    => $self->samtools_version,
         picard_version      => $self->picard_version,
         bam_header          => $self->bam_header_path,

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -175,7 +175,7 @@ sub create {
             #handle duplicates on a per-library basis
             for my $alignment (@alignments) {
                 my $library = $alignment->instrument_data->library;
-                my $temp_allocation = $self->_get_temp_allocation($alignment);
+                my $temp_allocation = $self->_get_temp_allocation($alignment->id, $self->output_dir);
                 push @{ $bams_per_library->{$library->id} }, $alignment->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
                 $libraries->{$library->id} = $library;
                 push @temp_allocations, $temp_allocation;
@@ -196,7 +196,7 @@ sub create {
         } else {
             #just collect the BAMs for a merge
             for my $alignment (@alignments) {
-                my $temp_allocation = $self->_get_temp_allocation($alignment);
+                my $temp_allocation = $self->_get_temp_allocation($alignment->id, $self->output_dir);
                 push @bams_for_final_merge, $alignment->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
                 push @temp_allocations, $temp_allocation;
             }
@@ -333,11 +333,11 @@ sub _remove_per_lane_bam {
 }
 
 sub _get_temp_allocation {
-    my ($self, $alignment) = @_;
+    my ($self, $alignment_id, $output_dir) = @_;
     return Genome::Disk::Allocation->create(
         disk_group_name     => $ENV{GENOME_DISK_GROUP_ALIGNMENTS},
-        allocation_path     => 'merged/recreated_per_lane_bam/'.$alignment->id.'_'._get_uuid_string(),
-        kilobytes_requested => Genome::Sys->disk_usage_for_path($self->output_dir),
+        allocation_path     => 'merged/recreated_per_lane_bam/'.$alignment_id.'_'._get_uuid_string(),
+        kilobytes_requested => Genome::Sys->disk_usage_for_path($output_dir),
         owner_class_name    => 'Genome::Sys::User',
         owner_id            => Genome::Sys->username,
     );

--- a/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
@@ -250,7 +250,10 @@ sub _run_htseq_count {
     } else {
         # a completed alignment result will need to have a sorted bam created
         $self->debug_message("No temp_scratch_directory found: name sort the BAM in temp space.");
-        my $unsorted_bam = $alignment_result->output_dir . '/all_sequences.bam';
+
+        my $temp_allocation = Genome::InstrumentData::AlignmentResult::Merged->_get_temp_allocation($alignment_result->id, $output_dir);
+        my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
+
         my $sorted_bam_noprefix = "$tmp/all_sequences.namesorted";
         $sorted_bam = $sorted_bam_noprefix . '.bam';
 
@@ -259,6 +262,8 @@ sub _run_htseq_count {
             input_files => [$unsorted_bam],
             output_files => [$sorted_bam],
         );
+
+        $temp_allocation->delete;
     }
 
     my @header = `$samtools_path view -H $sorted_bam`;


### PR DESCRIPTION
Currently the apipe-test-rnaseq build failure is caused by the bug that HTseq count fails to find the per lane bam that is removed after bam merge. This PR fixes the bug and also makes the change to give correct instrument_data_id to RecreatePerLaneBam.