### PR TITLE
Refactor per-lane locking out of Merged.pm and into AlignmentResult.pm

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -273,7 +273,6 @@ sub create {
                     die $self->error_message("Fail to run flagstat on $bam_path");
                 }
             }
-            $alignment->_reallocate_disk_allocation;
             $self->_remove_per_lane_bam_post_commit($bam_path, $alignment);
         }
     }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -825,52 +825,11 @@ sub scalar_property_from_underlying_alignment_results {
     }
 }
 
-
 sub _lock_per_lane_alignments {
     my $self = shift;
-
     for my $alignment ($self->collect_individual_alignments) {
-        unless ($alignment->get_merged_alignment_results) {
-            my @bams = $alignment->alignment_bam_file_paths;
-            unless (@bams) {
-               die $self->error_message("Alignment result with class (%s) and id (%s) has neither ".
-                   "merged results nor valid bam paths. This likely means that this alignment result ".
-                   "needs to be removed and realigned because data has been lost. ".
-                   "Please create an apipe-support ticket for this.", $alignment->class, $alignment->id);
-               #There is no way to recreate per lane bam if merged bam
-               #does not exist and per lane bam is removed. Software
-               #result of this per lane alignment needs to be removed and
-               #this per lane instrument data needs to be realigned
-               #with that aligner.
-            }
-
-            my $lock_var = File::Spec->join('genome', __PACKAGE__, 'lock-per-lane-alignment-'.$alignment->id);
-            my $lock = Genome::Sys->lock_resource(
-                resource_lock => $lock_var,
-                scope         => 'site',
-                max_try       => 288, # Try for 48 hours every 10 minutes
-                block_sleep   => 600,
-            );
-            die $self->error_message("Unable to acquire the lock for per lane alignment result id (%s) !", $alignment->id) unless $lock;
-
-            # If the build before us successfully created a merged alignment result, we no longer need a lock
-            # If it failed, we will add an observer just as the first build did.
-            if ($alignment->get_merged_alignment_results) {
-                Genome::Sys->unlock_resource(resource_lock => $lock);
-            } else {
-                # The problem here is if we commit BEFORE merge is done, we unlock too early.
-                # However, if we unlock any other way we may fail to unlock more often and leave old locks.
-                UR::Context->process->add_observer(
-                    aspect   => 'commit',
-                    once => 1,
-                    callback => sub {
-                        Genome::Sys->unlock_resource(resource_lock => $lock);
-                    }
-                );
-            }
-        }
+        $alignment->lock_bam_file_access;
     }
-
     return 1;
 }
 


### PR DESCRIPTION
This PR refactors per-lane bam locking code out of G::I::AR::Merged and into G::I::AlignmentResult. It also removes an extra reallocation.