### PR TITLE
re-enable Abyss.t

### DIFF
--- a/lib/perl/Genome/Model/Build/DeNovoAssembly/Abyss.t
+++ b/lib/perl/Genome/Model/Build/DeNovoAssembly/Abyss.t
@@ -20,8 +20,6 @@ if (Genome::Config->arch_os ne 'x86_64') {
     plan skip_all => 'requires 64-bit machine';
 }
 
-plan skip_all => 'causes timeout on pd queues';
-
 use_ok('Genome::Model::Build::DeNovoAssembly::Abyss') or die;
 
 my $base_dir = $ENV{GENOME_TEST_INPUTS} . '/Genome-Model/DeNovoAssembly';


### PR DESCRIPTION
I previously disabled this test because I thought the production blades had a
problem running it but I've been unable to reproduce the problem locally.

[AR-953][]

[AR-953]: https://jira.gsc.wustl.edu/browse/AR-953