### PR TITLE
Match -M to actual resource requests.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -318,7 +318,7 @@ sub required_arch_os {
 
 sub required_rusage {
     # override in subclasses
-    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 1610612736";
+    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";
     ''
 }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Maq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Maq.pm
@@ -29,7 +29,7 @@ sub required_arch_os {
 }
 
 sub required_rusage { 
-    "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 1610612736";
+    "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";
 }
 
 sub extra_metrics {

--- a/lib/perl/Genome/InstrumentData/IntermediateAlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/IntermediateAlignmentResult.pm
@@ -127,7 +127,7 @@ sub required_arch_os {
 
 sub required_rusage { 
     # override in subclasses
-    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 1610612736";
+    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";
     ''
 }
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -71,7 +71,7 @@ sub __display_name__ {
 
 sub required_rusage {
     # override in subclasses
-    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 1610612736";
+    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";
     ''
 }
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -81,7 +81,7 @@ sub __display_name__ {
 
 sub required_rusage {
     # override in subclasses
-    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 1610612736";
+    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";
     ''
 }
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/RtgSnp.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/RtgSnp.pm
@@ -11,7 +11,7 @@ class Genome::Model::Tools::DetectVariants2::RtgSnp {
     is => ['Genome::Model::Tools::DetectVariants2::Detector'],
     has_param => [
         lsf_resource => {
-            default => "-R 'select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]' -M 1610612736",
+            default => "-R 'select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]' -M 16000000",
         }
     ],
     has => [

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Samtools.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Samtools.pm
@@ -8,7 +8,7 @@ class Genome::Model::Tools::DetectVariants2::Samtools {
     is => ['Genome::Model::Tools::DetectVariants2::Detector'],
     has_param => [
         lsf_resource => {
-            default => "-R 'select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]' -M 1610612736",
+            default => "-R 'select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]' -M 16000000",
         }
     ],
     has_optional => [

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Varscan.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Varscan.pm
@@ -16,7 +16,7 @@ class Genome::Model::Tools::DetectVariants2::Varscan {
     ],
     has_param => [
         lsf_resource => {
-            default => "-R 'select[ncpus>=2] span[hosts=1] rusage[mem=16000]' -M 1610612736 -n 2",
+            default => "-R 'select[ncpus>=2] span[hosts=1] rusage[mem=16000]' -M 16000000 -n 2",
         }
     ],
 };

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/VarscanSomatic.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/VarscanSomatic.pm
@@ -16,7 +16,7 @@ class Genome::Model::Tools::DetectVariants2::VarscanSomatic {
     ],
     has_param => [
         lsf_resource => {
-            default => "-R 'select[ncpus>=3] span[hosts=1] rusage[mem=16000]' -M 1610612736 -n 3",
+            default => "-R 'select[ncpus>=3] span[hosts=1] rusage[mem=16000]' -M 16000000 -n 3",
         },
     ],
 };

--- a/lib/perl/Genome/Model/Tools/Sam/Pileup.pm
+++ b/lib/perl/Genome/Model/Tools/Sam/Pileup.pm
@@ -51,7 +51,7 @@ class Genome::Model::Tools::Sam::Pileup {
     ],
     has_param => [
         lsf_resource => {
-            default => "-R 'select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]' -M 1610612736",
+            default => "-R 'select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]' -M 16000000",
         }
     ],
 };

--- a/lib/perl/Genome/Model/Tools/Vcf/CreateCrossSampleVcf/Pileup.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/CreateCrossSampleVcf/Pileup.pm
@@ -35,7 +35,7 @@ class Genome::Model::Tools::Vcf::CreateCrossSampleVcf::Pileup {
     ],
     has_param => [
         lsf_resource => {
-            default => "-R 'select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]' -M 1610612736",
+            default => "-R 'select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]' -M 16000000",
         }
     ],
 };


### PR DESCRIPTION
Some bad requests were copy+pasted around over time... I found a copy of this `-M` limit in a version of the Samtools command from 2009.