### PR TITLE
Prefer the existing per-lane BAM if we have one.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1630,14 +1630,11 @@ sub revivified_alignment_bam_file_paths {
     my $self = shift;
     my %p = Params::Validate::validate(@_, {disk_allocation => { isa => 'Genome::Disk::Allocation'}});
 
-    # If we have a merged alignment result, the per-lane bam can be regenerated and we will do so now
-    # This is less efficient than using the in-place per-lane bam. However, it aids us in terms of
-    # contention, and in our transition period (allowing us to delete all per-lane bams now).
-    if ($self->get_merged_alignment_results) {
-        return $self->_revivified_bam_file_path if defined $self->_revivified_bam_file_path;
-    } elsif (my @bams = $self->alignment_bam_file_paths) {
+    if (my @bams = $self->alignment_bam_file_paths) {
         return @bams;
     }
+
+    return $self->_revivified_bam_file_path if defined $self->_revivified_bam_file_path;
 
     my $revivified_bam = File::Spec->join($p{disk_allocation}->absolute_path, 'all_sequences.bam');
     my $merged_bam    = $self->get_merged_bam_to_revivify_per_lane_bam;


### PR DESCRIPTION
It does not follow from the existence of a merged result that we can
necessarily revivify this BAM.  The merge may have happened on an older
snapshot and the revivification will in such a case fail for lack of the
.header file.