### PR TITLE
Don't log rollbacks on build requested

### DIFF
--- a/lib/perl/Genome/Model-build_requested.t
+++ b/lib/perl/Genome/Model-build_requested.t
@@ -22,6 +22,8 @@ my $sample = create_test_sample('test_sample');
 my $pp = create_test_pp('test_pp');
 my $model = create_test_model($sample, $pp, 'test_model');
 
+my $tx = UR::Context::Transaction->begin();
+
 $model->build_requested(0);
 is($model->build_requested, 0, 'unset build requested');
 {
@@ -43,6 +45,16 @@ is($model->build_requested, 1, 'set build requested with reason provided');
         body_text => $reason,
     );
     is($count, 1, 'found expected note');
+}
+
+$tx->rollback();
+{
+    my $count = count_notes(
+        notes => [$model->notes],
+        header_text => 'build_unrequested',
+        body_text => 'no reason given',
+    );
+    is($count, 0, 'no new notes created during rollback');
 }
 
 done_testing();

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -148,8 +148,6 @@ class Genome::Model {
             # new instrument data instead of input models
         },
         _build_requested => {
-            # TODO: this has limited tracking as to who/why the build was requested
-            # Is it better as a Note than a column since it is TGI specific?
             is => 'Boolean',
             column_name => 'build_requested',
             doc => 'accesses/modifies the "build_requested" value without locking',

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -670,9 +670,7 @@ sub build_requested {
     # Writing the if like this allows someone to do build_requested(undef)
     if (@_ > 1) {
         $self->_lock();
-        my ($calling_package, $calling_subroutine) = (caller(1))[0,3];
-        my $default_reason = 'no reason given';
-        $default_reason .= ' called by ' . $calling_package . '::' . $calling_subroutine if $calling_package;
+        my $default_reason = Carp::shortmess('no reason given');
         $self->add_note(
             header_text => $value ? 'build_requested' : 'build_unrequested',
             body_text => defined $reason ? $reason : $default_reason,

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -665,8 +665,14 @@ sub build_requested {
     my ($self, $value, $reason) = @_;
     # Writing the if like this allows someone to do build_requested(undef)
     if (@_ > 1) {
-        $self->_lock();
         my ($calling_package, $calling_subroutine) = (caller(1))[0,3];
+
+        if($calling_subroutine && grep { $_ eq $calling_subroutine } qw(UR::Change::undo UR::Context::_reverse_all_changes)) {
+            #don't log rollbacks--the log of the original request is removed by the rollback.
+            return $self->__build_requested($value);
+        }
+
+        $self->_lock();
         my $default_reason = 'no reason given';
         $default_reason .= ' called by ' . $calling_package . '::' . $calling_subroutine if $calling_package;
         $self->add_note(

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -699,9 +699,18 @@ sub _lock {
         die("Unable to acquire the lock to request $model_id. Is something already running or did it exit uncleanly?")
             unless $lock;
 
-        my $commit_observer;
+        my ($commit_observer, $rollback_observer);
         $commit_observer = UR::Context->process->add_observer(
                                aspect => 'commit',
+                               once => 1,
+                               callback => sub {
+                                   Genome::Sys->unlock_resource(resource_lock => $lock);
+                                   $rollback_observer->delete;
+                               }
+                           );
+        $rollback_observer = UR::Context->current->add_observer(
+                               aspect => 'rollback',
+                               once => 1,
                                callback => sub {
                                    Genome::Sys->unlock_resource(resource_lock => $lock);
                                    $commit_observer->delete;


### PR DESCRIPTION
Issues this PR is attempting to address:
* Processes will sometimes acquire the lock and hold onto it for a long time even though they haven't attempted to modify the `build_requested` value.
* Processes spam the model notes with calls from `_reverse_all_changes`.

This short script demonstrates the existing behaviour:
```
$ genome-perl -M5.10.0 -MGenome -e 'my $m = Genome::Model->get(name => "apipe-test-reference-alignment"); say scalar(@{[$m->notes]}); UR::Context->rollback(); say scalar(@{[$m->notes]});'
13035
13036
Removing remaining resource lock: 'build_requested/2880887847' at /.../Genome/Sys/Lock/FileBackend.pm line 244.
```

Here's the behaviour with the changes:
```
$ genome-perl -M5.10.0 -e 'use above "Genome"; my $m = Genome::Model->get(name => "apipe-test-reference-alignment"); say scalar(@{[$m->notes]}); UR::Context->rollback(); say scalar(@{[$m->notes]});'
Using libraries at /.../git/genome-fast/lib/perl
13035
13035
```

While this seems to be effective, I do wonder if there might be a better way to accomplish the goal than inspecting `caller`.