### PR TITLE
ERCC-based Quality Control Screening for RNASeq: Part 2

### DIFF
--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -47,7 +47,7 @@ process.opts <- function() {
   return(opts)
 }
 
-make.LinearityPlot <- function(df) {
+linearity.plot <- function(df) {
   df$count <- as.numeric(df$count)
 
   df$logMix1  <- log2(df$Mix1)
@@ -208,7 +208,7 @@ main <- function() {
   }
 
   pdf(opts$output)
-  r2 <- make.LinearityPlot(df)
+  r2 <- linearity.plot(df)
   mix.plot(mix1DF, "Mix1")
   mix.plot(mix2DF, "Mix2")
 

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -63,7 +63,13 @@ make.LinearityPlot <- function(df) {
           geom_point(aes(color=subgroup)) +
           geom_smooth(method=lm) +
           annotate('text', 5, -3, label=correlation_label)
-  p <- p + opts(title="log2(alignment counts) vs log2(Mix 1 concentrations)")
+
+  p <- p +
+       opts(title="log2(alignment counts) vs log2(Mix 1 concentrations)")
+
+  # adjust axis labels
+  p <- p + ylab("log2(Count)") + xlab("log2(Mix1)")
+
   print(p)
 
   return(count_r_squared)

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -198,7 +198,14 @@ main <- function() {
   cat(paste("\n===> Mix2 Summary Stats <=== \n"))
   print(mix2DF)
 
-  test.mixture(mix1DF, mix2DF)
+  if (sum(mix1DF$AlignmentCounts) > 0 &&
+      sum(mix2DF$AlignmentCounts) > 0) {
+    test.mixture(mix1DF, mix2DF)
+  }
+  else {
+    cat(paste("===> No ERCC Spike-Ins Found! <===\n"))
+    q(status=0)
+  }
 
   pdf(opts$output)
   r2 <- make.LinearityPlot(df)

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -125,7 +125,7 @@ test.mixture <- function(Mix1DF, Mix2DF) {
   test.mix1 <- chisq.test(Mix1DF$AlignmentCounts/10000, p=Mix1DF$ExpectedMixRatios)
   cat(paste("\t(Mix1) Chi-squared Statistic :", test.mix1[['statistic']], "\n", sep=' '))
   cat(paste("\t(Mix1) Degrees-of-Freedom    :", test.mix1[['parameter']], "\n", sep=' '))
-  cat(paste("\t(Mix2) p-value               :", test.mix1[['p.value']],   "\n", sep=' '))
+  cat(paste("\t(Mix1) p-value               :", test.mix1[['p.value']],   "\n", sep=' '))
   cat(paste("\n"))
 
   if (test.mix1[["p.value"]] < p_value_threshold) {

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -121,17 +121,23 @@ test.mixture <- function(Mix1DF, Mix2DF) {
   hypo.mix2 <- TRUE
   p_value_threshold <- 0.05
 
-#  cat(paste("Running Chi-squared test for Mix 1 usage\n"))
+  cat(paste("Running Chi-squared test for Mix 1 usage\n"))
   test.mix1 <- chisq.test(Mix1DF$AlignmentCounts/10000, p=Mix1DF$ExpectedMixRatios)
-#  print(test.mix1)
+  cat(paste("\t(Mix1) Chi-squared Statistic :", test.mix1[['statistic']], "\n", sep=' '))
+  cat(paste("\t(Mix1) Degrees-of-Freedom    :", test.mix1[['parameter']], "\n", sep=' '))
+  cat(paste("\t(Mix2) p-value               :", test.mix1[['p.value']],   "\n", sep=' '))
+  cat(paste("\n"))
 
   if (test.mix1[["p.value"]] < p_value_threshold) {
     hypo.mix1 <- FALSE
   }
 
-#  cat(paste("Running Chi-squared test for Mix 2 usage\n"))
+  cat(paste("Running Chi-squared test for Mix 2 usage\n"))
   test.mix2 <- chisq.test(Mix2DF$AlignmentCounts/10000, p=Mix2DF$ExpectedMixRatios)
-#  print(test.mix2)
+  cat(paste("\t(Mix2) Chi-squared Statistic :", test.mix2[['statistic']], "\n", sep=' '))
+  cat(paste("\t(Mix2) Degrees-of-Freedom    :", test.mix2[['parameter']], "\n", sep=' '))
+  cat(paste("\t(Mix2) p-value               :", test.mix2[['p.value']],   "\n", sep=' '))
+  cat(paste("\n"))
 
   if (test.mix2[["p.value"]] < p_value_threshold) {
     hypo.mix2 <- FALSE
@@ -139,22 +145,17 @@ test.mixture <- function(Mix1DF, Mix2DF) {
 
   if ( (hypo.mix1 == FALSE && hypo.mix2 == FALSE) ||
        (hypo.mix1 == TRUE && hypo.mix2 == TRUE) ) {
-    cat(paste("==> Couldn't ascertain whether mix 1 or mix 2 was used! <==\n"))
-    cat(paste("\n"))
-    cat(paste("==== Chi-squared test for Mix 1 usage results ==== \n"))
-    print(test.mix1)
-    cat(paste("==== Chi-squared test for Mix 2 usage results ==== \n"))
-    print(test.mix2)
-    return
+    cat(paste("DECISION: Couldn't ascertain whether mix 1 or mix 2 was used! \n"))
+    cat(paste("          -- Please investigate with the analysis plots -- \n"))
+  }
+  else if (hypo.mix1 == TRUE) {
+    cat(paste("DECISION: Mix 1 was used \n"))
+  }
+  else {
+    cat(paste("DECISION: Mix 2 was used \n"))
   }
 
-  if (hypo.mix1 == TRUE) {
-    cat(paste("\n===> Mix 1 was used <=== \n"))
-  }
-
-  if (hypo.mix2 == TRUE) {
-    cat(paste("\n===> Mix 2 was used <=== \n"))
-  }
+  cat(paste("\n"))
 }
 
 readTSV <- function(inputTSV) {
@@ -197,9 +198,11 @@ main <- function() {
   print(mix1DF)
   cat(paste("\n===> Mix2 Summary Stats <=== \n"))
   print(mix2DF)
+  cat(paste("\n"))
 
   if (sum(mix1DF$AlignmentCounts) > 0 &&
       sum(mix2DF$AlignmentCounts) > 0) {
+    cat(paste("===> Goodness-of-Fit-Tests to Determine Which Mix Was Used <===\n"))
     test.mixture(mix1DF, mix2DF)
   }
   else {
@@ -207,6 +210,7 @@ main <- function() {
     q(status=0)
   }
 
+  cat(paste("===> Generating Output Plots <===\n"))
   pdf(opts$output)
   r2 <- linearity.plot(df)
   mix.plot(mix1DF, "Mix1")
@@ -218,7 +222,7 @@ main <- function() {
 
 
   r2_text <- paste("R^2 :", r2, sep=" ")
-  cat(paste("===>", r2_text, "<===", "\n", sep=" "))
+  cat(paste(r2_text, "\n", sep=" "))
 
   cat(paste("\nSee", opts$output, "for the analysis plots", "\n", sep=" "))
 }

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -80,16 +80,9 @@ make.MixFrame <- function(mixType, df) {
             by=list(Group=df$subgroup),
             FUN=sum)
 
-  epsilon <- 0.0001
-
   colnames(mix)[3] <- "AlignmentCounts"
   mix$Probability <- mix[,mixType] / sum(mix[,mixType])
   mix$ExpectedCounts <- mix$Probability * sum(mix$AlignmentCounts)
-
-  # account for 0 count cases ( log2(0) is undefined )
-  tmpCounts <- ifelse(mix$AlignmentCounts == 0, epsilon, mix$AlignmentCounts)
-  mix$log2AlignmentCounts <- log2(tmpCounts)
-
   colnames(mix)[2] <- paste("Concentration", mixType, sep="")
 
   return(mix)
@@ -129,14 +122,16 @@ test.mixture <- function(Mix1DF, Mix2DF) {
   p_value_threshold <- 0.05
 
 #  cat(paste("Running Chi-squared test for Mix 1 usage\n"))
-  test.mix1 <- chisq.test(Mix1DF$log2AlignmentCounts, p=Mix1DF$Probability)
+  test.mix1 <- chisq.test(Mix1DF$AlignmentCounts/10000, p=Mix1DF$Probability)
+#  print(test.mix1)
 
   if (test.mix1[["p.value"]] < p_value_threshold) {
     hypo.mix1 <- FALSE
   }
 
 #  cat(paste("Running Chi-squared test for Mix 2 usage\n"))
-  test.mix2 <- chisq.test(Mix2DF$log2AlignmentCounts, p=Mix2DF$Probability)
+  test.mix2 <- chisq.test(Mix2DF$AlignmentCounts/10000, p=Mix2DF$Probability)
+#  print(test.mix2)
 
   if (test.mix2[["p.value"]] < p_value_threshold) {
     hypo.mix2 <- FALSE

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -5,6 +5,9 @@ library(reshape, warn.conflicts=FALSE, quiet=TRUE)
 library(ggplot2, quietly=TRUE)
 library(getopt)
 
+# allow output to be 100 columns wide
+options(width=as.integer(100))
+
 opt <- getopt(
   matrix(
     c('data'    ,   'd', 1, "character",
@@ -34,36 +37,389 @@ if ( is.null(opt$data) ) {
  if ( is.null(opt$output  ) ) { opt$output  <- 'output.pdf' }
  if ( is.null(opt$epsilon ) ) { opt$epsilon <- 0.01         }
 
-inputTSV <- opt$data
-epsilon  <- opt$epsion
-pdfFile  <- opt$output
+#inputTSV <- opt$data
+#epsilon  <- opt$epsilon
+#pdfFile  <- opt$output
 
-data = read.delim(inputTSV)
+#################################
+make.LinearityPlot <- function(df) {
+  df$count <- as.numeric(df$count)
 
-data$count = as.numeric(data$count)
+  df$logMix1  <- log2(df$Mix1)
+  df$logMix2  <- log2(df$Mix2)
+  df$logCount <- log2(df$count + 1)
 
-data$log_concentration = log2(data$concentration)
-data$log_count         = log2(data$count + 1)
 
+  count_model <- lm(logCount ~ logMix1, data=df)
+  count_r_squared = summary(count_model)[['r.squared']]
+  correlation_label <- paste("R^2 =", count_r_squared, sep=' ')
 
-pdf(pdfFile)
-ggplot(data, aes(x=log_concentration)) + geom_histogram()
+  p <- ggplot(df, aes(x=logMix1, y=logCount)) +
+          geom_point(aes(color=subgroup)) +
+          geom_smooth(method=lm) +
+          annotate('text', 5, -3, label=correlation_label)
+  p <- p + opts(title="log2(alignment counts) vs log2(Mix 1 concentrations)")
+  print(p)
 
-ggplot(data, aes(x=log_count)) + geom_histogram()
+  return(count_r_squared)
+}
 
-count_model <- lm(log_count ~ log_concentration, data=data)
-count_r_squared = summary(count_model)[['r.squared']]
+make.MixFrame <- function(mixType, df) {
+  mix <- aggregate(df[c(mixType, "count")],
+            by=list(Group=df$subgroup),
+            FUN=sum)
 
-ggplot(data, aes(x=log_concentration, y=log_count)
-       ) + geom_point(aes(color=subgroup)
-       ) + geom_smooth(method=lm
-       ) + annotate('text', 5, -3,
-                    label=paste("R^2 =", count_r_squared, sep=' '))
+  epsilon <- 0.0001
+
+  colnames(mix)[3] <- "AlignmentCounts"
+  mix$Probability <- mix[,mixType] / sum(mix[,mixType])
+  mix$ExpectedCounts <- mix$Probability * sum(mix$AlignmentCounts)
+
+  # account for 0 count cases ( log2(0) is undefined )
+  tmpCounts <- ifelse(mix$AlignmentCounts == 0, epsilon, mix$AlignmentCounts)
+  mix$log2AlignmentCounts <- log2(tmpCounts)
+
+  colnames(mix)[2] <- paste("Concentration", mixType, sep="")
+
+  return(mix)
+}
+
+mix.plot <- function(MixDF, MixType) {
+  MeltDF <- suppressMessages(melt(MixDF))
+  df <- MeltDF[MeltDF$variable == "AlignmentCounts" |
+               MeltDF$variable == "ExpectedCounts", ]
+  # Reset the number factors on subsetted data frame
+  df$variable <- factor(df$variable)
+
+  p <- ggplot(df, aes(x=Group, y=value, fill=variable))
+  p <- p + geom_bar(position="dodge", color="black") 
+  title <- paste("Observed & Expected Alignment Counts (",
+                 MixType, ")",
+                 sep="")
+
+  # adjust plot title
+  p <- p + opts(title=title)
+
+  # adjust y axis label
+  p <- p + ylab("Count")
+
+  # adjust legend placement
+  p <- p + opts(legend.position="top", legend.direction="horizontal")
+
+  # suppress legend title
+  p <- p + scale_fill_discrete(name="")
+
+  print(p)
+}
+
+test.mixture <- function(Mix1DF, Mix2DF) {
+  hypo.mix1 <- TRUE
+  hypo.mix2 <- TRUE
+  p_value_threshold <- 0.05
+
+#  cat(paste("Running Chi-squared test for Mix 1 usage\n"))
+  test.mix1 <- chisq.test(Mix1DF$log2AlignmentCounts, p=Mix1DF$Probability)
+
+  if (test.mix1[["p.value"]] < p_value_threshold) {
+    hypo.mix1 <- FALSE
+  }
+
+#  cat(paste("Running Chi-squared test for Mix 2 usage\n"))
+  test.mix2 <- chisq.test(Mix2DF$log2AlignmentCounts, p=Mix2DF$Probability)
+
+  if (test.mix2[["p.value"]] < p_value_threshold) {
+    hypo.mix2 <- FALSE
+  }
+
+  if ( (hypo.mix1 == FALSE && hypo.mix2 == FALSE) ||
+       (hypo.mix1 == TRUE && hypo.mix2 == TRUE) ) {
+    cat(paste("==> Couldn't ascertain whether mix 1 or mix 2 was used! <==\n"))
+    cat(paste("\n"))
+    cat(paste("==== Chi-squared test for Mix 1 usage results ==== \n"))
+    print(test.mix1)
+    cat(paste("==== Chi-squared test for Mix 2 usage results ==== \n"))
+    print(test.mix2)
+    return
+  }
+
+  if (hypo.mix1 == TRUE) {
+    cat(paste("\n===> Mix 1 was used <=== \n"))
+  }
+
+  if (hypo.mix2 == TRUE) {
+    cat(paste("\n===> Mix 2 was used <=== \n"))
+  }
+}
+
+readTSV <- function(inputTSV) {
+  df <- read.table(inputTSV, header=TRUE)
+
+  # let's rename the columns so they're easier to use in this script
+  # these were the original column names in the TSV:
+  # 1. 'Re-sort ID'
+  # 2. 'ERCC ID'
+  # 3. 'subgroup'
+  # 4. 'Mix 1 concentration (attomoles/ul)'
+  # 5. 'Mix 2 concentration (attomoles/ul)'
+  # 6. 'label'
+  # 7. 'count'
+
+  newnames <- c(
+      "ReSortID",
+      "ERCCID",
+      "subgroup",
+      "Mix1",
+      "Mix2",
+      "label",
+      "count"
+  )
+
+  colnames(df) <- newnames
+  df$subgroup <- factor(df$subgroup)
+  return(df)
+}
+
+df <- readTSV(opt$data)
+
+mix1DF <- make.MixFrame("Mix1", df)
+mix2DF <- make.MixFrame("Mix2", df)
+
+cat(paste("\n===> Mix1 Summary Stats <=== \n"))
+mix1DF
+cat(paste("\n===> Mix2 Summary Stats <=== \n"))
+mix2DF
+
+test.mixture(mix1DF, mix2DF)
+
+pdf(opt$output)
+r2 <- make.LinearityPlot(df)
+mix.plot(mix1DF, "Mix1")
+mix.plot(mix2DF, "Mix2")
+
+sink(file="/dev/null")
 dev.off()
+sink()
 
-r2 <- paste("R^2 :", count_r_squared, sep=" ")
-cat(paste("\n", "===========", r2, "===========", "\n", sep="\n"))
-cat(paste("See", pdfFile, "for the analysis plots", "\n", sep=" "))
+
+r2_text <- paste("R^2 :", r2, sep=" ")
+cat(paste("===>", r2_text, "<===", "\n", sep=" "))
+
+cat(paste("\nSee", opt$output, "for the analysis plots", "\n", sep=" "))
 
 # signal success and exit
 q(status=0)
+
+#################################
+
+#data = read.delim(inputTSV)
+#
+#data$count = as.numeric(data$count)
+#
+#data$log_concentration = log2(data$concentration)
+#data$log_count         = log2(data$count + 1)
+#
+#
+#pdf(pdfFile)
+#ggplot(data, aes(x=log_concentration)) + geom_histogram()
+#
+#ggplot(data, aes(x=log_count)) + geom_histogram()
+#
+#count_model <- lm(log_count ~ log_concentration, data=data)
+#count_r_squared = summary(count_model)[['r.squared']]
+#
+#ggplot(data, aes(x=log_concentration, y=log_count)
+#       ) + geom_point(aes(color=subgroup)
+#       ) + geom_smooth(method=lm
+#       ) + annotate('text', 5, -3,
+#                    label=paste("R^2 =", count_r_squared, sep=' '))
+#dev.off()
+#
+#r2 <- paste("R^2 :", count_r_squared, sep=" ")
+#cat(paste("\n", "===========", r2, "===========", "\n", sep="\n"))
+#cat(paste("See", pdfFile, "for the analysis plots", "\n", sep=" "))
+#
+## signal success and exit
+#q(status=0)
+
+#> aggregate(df["Mix1"], by=list(Group=df$subgroup), FUN=sum)
+#  Group     Mix1
+#1     A 41406.01
+#2     B 20703.01
+#3     C 20703.01
+#4     D 20703.01
+#> aggregate(df["Mix2"], by=list(Group=df$subgroup), FUN=sum)
+#  Group     Mix2
+#1     A 10351.50
+#2     B 20703.01
+#3     C 31054.51
+#4     D 41406.01
+#> 41406.01 + 20703.01 + 20703.01 + 20703.01
+#[1] 103515
+#> 10351.50 + 20703.01 + 31054.51 + 41406.01
+#[1] 103515
+#> class(aggregate(df["Mix2"], by=list(Group=df$subgroup), FUN=sum))
+#[1] "data.frame"
+#> mix1 <- aggregate(df["Mix1"], by=list(Group=df$subgroup), FUN=sum)
+#> mix2 <- aggregate(df["Mix2"], by=list(Group=df$subgroup), FUN=sum)
+#> mix1$Mix1 / sum(mix1$Mix1)
+#[1] 0.4 0.2 0.2 0.2
+#> mix2$Mix2 / sum(mix2$Mix2)
+#[1] 0.1 0.2 0.3 0.4
+#>
+#> mix1$Probability <- mix1$Mix1 / sum(mix1$Mix1)
+#> mix2$Probability <- mix2$Mix2 / sum(mix2$Mix2)
+#> mix1
+#  Group     Mix1 Probability
+#1     A 41406.01         0.4
+#2     B 20703.01         0.2
+#3     C 20703.01         0.2
+#4     D 20703.01         0.2
+#> mix2
+#  Group     Mix2 Probability
+#1     A 10351.50         0.1
+#2     B 20703.01         0.2
+#3     C 31054.51         0.3
+#4     D 41406.01         0.4
+#> aggregate(df["count"], by=list(AlignmentCounts=df$subgroup), FUN=sum)
+#  AlignmentCounts  count
+#1               A 278722
+#2               B 170081
+#3               C 138932
+#4               D 148281
+#> aggregate(df["Mix2", "count"], by=list(Group=df$subgroup), FUN=sum)
+#Error in aggregate.data.frame(as.data.frame(x), ...) :
+#  arguments must have same length
+#> aggregate(df[c("Mix2", "count")], by=list(Group=df$subgroup), FUN=sum)
+#  Group     Mix2  count
+#1     A 10351.50 278722
+#2     B 20703.01 170081
+#3     C 31054.51 138932
+#4     D 41406.01 148281
+#> aggregate(df[c("Mix1", "count")], by=list(Group=df$subgroup), FUN=sum)
+#  Group     Mix1  count
+#1     A 41406.01 278722
+#2     B 20703.01 170081
+#3     C 20703.01 138932
+#4     D 20703.01 148281
+#> mix1 <- aggregate(df[c("Mix1", "count")], by=list(Group=df$subgroup), FUN=sum)
+#
+#> mix2 <- aggregate(df[c("Mix2", "count")], by=list(Group=df$subgroup), FUN=sum)
+#
+#> mix1$Probability <- mix1$Mix1 / sum(mix1$Mix1)
+#> mix2$Probability <- mix2$Mix2 / sum(mix2$Mix2)
+#> mix1
+#  Group     Mix1  count Probability
+#1     A 41406.01 278722         0.4
+#2     B 20703.01 170081         0.2
+#3     C 20703.01 138932         0.2
+#4     D 20703.01 148281         0.2
+#> sum(mix1$count)
+#[1] 736016
+#> sum(df$count)
+#[1] 736016
+#> mix1$Probability * sum(mix1$count)
+#[1] 294406.4 147203.2 147203.2 147203.2
+#> sum(mix1$Probability * sum(mix1$count))
+#[1] 736016
+#> mix1$ExpectedCounts <- mix1$Probability * sum(mix1$count)
+#> mix1
+#  Group     Mix1  count Probability ExpectedCounts
+#1     A 41406.01 278722         0.4       294406.4
+#2     B 20703.01 170081         0.2       147203.2
+#3     C 20703.01 138932         0.2       147203.2
+#4     D 20703.01 148281         0.2       147203.2
+#> mix1$ExpectedCounts <- mix2$Probability * sum(mix2$count)
+#> mix1$ExpectedCounts <- mix1$Probability * sum(mix1$count)
+#> mix2$ExpectedCounts <- mix2$Probability * sum(mix2$count)
+#> mix1
+#  Group     Mix1  count Probability ExpectedCounts
+#1     A 41406.01 278722         0.4       294406.4
+#2     B 20703.01 170081         0.2       147203.2
+#3     C 20703.01 138932         0.2       147203.2
+#4     D 20703.01 148281         0.2       147203.2
+#> mix2
+#  Group     Mix2  count Probability ExpectedCounts
+#1     A 10351.50 278722         0.1        73601.6
+#2     B 20703.01 170081         0.2       147203.2
+#3     C 31054.51 138932         0.3       220804.8
+#4     D 41406.01 148281         0.4       294406.4
+#> chisq.test(mix1$count, p=mix1$Probability)
+#
+#        Chi-squared test for given probabilities
+#
+#data:  mix1$count
+#X-squared = 4863.81, df = 3, p-value < 2.2e-16
+#
+#> chisq.test(mix2$count, p=mix2$Probability)
+#
+#        Chi-squared test for given probabilities
+#
+#data:  mix2$count
+#X-squared = 678091.5, df = 3, p-value < 2.2e-16
+#
+#> chisq.test(mix2$count, p=mix2$Probability, correct=FALSE)
+#
+#        Chi-squared test for given probabilities
+#
+#data:  mix2$count
+#X-squared = 678091.5, df = 3, p-value < 2.2e-16
+#
+#> chisq.test(mix1$count, p=mix1$Probability, correct=FALSE)
+#
+#        Chi-squared test for given probabilities
+#
+#data:  mix1$count
+#X-squared = 4863.81, df = 3, p-value < 2.2e-16
+#
+#> ((278722-294406.4)^2/294406.4) + ((170081-147203.2)^2/147203.2) + ((138932-147203.2)^2/147203.2) + ((148281-147203.2)^2/147203.2)
+#[1] 4863.81
+#> mix1$count - mix1$ExpectedCounts
+#[1] -15684.4  22877.8  -8271.2   1077.8
+#> mix2$count - mix2$ExpectedCounts
+#[1]  205120.4   22877.8  -81872.8 -146125.4
+#> log(mix1$count) - log(mix1$ExpectedCounts)
+#[1] -0.054746256  0.144460849 -0.057829340  0.007295177
+#> log(mix2$count) - log(mix2$ExpectedCounts)
+#[1]  1.3315481  0.1444608 -0.4632944 -0.6858520
+#> log(mix1$count) - log(mix1$ExpectedCounts)
+#> logMix1Counts <- log(mix1$count)
+#> logMix2Counts <- log(mix2$count)
+#> chisq.test(logMix1Counts, p=mix1$Probability)
+#
+#        Chi-squared test for given probabilities
+#
+#data:  logMix1Counts
+#X-squared = 3.9819, df = 3, p-value = 0.2634
+#
+#> chisq.test(logMix2Counts, p=mix2$Probability)
+#
+#        Chi-squared test for given probabilities
+#
+#data:  logMix2Counts
+#X-squared = 16.2073, df = 3, p-value = 0.001028
+#
+#Warning message:
+#In chisq.test(logMix2Counts, p = mix2$Probability) :
+#  Chi-squared approximation may be incorrect
+#> logMix1Counts <- log2(mix1$count)
+#> logMix2Counts <- log2(mix2$count)
+#> chisq.test(logMix1Counts, p=mix1$Probability)
+#
+#        Chi-squared test for given probabilities
+#
+#data:  logMix1Counts
+#X-squared = 5.7447, df = 3, p-value = 0.1247
+#
+#> chisq.test(logMix2Counts, p=mix2$Probability)
+#
+#        Chi-squared test for given probabilities
+#
+#data:  logMix2Counts
+#X-squared = 23.3822, df = 3, p-value = 3.361e-05
+#
+#>
+#> df3 <- melt(mix2)
+#Using Group as id variables
+#> p2 <- ggplot(df3[df3$variable == "count" | df3$variable == "ExpectedCounts",], aes(x=Group, y=value, fill=variable))
+#> p2 <- p2 + geom_bar(position="dodge", color="black") + scale_fill_brewer(palette="Pastel1")
+#> p2

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -1,47 +1,52 @@
 #!/usr/bin/env Rscript
 
+# L I B R A R I E S ###########################################################
 library(plyr, quietly=TRUE)
 library(reshape, warn.conflicts=FALSE, quiet=TRUE)
 library(ggplot2, quietly=TRUE)
 library(getopt)
 
+# C O N F I G S ###############################################################
 # allow output to be 100 columns wide
 options(width=as.integer(100))
 
-opt <- getopt(
-  matrix(
-    c('data'    ,   'd', 1, "character",
-      'output'  ,   'o', 2, "character",
-      'epsilon' ,   'e', 2, "double",
-      'help'    ,   'h', 0, "logical"),
-    byrow=TRUE, ncol=4
-  )
-);
+# F U N C T I O N S ###########################################################
+process.opts <- function() {
+  opts <- getopt(
+    matrix(
+      c('data'    ,   'd', 1, "character",
+        'output'  ,   'o', 2, "character",
+        'epsilon' ,   'e', 2, "double",
+        'help'    ,   'h', 0, "logical"),
+      byrow=TRUE, ncol=4
+    )
+  );
 
-#help was asked for.
-if ( !is.null(opt$help) ) {
-  #get the script name (only works when invoked with Rscript).
-  self <- commandArgs()[1];
-  #print a friendly message and exit with a non-zero error code
-  cat(paste("Usage: ",self," [-[-help|h]] [-[-data|d] <data.tsv>] [-[-output|o] <output.pdf>] [-[-epsilon|e] <0.01>]\n",sep=""));
-  q(status=1);
+  #help was asked for.
+  if ( !is.null(opts$help) ) {
+    #get the script name (only works when invoked with Rscript).
+    self <- commandArgs()[1];
+    #print a friendly message and exit with a non-zero error code
+    cat(paste("Usage: ",self," [-[-help|h]] [-[-data|d] <data.tsv>] [-[-output|o] <output.pdf>] [-[-epsilon|e] <0.01>]\n",sep=""));
+    q(status=1);
+  }
+
+  if ( is.null(opts$data) ) {
+    #get the script name (only works when invoked with Rscript).
+    cat(paste("Please specify an input data file via the '--data=<data.tsv>' option! \n",sep=""));
+    q(status=1);
+  }
+
+  #set some reasonable defaults for the options
+  if ( is.null(opts$output  ) ) { opts$output  <- 'output.pdf' }
+  if ( is.null(opts$epsilon ) ) { opts$epsilon <- 0.01         }
+
+  #inputTSV <- opts$data
+  #epsilon  <- opts$epsilon
+  #pdfFile  <- opts$output
+  return(opts)
 }
 
-if ( is.null(opt$data) ) {
-  #get the script name (only works when invoked with Rscript).
-  cat(paste("Please specify an input data file via the '--data=<data.tsv>' option! \n",sep=""));
-  q(status=1);
-}
-
-#set some reasonable defaults for the options
- if ( is.null(opt$output  ) ) { opt$output  <- 'output.pdf' }
- if ( is.null(opt$epsilon ) ) { opt$epsilon <- 0.01         }
-
-#inputTSV <- opt$data
-#epsilon  <- opt$epsilon
-#pdfFile  <- opt$output
-
-#################################
 make.LinearityPlot <- function(df) {
   df$count <- as.numeric(df$count)
 
@@ -179,247 +184,39 @@ readTSV <- function(inputTSV) {
   return(df)
 }
 
-df <- readTSV(opt$data)
+main <- function() {
+  opts <- process.opts()
 
-mix1DF <- make.MixFrame("Mix1", df)
-mix2DF <- make.MixFrame("Mix2", df)
+  df <- readTSV(opts$data)
 
-cat(paste("\n===> Mix1 Summary Stats <=== \n"))
-mix1DF
-cat(paste("\n===> Mix2 Summary Stats <=== \n"))
-mix2DF
+  mix1DF <- make.MixFrame("Mix1", df)
+  mix2DF <- make.MixFrame("Mix2", df)
 
-test.mixture(mix1DF, mix2DF)
+  cat(paste("\n===> Mix1 Summary Stats <=== \n"))
+  print(mix1DF)
+  cat(paste("\n===> Mix2 Summary Stats <=== \n"))
+  print(mix2DF)
 
-pdf(opt$output)
-r2 <- make.LinearityPlot(df)
-mix.plot(mix1DF, "Mix1")
-mix.plot(mix2DF, "Mix2")
+  test.mixture(mix1DF, mix2DF)
 
-sink(file="/dev/null")
-dev.off()
-sink()
+  pdf(opts$output)
+  r2 <- make.LinearityPlot(df)
+  mix.plot(mix1DF, "Mix1")
+  mix.plot(mix2DF, "Mix2")
+
+  sink(file="/dev/null")
+  dev.off()
+  sink()
 
 
-r2_text <- paste("R^2 :", r2, sep=" ")
-cat(paste("===>", r2_text, "<===", "\n", sep=" "))
+  r2_text <- paste("R^2 :", r2, sep=" ")
+  cat(paste("===>", r2_text, "<===", "\n", sep=" "))
 
-cat(paste("\nSee", opt$output, "for the analysis plots", "\n", sep=" "))
+  cat(paste("\nSee", opts$output, "for the analysis plots", "\n", sep=" "))
+}
+
+# M A I N #####################################################################
+main()
 
 # signal success and exit
 q(status=0)
-
-#################################
-
-#data = read.delim(inputTSV)
-#
-#data$count = as.numeric(data$count)
-#
-#data$log_concentration = log2(data$concentration)
-#data$log_count         = log2(data$count + 1)
-#
-#
-#pdf(pdfFile)
-#ggplot(data, aes(x=log_concentration)) + geom_histogram()
-#
-#ggplot(data, aes(x=log_count)) + geom_histogram()
-#
-#count_model <- lm(log_count ~ log_concentration, data=data)
-#count_r_squared = summary(count_model)[['r.squared']]
-#
-#ggplot(data, aes(x=log_concentration, y=log_count)
-#       ) + geom_point(aes(color=subgroup)
-#       ) + geom_smooth(method=lm
-#       ) + annotate('text', 5, -3,
-#                    label=paste("R^2 =", count_r_squared, sep=' '))
-#dev.off()
-#
-#r2 <- paste("R^2 :", count_r_squared, sep=" ")
-#cat(paste("\n", "===========", r2, "===========", "\n", sep="\n"))
-#cat(paste("See", pdfFile, "for the analysis plots", "\n", sep=" "))
-#
-## signal success and exit
-#q(status=0)
-
-#> aggregate(df["Mix1"], by=list(Group=df$subgroup), FUN=sum)
-#  Group     Mix1
-#1     A 41406.01
-#2     B 20703.01
-#3     C 20703.01
-#4     D 20703.01
-#> aggregate(df["Mix2"], by=list(Group=df$subgroup), FUN=sum)
-#  Group     Mix2
-#1     A 10351.50
-#2     B 20703.01
-#3     C 31054.51
-#4     D 41406.01
-#> 41406.01 + 20703.01 + 20703.01 + 20703.01
-#[1] 103515
-#> 10351.50 + 20703.01 + 31054.51 + 41406.01
-#[1] 103515
-#> class(aggregate(df["Mix2"], by=list(Group=df$subgroup), FUN=sum))
-#[1] "data.frame"
-#> mix1 <- aggregate(df["Mix1"], by=list(Group=df$subgroup), FUN=sum)
-#> mix2 <- aggregate(df["Mix2"], by=list(Group=df$subgroup), FUN=sum)
-#> mix1$Mix1 / sum(mix1$Mix1)
-#[1] 0.4 0.2 0.2 0.2
-#> mix2$Mix2 / sum(mix2$Mix2)
-#[1] 0.1 0.2 0.3 0.4
-#>
-#> mix1$Probability <- mix1$Mix1 / sum(mix1$Mix1)
-#> mix2$Probability <- mix2$Mix2 / sum(mix2$Mix2)
-#> mix1
-#  Group     Mix1 Probability
-#1     A 41406.01         0.4
-#2     B 20703.01         0.2
-#3     C 20703.01         0.2
-#4     D 20703.01         0.2
-#> mix2
-#  Group     Mix2 Probability
-#1     A 10351.50         0.1
-#2     B 20703.01         0.2
-#3     C 31054.51         0.3
-#4     D 41406.01         0.4
-#> aggregate(df["count"], by=list(AlignmentCounts=df$subgroup), FUN=sum)
-#  AlignmentCounts  count
-#1               A 278722
-#2               B 170081
-#3               C 138932
-#4               D 148281
-#> aggregate(df["Mix2", "count"], by=list(Group=df$subgroup), FUN=sum)
-#Error in aggregate.data.frame(as.data.frame(x), ...) :
-#  arguments must have same length
-#> aggregate(df[c("Mix2", "count")], by=list(Group=df$subgroup), FUN=sum)
-#  Group     Mix2  count
-#1     A 10351.50 278722
-#2     B 20703.01 170081
-#3     C 31054.51 138932
-#4     D 41406.01 148281
-#> aggregate(df[c("Mix1", "count")], by=list(Group=df$subgroup), FUN=sum)
-#  Group     Mix1  count
-#1     A 41406.01 278722
-#2     B 20703.01 170081
-#3     C 20703.01 138932
-#4     D 20703.01 148281
-#> mix1 <- aggregate(df[c("Mix1", "count")], by=list(Group=df$subgroup), FUN=sum)
-#
-#> mix2 <- aggregate(df[c("Mix2", "count")], by=list(Group=df$subgroup), FUN=sum)
-#
-#> mix1$Probability <- mix1$Mix1 / sum(mix1$Mix1)
-#> mix2$Probability <- mix2$Mix2 / sum(mix2$Mix2)
-#> mix1
-#  Group     Mix1  count Probability
-#1     A 41406.01 278722         0.4
-#2     B 20703.01 170081         0.2
-#3     C 20703.01 138932         0.2
-#4     D 20703.01 148281         0.2
-#> sum(mix1$count)
-#[1] 736016
-#> sum(df$count)
-#[1] 736016
-#> mix1$Probability * sum(mix1$count)
-#[1] 294406.4 147203.2 147203.2 147203.2
-#> sum(mix1$Probability * sum(mix1$count))
-#[1] 736016
-#> mix1$ExpectedCounts <- mix1$Probability * sum(mix1$count)
-#> mix1
-#  Group     Mix1  count Probability ExpectedCounts
-#1     A 41406.01 278722         0.4       294406.4
-#2     B 20703.01 170081         0.2       147203.2
-#3     C 20703.01 138932         0.2       147203.2
-#4     D 20703.01 148281         0.2       147203.2
-#> mix1$ExpectedCounts <- mix2$Probability * sum(mix2$count)
-#> mix1$ExpectedCounts <- mix1$Probability * sum(mix1$count)
-#> mix2$ExpectedCounts <- mix2$Probability * sum(mix2$count)
-#> mix1
-#  Group     Mix1  count Probability ExpectedCounts
-#1     A 41406.01 278722         0.4       294406.4
-#2     B 20703.01 170081         0.2       147203.2
-#3     C 20703.01 138932         0.2       147203.2
-#4     D 20703.01 148281         0.2       147203.2
-#> mix2
-#  Group     Mix2  count Probability ExpectedCounts
-#1     A 10351.50 278722         0.1        73601.6
-#2     B 20703.01 170081         0.2       147203.2
-#3     C 31054.51 138932         0.3       220804.8
-#4     D 41406.01 148281         0.4       294406.4
-#> chisq.test(mix1$count, p=mix1$Probability)
-#
-#        Chi-squared test for given probabilities
-#
-#data:  mix1$count
-#X-squared = 4863.81, df = 3, p-value < 2.2e-16
-#
-#> chisq.test(mix2$count, p=mix2$Probability)
-#
-#        Chi-squared test for given probabilities
-#
-#data:  mix2$count
-#X-squared = 678091.5, df = 3, p-value < 2.2e-16
-#
-#> chisq.test(mix2$count, p=mix2$Probability, correct=FALSE)
-#
-#        Chi-squared test for given probabilities
-#
-#data:  mix2$count
-#X-squared = 678091.5, df = 3, p-value < 2.2e-16
-#
-#> chisq.test(mix1$count, p=mix1$Probability, correct=FALSE)
-#
-#        Chi-squared test for given probabilities
-#
-#data:  mix1$count
-#X-squared = 4863.81, df = 3, p-value < 2.2e-16
-#
-#> ((278722-294406.4)^2/294406.4) + ((170081-147203.2)^2/147203.2) + ((138932-147203.2)^2/147203.2) + ((148281-147203.2)^2/147203.2)
-#[1] 4863.81
-#> mix1$count - mix1$ExpectedCounts
-#[1] -15684.4  22877.8  -8271.2   1077.8
-#> mix2$count - mix2$ExpectedCounts
-#[1]  205120.4   22877.8  -81872.8 -146125.4
-#> log(mix1$count) - log(mix1$ExpectedCounts)
-#[1] -0.054746256  0.144460849 -0.057829340  0.007295177
-#> log(mix2$count) - log(mix2$ExpectedCounts)
-#[1]  1.3315481  0.1444608 -0.4632944 -0.6858520
-#> log(mix1$count) - log(mix1$ExpectedCounts)
-#> logMix1Counts <- log(mix1$count)
-#> logMix2Counts <- log(mix2$count)
-#> chisq.test(logMix1Counts, p=mix1$Probability)
-#
-#        Chi-squared test for given probabilities
-#
-#data:  logMix1Counts
-#X-squared = 3.9819, df = 3, p-value = 0.2634
-#
-#> chisq.test(logMix2Counts, p=mix2$Probability)
-#
-#        Chi-squared test for given probabilities
-#
-#data:  logMix2Counts
-#X-squared = 16.2073, df = 3, p-value = 0.001028
-#
-#Warning message:
-#In chisq.test(logMix2Counts, p = mix2$Probability) :
-#  Chi-squared approximation may be incorrect
-#> logMix1Counts <- log2(mix1$count)
-#> logMix2Counts <- log2(mix2$count)
-#> chisq.test(logMix1Counts, p=mix1$Probability)
-#
-#        Chi-squared test for given probabilities
-#
-#data:  logMix1Counts
-#X-squared = 5.7447, df = 3, p-value = 0.1247
-#
-#> chisq.test(logMix2Counts, p=mix2$Probability)
-#
-#        Chi-squared test for given probabilities
-#
-#data:  logMix2Counts
-#X-squared = 23.3822, df = 3, p-value = 3.361e-05
-#
-#>
-#> df3 <- melt(mix2)
-#Using Group as id variables
-#> p2 <- ggplot(df3[df3$variable == "count" | df3$variable == "ExpectedCounts",], aes(x=Group, y=value, fill=variable))
-#> p2 <- p2 + geom_bar(position="dodge", color="black") + scale_fill_brewer(palette="Pastel1")
-#> p2

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.R
@@ -81,8 +81,8 @@ make.MixFrame <- function(mixType, df) {
             FUN=sum)
 
   colnames(mix)[3] <- "AlignmentCounts"
-  mix$Probability <- mix[,mixType] / sum(mix[,mixType])
-  mix$ExpectedCounts <- mix$Probability * sum(mix$AlignmentCounts)
+  mix$ExpectedMixRatios <- mix[,mixType] / sum(mix[,mixType])
+  mix$ExpectedCounts <- mix$ExpectedMixRatios * sum(mix$AlignmentCounts)
   colnames(mix)[2] <- paste("Concentration", mixType, sep="")
 
   return(mix)
@@ -122,7 +122,7 @@ test.mixture <- function(Mix1DF, Mix2DF) {
   p_value_threshold <- 0.05
 
 #  cat(paste("Running Chi-squared test for Mix 1 usage\n"))
-  test.mix1 <- chisq.test(Mix1DF$AlignmentCounts/10000, p=Mix1DF$Probability)
+  test.mix1 <- chisq.test(Mix1DF$AlignmentCounts/10000, p=Mix1DF$ExpectedMixRatios)
 #  print(test.mix1)
 
   if (test.mix1[["p.value"]] < p_value_threshold) {
@@ -130,7 +130,7 @@ test.mixture <- function(Mix1DF, Mix2DF) {
   }
 
 #  cat(paste("Running Chi-squared test for Mix 2 usage\n"))
-  test.mix2 <- chisq.test(Mix2DF$AlignmentCounts/10000, p=Mix2DF$Probability)
+  test.mix2 <- chisq.test(Mix2DF$AlignmentCounts/10000, p=Mix2DF$ExpectedMixRatios)
 #  print(test.mix2)
 
   if (test.mix2[["p.value"]] < p_value_threshold) {

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -86,8 +86,8 @@ sub execute {
     );
 
     $self->index_bam($remapped_bam);
-    my $idxstats = $self->generate_idxstats($remapped_bam);
-    my $tsv = $self->generate_tsvfile($idxstats);
+    my $idxfile = $self->generate_idxstats($remapped_bam);
+    my $tsv = $self->generate_tsvfile($idxfile);
     $self->save_tsv_stats($tsv);
 
     $self->run_analysis_script($tsv);
@@ -382,15 +382,14 @@ sub generate_idxstats {
         skip_if_output_is_present => 0
     );
 
-    my $idxstats_hash_ref = Genome::Model::Tools::Sam::Idxstats->parse_file_into_hashref(
-        "$samtools_idxstats_path"
-    );
-
-    return $idxstats_hash_ref;
+    return $samtools_idxstats_path;
 }
 
 sub generate_tsvfile {
-    my ($self, $idxstats) = @_;
+    my ($self, $idxfile) = @_;
+
+    my $idxstats =
+      Genome::Model::Tools::Sam::Idxstats->parse_file_into_hashref("$idxfile");
 
     my $r_input_file = Genome::Sys->create_temp_file_path();
 

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -22,7 +22,8 @@ class Genome::Model::Tools::Transcriptome::ErccMapUnaligned {
         ercc_fasta_file => {
             is => 'FilePath',
             doc => 'The FASTA format sequence for all ERCC transcripts.',
-            example_values => ['/gscmnt/gc13001/info/model_data/jwalker_scratch/ERCC/ERCC92.fa'],
+            default_value => '/gscmnt/gc13001/info/model_data/jwalker_scratch/ERCC/ERCC92.fa',
+            is_optional => '1',
         },
         ercc_spike_in_file => {
             is => 'FilePath',

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -22,7 +22,7 @@ class Genome::Model::Tools::Transcriptome::ErccMapUnaligned {
         ercc_fasta_file => {
             is => 'FilePath',
             doc => 'The FASTA format sequence for all ERCC transcripts.',
-            default_value => '/gscmnt/gc13001/info/model_data/jwalker_scratch/ERCC/ERCC92.fa',
+            default_value => '/gscmnt/gc9008/info/model_data/2861523156/build0bfc1bd5fcfc474c9db737a520ae109d/appended_sequences.fa',
             is_optional => '1',
         },
         ercc_spike_in_file => {

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -239,7 +239,8 @@ sub display_remapped_alignment_statistics {
     print "\t", '# Unmapped : ', $alignment_counts{'unmapped'}, "\n";
     print "\t", 'Total      : ', $total                       , "\n";
     if ($total != 0) {
-        print "\t", '% Mapped   : ', $alignment_counts{'mapped'}/$total, "\n";
+        my $pct = ($alignment_counts{'mapped'}/$total) * 100;
+        print "\t", '% Mapped   : ', $pct, "\n";
     }
     else {
         print "\t", '% Mapped   : 0', "\n";

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -185,6 +185,10 @@ sub get_bam {
         $bam = $self->get_bam_from_model();
     }
 
+    unless (-e $bam) {
+        die "Couldn't find bam: '$bam' on file system!\n";
+    }
+
     return $bam;
 }
 

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -439,6 +439,10 @@ sub save_tsv_stats {
     my ($self, $tsv) = @_;
 
     my $dst_file = Path::Class::File->new($self->raw_stats_file);
+    if (-e $dst_file) {
+        $self->status_message("Removing an earlier version of '$dst_file'");
+        $dst_file->remove();
+    }
 
     $self->status_message("Saving raw stats to $dst_file");
     Genome::Sys->copy_file("$tsv", "$dst_file");

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -173,6 +173,10 @@ sub get_bam {
             "bam file via '--bam_file' to proceed!\n";
     }
 
+    if ($self->bam_file && $self->model) {
+        die "Specify only ONE '--model' or '--bam-file', NOT both!\n";
+    }
+
     my $bam;
     if ($self->bam_file) {
         $bam = Path::Class::File->new($self->bam_file);

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -110,13 +110,6 @@ sub get_bam_from_build {
           "Didn't find a bam file associated with build %s",
           $self->build->__display_name__
       );
-    $bam = Path::Class::File->new($bam);
-    unless (-e $bam) {
-        my $msg = "Didn't find bam file: '$bam' on file system!";
-        die $self->error_message($msg);
-    }
-    $self->status_message("Using BAM: $bam");
-    $self->bam_file("$bam");
 
     $self->status_message("Using BAM: $bam");
     return $bam;
@@ -174,14 +167,12 @@ sub get_bam {
     }
 
     my $bam;
-    if ($self->bam_file) {
-        $bam = Path::Class::File->new($self->bam_file);
-    }
-    else {
-        $bam = $self->get_bam_from_build();
+
+    unless ($self->bam_file) {
+        $self->bam_file($self->get_bam_from_build());
     }
 
-    unless (-e $bam) {
+    unless (-e $self->bam_file) {
         die $self->error_message("Couldn't find bam: '$bam' on file system!");
     }
 

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -299,13 +299,13 @@ sub generate_tsvfile {
     my $r_input_file = Genome::Sys->create_temp_file_path();
 
     my @headers = (
-        'Re-sort ID',
-        'ERCC ID',
-        'subgroup',
-        'ERCC Mix',
-        'concentration (attomoles/ul)',
-        'label',
-        'count',
+        q{'Re-sort ID'},
+        q{'ERCC ID'},
+        q{'subgroup'},
+        q{'Mix 1 concentration (attomoles/ul)'},
+        q{'Mix 2 concentration (attomoles/ul)'},
+        q{'label'},
+        q{'count'},
     );
 
     my $writer = Genome::Utility::IO::SeparatedValueWriter->create(
@@ -321,18 +321,16 @@ sub generate_tsvfile {
         unless ($ercc_data) {
             die('Missing chromosome: '. $chr);
         }
-        my $concentration = $ercc_data->{'concentration in Mix 1 (attomoles/ul)'};
-        if ($self->ercc_spike_in_mix == 2) {
-            $concentration = $ercc_data->{'concentration in Mix 2 (attomoles/ul)'};
-        }
+        my $mix1_concentration = $ercc_data->{'concentration in Mix 1 (attomoles/ul)'};
+        my $mix2_concentration = $ercc_data->{'concentration in Mix 2 (attomoles/ul)'};
         my %data = (
-            'Re-sort ID' => $ercc_data->{'Re-sort ID'},
-            'ERCC ID' => $ercc_data->{'ERCC ID'},
-            'subgroup' => $ercc_data->{'subgroup'},
-            'ERCC Mix' => $self->ercc_spike_in_mix,
-            'concentration (attomoles/ul)' => $concentration,
-            'label' => 'na',
-            'count' => $idxstats->{$chr}{map_read_ct},
+            q{'Re-sort ID'} => $ercc_data->{'Re-sort ID'},
+            q{'ERCC ID'} => $ercc_data->{'ERCC ID'},
+            q{'subgroup'} => $ercc_data->{'subgroup'},
+            q{'Mix 1 concentration (attomoles/ul)'} => $mix1_concentration,
+            q{'Mix 2 concentration (attomoles/ul)'} => $mix2_concentration,
+            q{'label'} => 'na',
+            q{'count'} => $idxstats->{$chr}{map_read_ct},
         );
         $writer->write_one(\%data);
     }

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -181,8 +181,8 @@ sub get_bam {
         $bam = $self->get_bam_from_build();
     }
 
-    unless (-e $self->bam_file) {
-        die "Couldn't find bam: '$self->bam_file' on file system!\n";
+    unless (-e $bam) {
+        die $self->error_message("Couldn't find bam: '$bam' on file system!");
     }
 
     return Path::Class::File->new($self->bam_file);
@@ -275,8 +275,9 @@ sub create_ercc_bowtie_index {
     my $search_pattern = $index_dir->file('ERCC.*');
     my @index_files = glob("$search_pattern");
     unless (@index_files == 6) {
-        die "[err] Didn't create the proper bowtie2 index file set in ",
-          "$index_dir !\n";
+        my $msg = "Didn't create the proper bowtie2 index file set in "
+                  .  "$index_dir !\n";
+        die $self->error_message($msg);
     }
 
     return $index_dir->file('ERCC');
@@ -343,10 +344,14 @@ sub generate_remapped_bam {
     );
 
     $stream->execute
-      or die "[err] Trouble executing remapped bam stream command!\n";
+      or die $self->error_message(
+           "Trouble executing remapped bam stream command!"
+       );
 
     unless (-e $remapped_bam_path) {
-        die "[err] Couldn't find the remapped bam: $remapped_bam_path \n!";
+        die $self->error_message(
+            "Couldn't find the remapped bam: $remapped_bam_path!"
+        );
     }
 
     return $remapped_bam_path;
@@ -419,7 +424,7 @@ sub generate_tsvfile {
     for my $chr (keys %{$idxstats}) {
         my $ercc_data = $ercc_control{$chr};
         unless ($ercc_data) {
-            die('Missing chromosome: '. $chr);
+            die $self->error_messasge('Missing chromosome: '. $chr);
         }
         my $mix1_concentration = $ercc_data->{'concentration in Mix 1 (attomoles/ul)'};
         my $mix2_concentration = $ercc_data->{'concentration in Mix 2 (attomoles/ul)'};

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -28,7 +28,7 @@ class Genome::Model::Tools::Transcriptome::ErccMapUnaligned {
         ercc_spike_in_file => {
             is => 'FilePath',
             doc => 'The control analysis file provided by Agilent for the ERCC spike-in.',
-            default_value => '/gscmnt/gc13001/info/model_data/jwalker_scratch/ERCC/ERCC_Controls_Analysis.txt',
+            default_value => '/gscmnt/gc13025/info/RNASeq/ERCC/metadata/ERCC_Controls_Analysis-v1.txt',
             is_optional => '1',
         },
         samtools_version => {

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -28,12 +28,8 @@ class Genome::Model::Tools::Transcriptome::ErccMapUnaligned {
         ercc_spike_in_file => {
             is => 'FilePath',
             doc => 'The control analysis file provided by Agilent for the ERCC spike-in.',
-            example_values => ['/gscmnt/gc13001/info/model_data/jwalker_scratch/ERCC/ERCC_Controls_Analysis.txt'],
-        },
-        ercc_spike_in_mix => {
-            is => 'Integer',
-            doc => 'The name of the Life Technologies ERCC spike-in mixture.',
-            valid_values => [ '1', '2'],
+            default_value => '/gscmnt/gc13001/info/model_data/jwalker_scratch/ERCC/ERCC_Controls_Analysis.txt',
+            is_optional => '1',
         },
         samtools_version => {
             is => 'Text',

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -34,21 +34,18 @@ class Genome::Model::Tools::Transcriptome::ErccMapUnaligned {
         samtools_version => {
             is => 'Text',
             doc => 'The version of samtools to run analysis.',
-            example_values => ['1.2'],
             default_value => '1.2',
             is_optional => '1',
         },
         samtools_max_mem => {
             is => 'Integer',
             doc => 'The max memory required by samtools (in bytes).',
-            example_values => ['14000000000'],
             default_value => '14000000000',
             is_optional => '1',
         },
         bowtie2_version => {
             is => 'Text',
             doc => 'The version of bwa to run analysis.',
-            example_values => ['2.1.0'],
             default_value => '2.1.0',
             is_optional => '1',
         },

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
@@ -18,8 +18,8 @@ SKIP: {
          1;
     #my $model = '39f7c31b4e28432f8cbee18c8a391d06'; # GRCh37 only align (Mix 2)
     #my $model = 'f8e2cf3aa1fe4e6da97370d8d7dd4f5a'; # GRCh37+ERCC align (Mix 2)
-    #my $model = '46fccb0ce8334d06bb09a26dd9903f9f'; # Heather's Model (1st)
-    my $model = '576d3c68ae574779b92052daead2fa2d'; # Heather's Model (2nd)
+    #my $model = '46fccb0ce8334d06bb09a26dd9903f9f'; # Heather's 1st Model [NO ERCC]
+    my $model = '576d3c68ae574779b92052daead2fa2d'; # Heather's 2nd Model [Mix1]
     my $ercc_dir = Path::Class::Dir->new(
         '/gscmnt/gc13001/info/',
         'model_data/jwalker_scratch/ERCC/remap'

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
@@ -15,7 +15,7 @@ use_ok('Genome::Model::Tools::Transcriptome::ErccMapUnaligned');
 
 SKIP: {
     skip "this is a long-running test & requires a human to view its outputs",
-         3;
+         1;
     #my $model = '39f7c31b4e28432f8cbee18c8a391d06'; # GRCh37 only align (Mix 2)
     #my $model = 'f8e2cf3aa1fe4e6da97370d8d7dd4f5a'; # GRCh37+ERCC align (Mix 2)
     #my $model = '46fccb0ce8334d06bb09a26dd9903f9f'; # Heather's Model (1st)
@@ -26,7 +26,7 @@ SKIP: {
     );
 
     run_analysis($model, $ercc_dir);
-#}
+}
 
 done_testing();
 

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
@@ -13,20 +13,21 @@ use Test::More;
 #This is a bare minimum test that just compiles Perl and the UR class.
 use_ok('Genome::Model::Tools::Transcriptome::ErccMapUnaligned');
 
-SKIP: {
-    skip "this is a long-running test & requires a human to view its outputs",
-         1;
+#SKIP: {
+#    skip "this is a long-running test & requires a human to view its outputs",
+#         2;
     #my $model = '39f7c31b4e28432f8cbee18c8a391d06'; # GRCh37 only align (Mix 2)
     #my $model = 'f8e2cf3aa1fe4e6da97370d8d7dd4f5a'; # GRCh37+ERCC align (Mix 2)
-    #my $model = '46fccb0ce8334d06bb09a26dd9903f9f'; # Heather's 1st Model [NO ERCC]
-    my $model = '576d3c68ae574779b92052daead2fa2d'; # Heather's 2nd Model [Mix1]
+    my $model = '46fccb0ce8334d06bb09a26dd9903f9f'; # Heather's 1st Model [NO ERCC]
+    #my $model = '576d3c68ae574779b92052daead2fa2d'; # Heather's 2nd Model [Mix1]
     my $ercc_dir = Path::Class::Dir->new(
         '/gscmnt/gc13001/info/',
         'model_data/jwalker_scratch/ERCC/remap'
     );
 
-    run_analysis($model, $ercc_dir);
-}
+    my $build = get_build($model);
+    run_analysis($build, $ercc_dir);
+#}
 
 done_testing();
 
@@ -34,14 +35,25 @@ done_testing();
 sub run_analysis {
     my ($model, $ercc_dir) = @_;
     my $tool = Genome::Model::Tools::Transcriptome::ErccMapUnaligned->create(
-        model           => $model,
+        build           => $model,
         ercc_fasta_file => $ercc_dir->file('ERCC92.fa')->stringify,
         ercc_spike_in_file =>
           $ercc_dir->file('ERCC_Controls_Analysis.txt')->stringify,
-        ercc_spike_in_mix => 2,
     );
     ok($tool, 'Got a G::M::T::Transcriptome::ErccMapUnaligned instance');
     $tool->execute or die "[err] Trouble running tool!\n";
+}
+
+sub get_build {
+    my $model_id = shift;
+    my $model = Genome::Model->get(id => $model_id);
+    my $build = $model->last_succeeded_build;
+    unless ($build) {
+        ok($build, 'got a build: ' . $build->id);
+        done_testing();
+        exit(0);
+    }
+    return $build;
 }
 
 sub get_bam {

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
@@ -16,8 +16,10 @@ use_ok('Genome::Model::Tools::Transcriptome::ErccMapUnaligned');
 SKIP: {
     skip "this is a long-running test & requires a human to view its outputs",
          3;
-    my $model = '39f7c31b4e28432f8cbee18c8a391d06'; # GRCh37 only align (Mix 2)
+    #my $model = '39f7c31b4e28432f8cbee18c8a391d06'; # GRCh37 only align (Mix 2)
     #my $model = 'f8e2cf3aa1fe4e6da97370d8d7dd4f5a'; # GRCh37+ERCC align (Mix 2)
+    #my $model = '46fccb0ce8334d06bb09a26dd9903f9f'; # Heather's Model (1st)
+    my $model = '576d3c68ae574779b92052daead2fa2d'; # Heather's Model (2nd)
     my $ercc_dir = Path::Class::Dir->new(
         '/gscmnt/gc13001/info/',
         'model_data/jwalker_scratch/ERCC/remap'

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
@@ -13,9 +13,9 @@ use Test::More;
 #This is a bare minimum test that just compiles Perl and the UR class.
 use_ok('Genome::Model::Tools::Transcriptome::ErccMapUnaligned');
 
-#SKIP: {
-#    skip "this is a long-running test & requires a human to view its outputs",
-#         2;
+SKIP: {
+    skip "this is a long-running test & requires a human to view its outputs",
+         2;
     #my $model = '39f7c31b4e28432f8cbee18c8a391d06'; # GRCh37 only align (Mix 2)
     #my $model = 'f8e2cf3aa1fe4e6da97370d8d7dd4f5a'; # GRCh37+ERCC align (Mix 2)
     my $model = '46fccb0ce8334d06bb09a26dd9903f9f'; # Heather's 1st Model [NO ERCC]
@@ -27,7 +27,7 @@ use_ok('Genome::Model::Tools::Transcriptome::ErccMapUnaligned');
 
     my $build = get_build($model);
     run_analysis($build, $ercc_dir);
-#}
+}
 
 done_testing();
 

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
@@ -25,17 +25,16 @@ SKIP: {
         'model_data/jwalker_scratch/ERCC/remap'
     );
 
-    my $bam = get_bam($model);
-    run_analysis($bam, $ercc_dir);
-}
+    run_analysis($model, $ercc_dir);
+#}
 
 done_testing();
 
 # S U B R O U T I N E S #######################################################
 sub run_analysis {
-    my ($bam, $ercc_dir) = @_;
+    my ($model, $ercc_dir) = @_;
     my $tool = Genome::Model::Tools::Transcriptome::ErccMapUnaligned->create(
-        bam_file        => $bam,
+        model           => $model,
         ercc_fasta_file => $ercc_dir->file('ERCC92.fa')->stringify,
         ercc_spike_in_file =>
           $ercc_dir->file('ERCC_Controls_Analysis.txt')->stringify,

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.t
@@ -36,7 +36,6 @@ sub run_analysis {
     my ($model, $ercc_dir) = @_;
     my $tool = Genome::Model::Tools::Transcriptome::ErccMapUnaligned->create(
         build           => $model,
-        ercc_fasta_file => $ercc_dir->file('ERCC92.fa')->stringify,
         ercc_spike_in_file =>
           $ercc_dir->file('ERCC_Controls_Analysis.txt')->stringify,
     );


### PR DESCRIPTION
This is "Part 2" of a 2-part introduction of a RNASeq quality control tool to address a need mentioned in BIO-1345.  [Part 1][1] was focused on getting the tool infrastructure and plumbing setup.  Part 2 is focused on the analysis being done and what kind of inputs and outputs the end user will need to supply and observe respectively.

## High-Level Summary of Perl Script Changes:

* A user must supply either a model ID, or a specific BAM file path, but not both.
* A number of required input parameters have been changed to optional and sensible default values have been placed for them.
* There are two specific files created by the tool that the end-user will notice: a PDF file containing analysis plots and a TSV file containing the raw data used to make the PDF file.  Both these file names are auto-generated by what the user supplied as inputs.
* The contents and structure of TSV file was changed for the R script.


## High-Level Summary of R Script Changes:

* Apply some software-engineering to the script.  Everything is modularized into functions.
* Introduce a [goodness of fit test][2] to evaluate which ERCC Mixture (Mix 1 or 2) was used in the RNASeq dataset.
* Remove 2 kinds of plots used in Part 1.  They were uninformative.
* Add 2 new "observed vs expected" plots for ERCC Mixtures 1 and 2.  They let the end-user do a [goodness of fit][2] by their own eyes.
* Add titles and axis labels on all the plots.
* Display some useful alignment summary table statistics for the end user.
* Tried to minimize the number of extraneous status & warnings messages issued by R.

[1]: https://github.com/genome/genome/pull/557
[2]: http://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test