### PR TITLE
Set tmp and mem requests for DV2 dispatchers

### DIFF
--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/DetectVariants.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/DetectVariants.pm
@@ -14,7 +14,7 @@ sub lsf_queue {
 }
 
 sub bsub_rusage {
-    return "-R 'select[tmp>4000] rusage[tmp=4000]'";
+    return "-R 'select[tmp>4000 && mem>600] rusage[tmp=4000,mem=600]' -M 600000 ";
 }
 
 sub execute{

--- a/lib/perl/Genome/Model/SomaticValidation/Command/DetectVariants.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/DetectVariants.pm
@@ -35,7 +35,7 @@ class Genome::Model::SomaticValidation::Command::DetectVariants{
             default => $ENV{GENOME_LSF_QUEUE_BUILD_WORKER},
         },
         lsf_resource => {
-            default => "-R 'select[mem>600] rusage[mem=600]' -M 600000",
+            default => "-R 'select[tmp>4000 && mem>600] rusage[tmp=4000,mem=600]' -M 600000",
         },
     ],
     #specific things used by the final process-validation script

--- a/lib/perl/Genome/Model/SomaticValidation/Command/DetectVariants.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/DetectVariants.pm
@@ -34,6 +34,9 @@ class Genome::Model::SomaticValidation::Command::DetectVariants{
         lsf_queue => {
             default => $ENV{GENOME_LSF_QUEUE_BUILD_WORKER},
         },
+        lsf_resource => {
+            default => "-R 'select[mem>600] rusage[mem=600]' -M 600000",
+        },
     ],
     #specific things used by the final process-validation script
     has_output_optional => [

--- a/lib/perl/Genome/Model/SomaticVariation/Command/DetectVariants.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/DetectVariants.pm
@@ -22,6 +22,9 @@ class Genome::Model::SomaticVariation::Command::DetectVariants{
         lsf_queue => {
             default => $ENV{GENOME_LSF_QUEUE_BUILD_WORKER},
         },
+        lsf_resource => {
+            default => "-R 'select[mem>600] rusage[mem=600]' -M 600000",
+        },
     ],
 };
 

--- a/lib/perl/Genome/Model/SomaticVariation/Command/DetectVariants.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/DetectVariants.pm
@@ -23,7 +23,7 @@ class Genome::Model::SomaticVariation::Command::DetectVariants{
             default => $ENV{GENOME_LSF_QUEUE_BUILD_WORKER},
         },
         lsf_resource => {
-            default => "-R 'select[mem>600] rusage[mem=600]' -M 600000",
+            default => "-R 'select[tmp>4000 && mem>600] rusage[tmp=4000,mem=600]' -M 600000",
         },
     ],
 };


### PR DESCRIPTION
@jasonwalker80 has been looking at resource usage, and noticed that these dispatchers used the default 4 GB memory request but in reality used only about 400 MB.  This PR sets an upper bound of 600 MB.

This also adds a temp space request to the Somatic pipelines to match the RefAlign request, since they do use some.