### PR TITLE
Optionally add tag(s) when associating menu item(s) to the AnP.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.pm
@@ -20,6 +20,12 @@ class Genome::Config::AnalysisProject::Command::AddMenuItem {
             default_value => 0,
             doc => 'Reprocess any existing instrument data with the new config',
         },
+        tag => {
+            is => 'Genome::Config::Tag',
+            is_many => 1,
+            doc => 'Tags to associate with the menu items',
+            is_optional => 1,
+        }
     ],
 };
 
@@ -85,13 +91,22 @@ sub _add_config_items_to_project {
     my $menu_items = shift;
 
     for (@$menu_items) {
-        Genome::Config::Profile::Item->create(
+        my $item = Genome::Config::Profile::Item->create(
             analysis_menu_item => $_,
             analysis_project => $project,
             status => 'active',
         );
+        $self->_apply_tags($item);
     }
 
+    return 1;
+}
+
+sub _apply_tags {
+    my ($self, $profile_item) = @_;
+    for my $tag ($self->tag){
+        $profile_item->add_tag($tag);
+    }
     return 1;
 }
 

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.t
@@ -28,15 +28,21 @@ my $b2 = Genome::Config::AnalysisProject::InstrumentDataBridge->create( analysis
 
 my $item = Genome::Config::AnalysisMenu::Item->create( name => 'test_item', file_path => '/tmp/idontexist', description => 'test');
 
+my $tag = Genome::Config::Tag->create( name => 'test tag for add-menu-item' );
+
 my $cmd = $class->create(
     analysis_project => $ap,
     analysis_menu_items => [$item],
     reprocess_existing => 1,
+    tag => [$tag],
 );
 
 $cmd->execute();
 
-ok(Genome::Config::Profile::Item->get(analysis_project => $ap, analysis_menu_item => $item), 'added item to the project');
+my $profile_item = Genome::Config::Profile::Item->get(analysis_project => $ap, analysis_menu_item => $item);
+ok($profile_item, 'added item to the project');
+
+is($profile_item->tags, $tag, 'tag associated with item');
 
 ok($b1->status eq 'new', 'first instrument data set to new');
 ok($b2->status eq 'new', 'second instrument data set to new');


### PR DESCRIPTION
This feature already existed when creating a configuration from a file directly.  This makes the two commands more similar.  (If more features are added to these, they would probably benefit from a common base.)