### PR TITLE
Picard classnames

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.t
@@ -16,6 +16,7 @@ use Genome::Test::Factory::SoftwareResult::User;
 
 my $TEST_BWA_VERSION = '0.7.10';
 my $TEST_SAMTOOLS_VERSION = '0.1.19';
+my $TEST_PICARD_VERSION = '1.113';
 my $samtools_path = Genome::Model::Tools::Sam->path_for_samtools_version($TEST_SAMTOOLS_VERSION);
 
 my $bam_path = $ENV{GENOME_TEST_INPUTS} . '/Genome-InstrumentData-AlignmentResult-Bwa/input.bam';
@@ -154,6 +155,7 @@ sub make_alignment_result {
         aligner_name => $aligner_name,
         aligner_version => $TEST_BWA_VERSION,
         samtools_version => $TEST_SAMTOOLS_VERSION,
+        picard_version => $TEST_PICARD_VERSION,
         aligner_params => $bwa_params,
         _user_data_for_nested_results => $result_users,
     );

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -339,6 +339,11 @@ sub run_java_vm {
 sub create {
     my $class = shift;
     my $self = $class->SUPER::create(@_);
+
+    if (not defined $self->use_version) {
+        die $self->error_message('Cannot pass undef to Picard::use_version');
+    }
+
     unless ($self->temp_directory) {
         my $base_temp_directory = Genome::Sys->base_temp_directory;
         my $temp_dir = File::Temp::tempdir($base_temp_directory .'/Picard-XXXX', CLEANUP => 1);

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -341,7 +341,8 @@ sub create {
     my $self = $class->SUPER::create(@_);
 
     if (not defined $self->use_version) {
-        die $self->error_message('Cannot pass undef to Picard::use_version');
+        warn $self->warning_message('Should not pass undef to Picard::use_version');
+        $self->use_version($PICARD_DEFAULT);
     }
 
     unless ($self->temp_directory) {

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -207,11 +207,32 @@ sub version_compare {
     return _parsed_version($a) <=> _parsed_version($b);
 }
 
+# convenience methods for version compare
+sub version_older_than {
+    my ($self, $version) = @_;
+    return $self->version_compare($self->use_version, $version) < 0;
+}
+
+sub version_newer_than {
+    my ($self, $version) = @_;
+    return $self->version_compare($self->use_version, $version) > 0;
+}
+
+sub version_at_most {
+    my ($self, $version) = @_;
+    return $self->version_compare($self->use_version, $version) <= 0;
+}
+
+sub version_at_least {
+    my ($self, $version) = @_;
+    return $self->version_compare($self->use_version, $version) >= 0;
+}
+
 # die if $self->use_version is less than the $min_version argument passed here
 sub enforce_minimum_version {
     my ($self, $min_version) = @_;
 
-    if ($self->version_compare($self->use_version, $min_version) < 0) {
+    if ($self->version_older_than($min_version)) {
         confess sprintf "This module requires picard version >= %s (%s requested)",
                 $min_version, $self->use_version;
     }

--- a/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
@@ -32,8 +32,13 @@ sub help_detail {
 EOS
 }
 
-sub _jar_name { 'BamIndexStats.jar' }
-sub _java_class_name { 'net.sf.picard.sam.BamIndexStats' }
+sub _jar_name {
+    return 'BamIndexStats.jar';
+}
+
+sub _java_class_name {
+    return 'net.sf.picard.sam.BamIndexStats';
+}
 
 sub _redirects {
     my $self = shift;

--- a/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
@@ -37,7 +37,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard sam BamIndexStats);
+    return qw(picard sam BamIndexStats);
 }
 
 sub _redirects {

--- a/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
@@ -36,8 +36,8 @@ sub _jar_name {
     return 'BamIndexStats.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.sam.BamIndexStats';
+sub _java_class {
+    return qw(net sf picard sam BamIndexStats);
 }
 
 sub _redirects {

--- a/lib/perl/Genome/Model/Tools/Picard/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/Base.pm
@@ -31,7 +31,7 @@ sub _java_class {
 sub _java_class_name {
     my $self = shift;
     my @class = $self->_java_class;
-    if ($self->version_compare($self->use_version, '1.114') < 0) {
+    if ($self->version_older_than('1.114')) {
         unshift @class, qw(net sf);
     }
     return join '.', @class;

--- a/lib/perl/Genome/Model/Tools/Picard/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/Base.pm
@@ -22,9 +22,15 @@ sub _jar_path {
     return File::Spec->catfile($self->picard_path, $self->_jar_name);
 }
 
-# java class name within the jar to run (e.g., 'net.sf.picard.sam.CleanSam')
+# Java class as an array (e.g., qw(picard sam SortSam))
+sub _java_class {
+    confess "sub _java_class must be overridden in child class";
+}
+
+# Java class name within the jar to run (e.g., 'net.sf.picard.sam.CleanSam')
 sub _java_class_name {
-    confess "sub _java_class_name must be overridden in child class";
+    my $self = shift;
+    return join '.', $self->_java_class;
 }
 
 # picard params should be 'inputs' and also have picard_param_name defined

--- a/lib/perl/Genome/Model/Tools/Picard/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/Base.pm
@@ -27,10 +27,14 @@ sub _java_class {
     confess "sub _java_class must be overridden in child class";
 }
 
-# Java class name within the jar to run (e.g., 'net.sf.picard.sam.CleanSam')
+# Handles assembly of correct class name
 sub _java_class_name {
     my $self = shift;
-    return join '.', $self->_java_class;
+    my @class = $self->_java_class;
+    if ($self->version_compare($self->use_version, '1.114') < 0) {
+        unshift @class, qw(net sf);
+    }
+    return join '.', @class;
 }
 
 # picard params should be 'inputs' and also have picard_param_name defined
@@ -146,11 +150,6 @@ sub build_cmdline_string {
         $self->_jar_path,
         $self->_java_class_name,
         join(" ", $self->_cmdline_args);
-
-    # hack to workaround premature release of 1.123 with altered classnames
-    if ($java_vm_cmd =~ /picard-tools.?1\.123/) {
-        $java_vm_cmd =~ s/net\.sf\.picard\./picard./;
-    }
 
     my $redirects = $self->_redirects;
     $java_vm_cmd = join(" ", $java_vm_cmd, $redirects) if $redirects;

--- a/lib/perl/Genome/Model/Tools/Picard/BedToIntervalList.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BedToIntervalList.pm
@@ -40,8 +40,13 @@ Converts a BED file to an Picard Interval List.
 EOS
 }
 
-sub _jar_name { 'BedToIntervalList.jar' }
-sub _java_class_name { 'picard.util.BedToIntervalList' }
+sub _jar_name {
+    return 'BedToIntervalList.jar';
+}
+
+sub _java_class_name {
+    return 'picard.util.BedToIntervalList';
+}
 
 sub _shellcmd_extra_params {
     my $self = shift;

--- a/lib/perl/Genome/Model/Tools/Picard/BedToIntervalList.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BedToIntervalList.pm
@@ -44,8 +44,8 @@ sub _jar_name {
     return 'BedToIntervalList.jar';
 }
 
-sub _java_class_name {
-    return 'picard.util.BedToIntervalList';
+sub _java_class {
+    return qw(picard util BedToIntervalList);
 }
 
 sub _shellcmd_extra_params {

--- a/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
@@ -39,7 +39,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard sam BuildBamIndex);
+    return qw(picard sam BuildBamIndex);
 }
 
 sub _validate_params {

--- a/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
@@ -38,8 +38,8 @@ sub _jar_name {
     return 'BuildBamIndex.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.sam.BuildBamIndex';
+sub _java_class {
+    return qw(net sf picard sam BuildBamIndex);
 }
 
 sub _validate_params {

--- a/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
@@ -35,7 +35,6 @@ EOS
 }
 
 sub _jar_name {
-    my $self = shift;
     return 'BuildBamIndex.jar';
 }
 

--- a/lib/perl/Genome/Model/Tools/Picard/CalculateHsMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CalculateHsMetrics.pm
@@ -71,7 +71,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard analysis directed CalculateHsMetrics);
+    return qw(picard analysis directed CalculateHsMetrics);
 }
 
 sub _shellcmd_extra_params {

--- a/lib/perl/Genome/Model/Tools/Picard/CalculateHsMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CalculateHsMetrics.pm
@@ -90,7 +90,7 @@ sub _shellcmd_extra_params {
 sub _validate_params {
     my $self = shift;
 
-    if ($self->bait_set_name && $self->version_compare($self->use_version, '1.52') <= 0) {
+    if ($self->bait_set_name && $self->version_at_most('1.52')) {
         $self->warning_message(
             sprintf 'bait_set_name is not compatible with Picard version %s, ignoring.',
                 $self->use_version

--- a/lib/perl/Genome/Model/Tools/Picard/CalculateHsMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CalculateHsMetrics.pm
@@ -70,8 +70,8 @@ sub _jar_name {
     return 'CalculateHsMetrics.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.analysis.directed.CalculateHsMetrics';
+sub _java_class {
+    return qw(net sf picard analysis directed CalculateHsMetrics);
 }
 
 sub _shellcmd_extra_params {

--- a/lib/perl/Genome/Model/Tools/Picard/CleanSam.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CleanSam.pm
@@ -40,7 +40,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard sam CleanSam);
+    return qw(picard sam CleanSam);
 }
 
 sub _validate_params {

--- a/lib/perl/Genome/Model/Tools/Picard/CleanSam.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CleanSam.pm
@@ -39,8 +39,8 @@ sub _jar_name {
     return 'CleanSam.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.sam.CleanSam';
+sub _java_class {
+    return qw(net sf picard sam CleanSam);
 }
 
 sub _validate_params {

--- a/lib/perl/Genome/Model/Tools/Picard/CollectAlignmentSummaryMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectAlignmentSummaryMetrics.pm
@@ -81,7 +81,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard analysis CollectAlignmentSummaryMetrics);
+    return qw(picard analysis CollectAlignmentSummaryMetrics);
 }
 
 sub _metric_header_as_key {

--- a/lib/perl/Genome/Model/Tools/Picard/CollectAlignmentSummaryMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectAlignmentSummaryMetrics.pm
@@ -80,8 +80,8 @@ sub _jar_name {
     return 'CollectAlignmentSummaryMetrics.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.analysis.CollectAlignmentSummaryMetrics';
+sub _java_class {
+    return qw(net sf picard analysis CollectAlignmentSummaryMetrics);
 }
 
 sub _metric_header_as_key {

--- a/lib/perl/Genome/Model/Tools/Picard/CollectGcBiasMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectGcBiasMetrics.pm
@@ -84,8 +84,8 @@ sub _jar_name {
     return 'CollectGcBiasMetrics.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.analysis.CollectGcBiasMetrics';
+sub _java_class {
+    return qw(net sf picard analysis CollectGcBiasMetrics);
 }
 
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/CollectGcBiasMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectGcBiasMetrics.pm
@@ -85,7 +85,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard analysis CollectGcBiasMetrics);
+    return qw(picard analysis CollectGcBiasMetrics);
 }
 
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/CollectGcBiasMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectGcBiasMetrics.pm
@@ -80,7 +80,12 @@ sub help_detail {
 EOS
 }
 
-sub _jar_name { 'CollectGcBiasMetrics.jar' }
-sub _java_class_name { 'net.sf.picard.analysis.CollectGcBiasMetrics' }
+sub _jar_name {
+    return 'CollectGcBiasMetrics.jar';
+}
+
+sub _java_class_name {
+    return 'net.sf.picard.analysis.CollectGcBiasMetrics';
+}
 
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/CollectInsertSizeMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectInsertSizeMetrics.pm
@@ -67,7 +67,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard analysis CollectInsertSizeMetrics);
+    return qw(picard analysis CollectInsertSizeMetrics);
 }
 
 sub _metric_header_as_key {

--- a/lib/perl/Genome/Model/Tools/Picard/CollectInsertSizeMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectInsertSizeMetrics.pm
@@ -66,8 +66,8 @@ sub _jar_name {
     return 'CollectInsertSizeMetrics.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.analysis.CollectInsertSizeMetrics';
+sub _java_class {
+    return qw(net sf picard analysis CollectInsertSizeMetrics);
 }
 
 sub _metric_header_as_key {

--- a/lib/perl/Genome/Model/Tools/Picard/CollectMultipleMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectMultipleMetrics.pm
@@ -66,7 +66,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard analysis CollectMultipleMetrics);
+    return qw(picard analysis CollectMultipleMetrics);
 }
 
 sub _cmdline_args {

--- a/lib/perl/Genome/Model/Tools/Picard/CollectMultipleMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectMultipleMetrics.pm
@@ -65,8 +65,8 @@ sub _jar_name {
     return 'CollectMultipleMetrics.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.analysis.CollectMultipleMetrics';
+sub _java_class {
+    return qw(net sf picard analysis CollectMultipleMetrics);
 }
 
 sub _cmdline_args {

--- a/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
@@ -41,8 +41,8 @@ sub _jar_name {
 
 sub _java_class {
     my $self = shift;
-    return qw(net sf samtools apps CompareSAMs) if $self->use_version eq '1.17';
-    return qw(net sf picard sam CompareSAMs);
+    return qw(samtools apps CompareSAMs) if $self->use_version eq '1.17';
+    return qw(picard sam CompareSAMs);
 }
 
 sub _validate_params {

--- a/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
@@ -41,8 +41,9 @@ sub _jar_name {
 
 sub _java_class {
     my $self = shift;
-    return qw(samtools apps CompareSAMs) if $self->use_version eq '1.17';
-    return qw(picard sam CompareSAMs);
+    return $self->version_older_than('1.21')
+        ? qw(samtools apps CompareSAMs) # before 1.21
+        : qw(picard sam CompareSAMs); # 1.21 and later
 }
 
 sub _validate_params {

--- a/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
@@ -39,10 +39,10 @@ sub _jar_name {
     return 'CompareSAMs.jar';
 }
 
-sub _java_class_name {
+sub _java_class {
     my $self = shift;
-    return 'net.sf.samtools.apps.CompareSAMs' if $self->use_version eq '1.17';
-    return 'net.sf.picard.sam.CompareSAMs';
+    return qw(net sf samtools apps CompareSAMs) if $self->use_version eq '1.17';
+    return qw(net sf picard sam CompareSAMs);
 }
 
 sub _validate_params {

--- a/lib/perl/Genome/Model/Tools/Picard/CreateSequenceDictionary.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CreateSequenceDictionary.pm
@@ -67,7 +67,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard sam CreateSequenceDictionary);
+    return qw(picard sam CreateSequenceDictionary);
 }
 
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/CreateSequenceDictionary.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CreateSequenceDictionary.pm
@@ -66,8 +66,8 @@ sub _jar_name {
     return 'CreateSequenceDictionary.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.sam.CreateSequenceDictionary';
+sub _java_class {
+    return qw(net sf picard sam CreateSequenceDictionary);
 }
 
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/EstimateLibraryComplexity.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/EstimateLibraryComplexity.pm
@@ -69,8 +69,8 @@ sub _jar_name {
     return 'EstimateLibraryComplexity.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.sam.EstimateLibraryComplexity';
+sub _java_class {
+    return qw(net sf picard sam EstimateLibraryComplexity);
 }
 
 sub _shellcmd_extra_params {

--- a/lib/perl/Genome/Model/Tools/Picard/EstimateLibraryComplexity.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/EstimateLibraryComplexity.pm
@@ -70,7 +70,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard sam EstimateLibraryComplexity);
+    return qw(picard sam EstimateLibraryComplexity);
 }
 
 sub _shellcmd_extra_params {

--- a/lib/perl/Genome/Model/Tools/Picard/SortSam.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/SortSam.pm
@@ -56,8 +56,8 @@ sub _jar_name {
     return 'SortSam.jar';
 }
 
-sub _java_class_name {
-    return 'net.sf.picard.sam.SortSam';
+sub _java_class {
+    return qw(net sf picard sam SortSam);
 }
 
 sub _shellcmd_extra_params {

--- a/lib/perl/Genome/Model/Tools/Picard/SortSam.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/SortSam.pm
@@ -57,7 +57,7 @@ sub _jar_name {
 }
 
 sub _java_class {
-    return qw(net sf picard sam SortSam);
+    return qw(picard sam SortSam);
 }
 
 sub _shellcmd_extra_params {


### PR DESCRIPTION
**Background:** Early versions of Picard all of have Java class names starting with `net.sf`. This changed in release 1.114, when Picard moved to GitHub and they removed the `net.sf`.

These commits codify this change and remove old hacks. These commits also change how sub-classes return their Java class name. The method was renamed from `_java_class_name` to `_java_class`, and it now returns an array of "components" instead of a string. The `_java_class_name` method is now only on the Base class, and handles prepending `net.sf` (if necessary) and doing a `join '.', @class` for the command-line.

:dolphin: :ribbon:

## TODO
- [x] Clarify which versions of Picard use different class names in `GMT::Picard::CompareSams` 
- [x] Use `version_compare` in `GMT::Picard::CompareSams`
- [x] Fix breakage when a caller passes in a Picard version set to `undef`