### PR TITLE
LockProxy and LockMigrationProxy

### DIFF
--- a/lib/perl/Genome/Command/DelegatesToResult.pm
+++ b/lib/perl/Genome/Command/DelegatesToResult.pm
@@ -168,7 +168,7 @@ sub _fetch_result {
 sub delete_transients {
     my ($self, $result) = @_;
     for my $transient_property ($result->__meta__->properties(is_transient => 1)) {
-        next if $transient_property->property_name eq '_lock_name';
+        next if $transient_property->property_name eq '_lock_proxy';
 
         my $value = undef;
         if (defined($transient_property->default_value)) {

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -678,16 +678,6 @@ sub _create_observer {
     return 1;
 }
 
-# Returns a closure that removes the given locks
-sub _unlock_closure {
-    my ($class, @locks) = @_;
-    return sub {
-        for my $lock (@locks) {
-            Genome::Sys->unlock_resource(resource_lock => $lock) if -e $lock;
-        }
-    };
-}
-
 # Returns a closure that creates a directory at the given path
 sub _create_directory_closure {
     my ($class, $path) = @_;

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Genome;
+use Genome::Sys::LockProxy qw();
 use Genome::Utility::Instrumentation;
 use Genome::Utility::File::Mode qw(mode);
 
@@ -438,9 +439,10 @@ sub get_lock {
     my ($class, $id, $tries) = @_;
     $tries ||= 60;
 
-    my $allocation_lock = Genome::Sys->lock_resource(
-        resource_lock => 'allocation/allocation_' . join('_', split(' ', $id)),
+    my $allocation_lock = Genome::Sys::LockProxy->new(
+        resource => 'allocation/allocation_' . join('_', split(' ', $id)),
         scope => 'site',
+    )->lock(
         max_try => $tries,
         block_sleep => 1,
     );
@@ -462,7 +464,7 @@ sub get_with_lock {
     my $mode = $class->_retrieve_mode;
     my $self = Genome::Disk::Allocation->$mode($id);
     unless ($self) {
-        Genome::Sys->unlock_resource(resource_lock => $lock);
+        $lock->unlock();
         confess "Found no allocation with ID $id";
     }
 
@@ -486,14 +488,15 @@ sub shadow_get_or_create {
 
     my $md5_hex = md5_hex($params{allocation_path});;
 
-    my $path = File::Spec->join(
+    my $resource = File::Spec->join(
         'allocation',
         'allocation_path_' . $md5_hex,
     );
 
-    my $lock = Genome::Sys->lock_resource(
-        resource_lock => $path,
+    my $lock = Genome::Sys::LockProxy->new(
+        resource => $resource,
         scope => 'site',
+    )->lock(
         wait_announce_interval => 600,
     );
 
@@ -508,7 +511,7 @@ sub shadow_get_or_create {
         $allocation = $class->create(%params, %create_extra_params);
     }
 
-    Genome::Sys->unlock_resource(resource_lock => $lock);
+    $lock->unlock();
 
     unless ($allocation) {
         croak sprintf("Failed to shadow_get_or_create allocation from params %s",

--- a/lib/perl/Genome/Disk/Detail/Allocation/Archiver.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Archiver.pm
@@ -126,7 +126,7 @@ sub archive {
 
     # If only there were finally blocks...
     if ($allocation_lock) {
-        Genome::Sys->unlock_resource(resource_lock => $allocation_lock);
+        $allocation_lock->unlock();
     }
 
     if ($error) {

--- a/lib/perl/Genome/Disk/Detail/Allocation/Mover.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Mover.pm
@@ -68,7 +68,7 @@ sub move {
                 $shadow_allocation->delete;
             }
         }
-        Genome::Sys->unlock_resource(resource_lock => $allocation_lock);
+        $allocation_lock->unlock();
         confess(sprintf(
                 "Could not copy allocation %s from %s to %s: %s",
                 $allocation_object->id, $original_absolute_path,
@@ -83,7 +83,7 @@ sub move {
 
     Genome::Sys->create_directory($new_volume_final_path);
     unless (Genome::Sys->rename($shadow_allocation->absolute_path, $new_volume_final_path)) {
-        Genome::Sys->unlock_resource(resource_lock => $allocation_lock);
+        $allocation_lock->unlock();
         my $shadow_allocation_abs_path = $shadow_allocation->absolute_path;
         $shadow_allocation->delete;
         confess($allocation_object->error_message(sprintf(
@@ -111,7 +111,7 @@ sub move {
 
     Genome::Disk::Allocation::_commit_unless_testing();
 
-    Genome::Sys->unlock_resource(resource_lock => $allocation_lock);
+    $allocation_lock->unlock();
 
     $shadow_allocation->delete;
 

--- a/lib/perl/Genome/Disk/Detail/Allocation/Unarchiver.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Unarchiver.pm
@@ -35,7 +35,7 @@ sub unarchive {
         Genome::Disk::Allocation->get_with_lock($id);
 
     unless ($allocation_object->is_archived) {
-        Genome::Sys->unlock_resource(resource_lock => $allocation_lock);
+        $allocation_lock->unlock();
         $allocation_object->status_message(
             "Allocation is not archived, cannot unarchive. Exiting.");
         return 1;
@@ -133,7 +133,7 @@ sub unarchive {
     my $error = $@;
 
     # finally blocks would be really sweet. Alas...
-    Genome::Sys->unlock_resource(resource_lock => $allocation_lock) if $allocation_lock;
+    $allocation_lock->unlock() if $allocation_lock;
     $shadow_allocation->delete();
 
     if ($error) {

--- a/lib/perl/Genome/Disk/Volume.pm
+++ b/lib/perl/Genome/Disk/Volume.pm
@@ -186,21 +186,6 @@ sub hard_unused_kb {
     return $self->hard_limit_kb - $self->used_kb;
 }
 
-sub get_lock {
-    my ($class, $mount_path, $tries) = @_;
-    $tries ||= 120;
-    my $modified_mount = $mount_path;
-    $modified_mount =~ s/\//_/g;
-    my $volume_lock = Genome::Sys->lock_resource(
-        resource_lock => 'allocation/volume' . $modified_mount,
-        scope => 'site',
-        max_try => $tries,
-        block_sleep => 1,
-        wait_announce_interval => 10,
-    );
-    return $volume_lock;
-}
-
 our @dummy_volumes;
 sub create_dummy_volume {
     my ($class, %params) = @_;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -2,6 +2,7 @@ package Genome::Model::Build::ReferenceSequence;
 use strict;
 use warnings;
 use Genome;
+use Genome::Sys::LockProxy qw();
 use File::Path;
 use File::Copy;
 
@@ -392,9 +393,10 @@ sub full_consensus_sam_index_path {
         
         $self->warning_message("no failx file at $idx_file!");
 
-        my $lock = Genome::Sys->lock_resource(
-            resource_lock => $data_dir.'/lock_for_faidx',
-            scope         => 'unknown',
+        my $lock = Genome::Sys::LockProxy->new(
+            resource => $data_dir.'/lock_for_faidx',
+            scope => 'unknown',
+        )->lock(
             max_try       => 2,
         );
         unless ($lock) {
@@ -408,8 +410,8 @@ sub full_consensus_sam_index_path {
             output_files => [$idx_file],
         );
 
-        unless (Genome::Sys->unlock_resource(resource_lock => $lock)) {
-            $self->error_message("Failed to unlock resource: $lock");
+        unless ($lock->unlock()) {
+            $self->error_message("Failed to unlock resource: " . $lock->resource);
             return;
         }
         unless ($rv == 1) {
@@ -459,17 +461,18 @@ sub get_sequence_dictionary {
 
     my $resource_lock = $seqdict_dir_path."/lock_for_seqdict-$file_type";
     #lock seqdict dir here
-    my $lock = Genome::Sys->lock_resource(
-        resource_lock => $resource_lock,
-        scope         => 'unknown',
-        max_try       => 2,
+    my $lock = Genome::Sys::LockProxy->new(
+        resource => $resource_lock,
+        scope => 'unknown',
+    )->lock(
+        max_try => 2,
     );
 
     # if it couldn't get the lock after 2 tries, pop a message and keep trying as much as it takes
     unless ($lock) {
         $self->status_message("Couldn't get a lock after 2 tries, waiting some more...");
-        $lock = Genome::Sys->lock_resource(
-        resource_lock => $resource_lock,
+        $lock = Genome::Sys::LockProxy->new(
+            resource => $resource_lock,
             scope => 'unknown',
         );
         unless($lock) {
@@ -493,8 +496,8 @@ sub get_sequence_dictionary {
         $self->status_message("Detected a remap file, and we're appending to another build. We'll skip sequence dictionary creation for the remap file and just copy the sequence dictionary from the reference build we're appending to.");
         Genome::Sys->copy_file($append_ref->get_sequence_dictionary($file_type, $species, $picard_version), $path);
 
-        unless (Genome::Sys->unlock_resource(resource_lock => $lock)) {
-            $self->error_message("Failed to unlock resource: $lock");
+        unless ($lock->unlock()) {
+            $self->error_message("Failed to unlock resource: " . $lock->resource);
             return;
         }
     } else {
@@ -515,8 +518,8 @@ sub get_sequence_dictionary {
 
         my $csd_rv = Genome::Sys->shellcmd(cmd=>$create_seq_dict_cmd);
 
-        unless (Genome::Sys->unlock_resource(resource_lock => $lock)) {
-            $self->error_message("Failed to unlock resource: $lock");
+        unless ($lock->unlock()) {
+            $self->error_message("Failed to unlock resource: " . $lock->resource);
             return;
         }
 
@@ -771,14 +774,15 @@ sub verify_or_create_local_cache {
     $self->status_message('Lock local cache directory');
     my $lock_name = $self->local_cache_lock;
     $self->status_message('Lock name: '.$lock_name);
-    my $lock = Genome::Sys->lock_resource(
-        resource_lock => $lock_name,
+    my $lock = Genome::Sys::LockProxy->new(
+        resource => $lock_name,
         scope => 'tgisan',
+    )->lock(
         max_try => 20, # 20 x 180 sec each = 1hr
         block_sleep => 180,
     );
     unless ($lock) {
-        $self->error_message("Failed to get lock for $lock_name!");
+        $self->error_message("Failed to get lock for %s!", $lock->resource);
         return;
     }
     $self->status_message('Lock obtained');
@@ -844,9 +848,9 @@ sub verify_or_create_local_cache {
 
     # rm lock
     $self->status_message('Remove lock');
-    my $rv = eval { Genome::Sys->unlock_resource(resource_lock=>$lock); };
+    my $rv = eval { $lock->unlock() };
     if ( not $rv ) {
-        $self->error_message("Failed to unlock ($lock): $@. But we don't care.");
+        $self->error_message("Failed to unlock (%s): %. But we don't care.", $lock->resource, $@);
     }
 
     $self->status_message('Verify or create local cache...OK');

--- a/lib/perl/Genome/Model/MetagenomicCompositionShotgun.pm
+++ b/lib/perl/Genome/Model/MetagenomicCompositionShotgun.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Genome;
+use Genome::Sys::LockProxy qw();
 use File::Basename;
 use File::Path 'make_path';
 use Sys::Hostname;
@@ -1060,9 +1061,10 @@ sub lock {
     my @parts = @_;
     my $lock_key = join('_', @parts);
     $self->debug_message("Creating lock on $lock_key...");
-    my $resource_lock = File::Spec->join($ENV{GENOME_LOCK_DIR}, $lock_key);
-    my $lock = Genome::Sys->lock_resource(
-        resource_lock => $resource_lock,
+    my $lock = Genome::Sys::LockProxy->new(
+        resource => $lock_key,
+        scope => 'site',
+    )->lock(
         max_try => 2,
     );
     return $lock;
@@ -1520,16 +1522,16 @@ sub _process_unaligned_reads {
                 die "Unsaved changes present on instrument data $new_instrument_data->{id} from $original_data_path!!!";
             }
             if (!$new_instrument_data->is_paired_end && $se_lock) {
-                $self->debug_message("Attempting to remove lock on $se_lock...");
-                unless(Genome::Sys->unlock_resource(resource_lock => $se_lock)) {
-                    die $self->error_message("Failed to unlock $se_lock.");
+                $self->debug_message("Attempting to remove lock on %s...", $se_lock->resource);
+                unless($se_lock->unlock()) {
+                    die $self->error_message("Failed to unlock %s.", $se_lock->resource);
                 }
                 undef($se_lock);
             }
             if ($new_instrument_data->is_paired_end && $pe_lock) {
-                $self->debug_message("Attempting to remove lock on $pe_lock...");
-                unless(Genome::Sys->unlock_resource(resource_lock => $pe_lock)) {
-                    die $self->error_message("Failed to unlock $pe_lock.");
+                $self->debug_message("Attempting to remove lock on %s...", $pe_lock->resource);
+                unless($pe_lock->unlock()) {
+                    die $self->error_message("Failed to unlock %s.", $pe_lock->resource);
                 }
                 undef($pe_lock);
             }

--- a/lib/perl/Genome/Model/MetagenomicCompositionShotgun.pm
+++ b/lib/perl/Genome/Model/MetagenomicCompositionShotgun.pm
@@ -939,7 +939,6 @@ sub get_imported_instrument_data_or_upload_paths {  #TODO not finished, not curr
     my ($self, $orig_inst_data, @paths) = @_;
     my @inst_data;
     my @upload_paths;
-    my @locks;
     my $tmp_dir;
     my $subdir;
 
@@ -959,7 +958,6 @@ sub get_imported_instrument_data_or_upload_paths {  #TODO not finished, not curr
                 } else {
                     die $self->error_message("Failed to lock $sub_path.");
                 }
-                push @locks, $lock;
             }
             push @upload_paths, $path;
         }
@@ -980,8 +978,6 @@ sub get_imported_instrument_data_or_upload_paths {  #TODO not finished, not curr
 
 sub upload_instrument_data_and_unlock {
     my ($self, $orig_data_paths_to_fastq_files, $locks_ref) = @_;
-    #TODO: Actually use locks.
-    my @locks;# = @$locks_ref;
 
     my @properties_from_prior = qw/ run_name subset_name sequencing_platform median_insert_size sd_above_insert_size library_name sample_name /;
     my @instrument_data;
@@ -1052,13 +1048,6 @@ sub upload_instrument_data_and_unlock {
         }
         if ($instrument_data->__changes__) {
             die "Unsaved changes present on instrument data $instrument_data->{id} from $original_data_path!!!";
-        }
-        for my $lock (@locks) {
-            if ($lock) {
-                unless(Genome::Sys->unlock_resource(resource_lock => $lock)) {
-                    die $self->error_message("Failed to unlock " . $lock->resource_lock . ".");
-                }
-            }
         }
         push @instrument_data, $instrument_data;
     }

--- a/lib/perl/Genome/Model/Tools/GenePredictor.pm
+++ b/lib/perl/Genome/Model/Tools/GenePredictor.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Genome;
+use Genome::Sys::LockProxy qw();
 use File::Temp;
 use File::Basename;
 use Bio::SeqIO;
@@ -131,9 +132,10 @@ sub lock_files_for_predictions {
         $lock_name =~ s/\//_/g;
         my $resource_lock = "gene_prediction/eukaryotic/$lock_name";
 
-        my $lock = Genome::Sys->lock_resource(
-            resource_lock => $resource_lock,
+        my $lock = Genome::Sys::LockProxy->new(
+            resource => $resource_lock,
             scope => 'site',
+        )->lock(
             block_sleep => 60,
             max_try => 10,
         );
@@ -147,9 +149,7 @@ sub lock_files_for_predictions {
 sub release_prediction_locks {
     my ($self, @locks) = @_;
     for my $lock (@locks) {
-        Genome::Sys->unlock_resource(
-            resource_lock => $lock,
-        );
+        $lock->unlock();
     }
     return 1;
 }

--- a/lib/perl/Genome/Model/Tools/Wiki/UpdateSolr.pm
+++ b/lib/perl/Genome/Model/Tools/Wiki/UpdateSolr.pm
@@ -2,6 +2,7 @@
 package Genome::Model::Tools::Wiki::UpdateSolr;
 
 use Genome;
+use Genome::Sys::LockProxy qw();
 
 use LWP::Simple;
 use XML::Simple;
@@ -36,9 +37,10 @@ sub execute {
         $resource_lock .= '_dev';
     }
 
-    my $lock = Genome::Sys->lock_resource(
-        resource_lock => $resource_lock,
+    my $lock = Genome::Sys::LockProxy->new(
+        resource => $resource_lock,
         scope => 'site',
+    )->lock(
         max_try => 1,
     );
     die 'someone else has the wiki_loader lock' if !$lock;
@@ -86,7 +88,7 @@ sub execute {
     }
 
     UR::Context->commit();
-    Genome::Sys->unlock_resource(resource_lock=>$lock);
+    $lock->unlock();
 }
 
 

--- a/lib/perl/Genome/Site/TGI/Extension/Sys.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys.pm
@@ -802,18 +802,6 @@ Houses some generic file and directory methods
 
 =back
 
-=head1 Methods for Locking
-
-=head2 lock_resource
-
-Document me!
-
-=head2 unlock_resource
-
-Document me!
-
-=head1 See Also
-
 =head1 Disclaimer
 
 Copyright (C) 2005 - 2008 Washington University Genome Sequencing Center

--- a/lib/perl/Genome/Site/TGI/Synchronize/SyncLimsAndGenome.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/SyncLimsAndGenome.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Genome;
+use Genome::Sys::LockProxy qw();
 
 use constant MAX_GENOTYPE_DATA_TO_PROCESS => 500;
 
@@ -65,16 +66,17 @@ sub _lock_me {
     my $self = shift;
     return 1 if $ENV{UR_DBI_NO_COMMIT};
     $self->status_message('Lock...');
-    my $lock = Genome::Sys->lock_resource(
+    my $lock = Genome::Sys::LockProxy->new(
         resource_lock => 'synchronize-genome-from-lims',
         scope => 'site',
+    )->lock(
         max_try => 1,
     );
     if ( not $lock ) {
         $self->error_message("Could not lock!");
         return;
     }
-    $self->status_message('Lock: '.$lock);
+    $self->status_message('Lock: ' . $lock->resource);
     $self->_lock($lock);
     return 1;
 }
@@ -83,8 +85,8 @@ sub _unlock_me {
     my $self = shift;
     return 1 if $ENV{UR_DBI_NO_COMMIT};
     return 1 if not $self->_lock;
-    $self->status_message('Unlock: '.$self->_lock);
-    eval{ Genome::Sys->unlock_resource(resource_lock => $self->_lock); };
+    $self->status_message('Unlock: '.$self->_lock->resource);
+    eval{ $self->_lock->unlock() };
     return 1;
 }
 

--- a/lib/perl/Genome/SoftwareResult.t
+++ b/lib/perl/Genome/SoftwareResult.t
@@ -228,11 +228,11 @@ sub _get_lock_hash {
 
 my $sr1 = Genome::Test_SR->create(p1=>'test', i1=>'test');
 # the lock_name will have _username_timestamp, so we don't want to keep that
-my $hash_without_optionals = _get_lock_hash($sr1->_lock_name);
+my $hash_without_optionals = _get_lock_hash($sr1->_lock_proxy->resource);
 $sr1->delete();
 
 my $sr2 = Genome::Test_SR->create(p1=>'test', p2=>undef, i1=>'test', i2=>undef);
-my $hash_with_optionals = _get_lock_hash($sr2->_lock_name);
+my $hash_with_optionals = _get_lock_hash($sr2->_lock_proxy->resource);
 
 is($hash_with_optionals, $hash_without_optionals,
     'Creates the same lock with or without optionals (that default to undef) specified');

--- a/lib/perl/Genome/SoftwareResult/User.t
+++ b/lib/perl/Genome/SoftwareResult/User.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use above 'Genome';
+use Genome::Sys::LockProxy qw();
 use Test::More;
 use Test::Exception;
 use Genome::Test::Factory::Build;
@@ -148,9 +149,14 @@ subtest 'multiple shortcutters result in only one user' => sub {
                 user => $users_hash{users}{sponsor},
                 software_result => $sr,
         });
-        my $lock = Genome::Sys->lock_resource(resource_lock => $resource, scope => 'site', max_try => 1);
+        my $lock = Genome::Sys::LockProxy->new(
+            resource => $resource,
+            scope => 'site',
+        )->lock(
+            max_try => 1,
+        );
         ok($lock, 'got lock');
-        Genome::Sys->unlock_resource(resource_lock => $lock);
+        $lock->unlock();
     };
 
     my @users = $sr->users;

--- a/lib/perl/Genome/Sys/Lock.pm
+++ b/lib/perl/Genome/Sys/Lock.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Carp qw(carp croak);
+use Genome::Utility::Instrumentation qw();
 use List::MoreUtils qw(all);
 use Params::Validate qw(validate HASHREF);
 

--- a/lib/perl/Genome/Sys/Lock.pm
+++ b/lib/perl/Genome/Sys/Lock.pm
@@ -155,12 +155,17 @@ C<scope> is the scope to which the lock is bound.  See C<scopes()> for valid sco
 
 sub unlock_resource {
     my $class = shift;
-    my %args = @_;
-
-    my $scope = $RESOURCE_LOCK_SCOPE{$args{resource_lock}};
+    my %args = validate(@_, {
+        resource_lock => 1,
+        scope => {
+            callbacks => {
+                'valid scope' => sub { validate_scope(shift) },
+            },
+        },
+    });
 
     my $rv = 1;
-    for my $backend (backends($scope)) {
+    for my $backend (backends($args{scope})) {
         if ($backend->has_lock($args{resource_lock})) {
             my @unlock_args = $backend->translate_unlock_args(%args);
             my $unlocked = $backend->unlock(@unlock_args);

--- a/lib/perl/Genome/Sys/Lock.pm
+++ b/lib/perl/Genome/Sys/Lock.pm
@@ -68,20 +68,9 @@ then C<lock()> will C<croak()>.
 
 =cut
 
-my %RESOURCE_LOCK_SCOPE;
 sub lock_resource {
     my $class = shift;
     my %args = validate(@_, LOCK_RESOURCE_PARAMS_SPEC());
-
-    if (exists $RESOURCE_LOCK_SCOPE{$args{resource_lock}}
-        && $RESOURCE_LOCK_SCOPE{$args{resource_lock}} ne $args{scope}) {
-        Carp::confess(sprintf("Attempted to lock the resource (%s) in "
-                . "scope (%s) while it has an existing lock in scope (%s).  "
-                . "Locking in multiple scopes is not currently supported.",
-                $args{resource_lock},
-                $RESOURCE_LOCK_SCOPE{$args{resource_lock}},
-                $args{scope}));
-    }
 
     # need to install handlers before backends start locking
     $class->_cleanup_handler_check();
@@ -113,8 +102,6 @@ sub lock_resource {
     } else {
         Genome::Utility::Instrumentation::increment('genome.sys.lock.lock_resource.inconsistent');
     }
-
-    $RESOURCE_LOCK_SCOPE{$args{resource_lock}} = $args{scope};
 
     return $args{resource_lock};
 

--- a/lib/perl/Genome/Sys/Lock.pm
+++ b/lib/perl/Genome/Sys/Lock.pm
@@ -107,18 +107,29 @@ sub lock_resource {
 
 }
 
-sub LOCK_RESOURCE_PARAMS_SPEC {
+sub PROXY_CONSTRUCTOR_PARAMS_SPEC {
     return {
-        resource_lock => 1,
+        resource => 1,
         scope => {
             callbacks => {
                 'valid scope' => sub { validate_scope(shift) },
             },
         },
+    };
+}
+
+sub PROXY_LOCK_PARAMS_SPEC {
+    return {
         block_sleep => { default => 60 },
         max_try => { default => 7200 },
         wait_announce_interval => { default => 0 },
     };
+}
+
+sub LOCK_RESOURCE_PARAMS_SPEC {
+    my %cons_spec = %{ PROXY_CONSTRUCTOR_PARAMS_SPEC() };
+    $cons_spec{resource_lock} = delete $cons_spec{resource};
+    return { %cons_spec, %{ PROXY_LOCK_PARAMS_SPEC() } };
 }
 
 =item unlock_resource()

--- a/lib/perl/Genome/Sys/Lock.t
+++ b/lib/perl/Genome/Sys/Lock.t
@@ -4,6 +4,7 @@ use warnings;
 use above 'Genome';
 
 use Genome::Sys::Lock::MockBackend;
+use Genome::Utility::Text qw(rand_string);
 use List::MoreUtils qw(all);
 use List::Util qw(shuffle);
 use Test::More tests => 10;
@@ -23,7 +24,7 @@ subtest 'shared mandatory both lock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -47,7 +48,7 @@ subtest 'shared mandatory fails to lock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -71,7 +72,7 @@ subtest 'first optional fails to lock' => sub {
 
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -94,7 +95,7 @@ subtest 'second optional fails to lock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -123,7 +124,7 @@ subtest 'first optional fails to lock, then unlock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -151,7 +152,7 @@ subtest 'second optional fails to lock, then unlock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -180,7 +181,7 @@ subtest 'with both locked, first optional fails to unlock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -209,7 +210,7 @@ subtest 'with both locked, second optional fails to unlock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -237,7 +238,7 @@ subtest 'with both locked, first mandatory fails to unlock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -263,7 +264,7 @@ subtest 'with both locked, second mandatory fails to unlock' => sub {
         );
         Genome::Sys::Lock->set_backends(site => \@backends);
 
-        my $resource_lock = 'Lock.t/' . random_string();
+        my $resource_lock = 'Lock.t/' . rand_string();
         my $lock = Genome::Sys::Lock->lock_resource(
             resource_lock => $resource_lock,
             scope => 'site',
@@ -277,11 +278,6 @@ subtest 'with both locked, second mandatory fails to unlock' => sub {
         ok(!$unlocked, 'unlocked failed');
     });
 };
-
-sub random_string {
-    my @chars = map { (shuffle 'a'..'z', 'A'..'Z', 0..9)[0] } 1..10;
-    return join('', @chars);
-}
 
 sub localize_backend_changes {
     my $sub = shift;

--- a/lib/perl/Genome/Sys/Lock.t
+++ b/lib/perl/Genome/Sys/Lock.t
@@ -132,6 +132,7 @@ subtest 'first optional fails to lock, then unlock' => sub {
 
         my $unlocked = Genome::Sys::Lock->unlock_resource(
             resource_lock => $resource_lock,
+            scope => 'site',
         );
         ok($unlocked, 'unlocked');
         ok(!(all { $_->has_lock($resource_lock) } @backends), 'both backends do not have resource lock');
@@ -159,6 +160,7 @@ subtest 'second optional fails to lock, then unlock' => sub {
 
         my $unlocked = Genome::Sys::Lock->unlock_resource(
             resource_lock => $resource_lock,
+            scope => 'site',
         );
         ok($unlocked, 'unlocked');
         ok(!(all { $_->has_lock($resource_lock) } @backends),
@@ -187,6 +189,7 @@ subtest 'with both locked, first optional fails to unlock' => sub {
 
         my $unlocked = Genome::Sys::Lock->unlock_resource(
             resource_lock => $resource_lock,
+            scope => 'site',
         );
         ok($unlocked, 'unlocked');
         ok(!(all { $_->has_lock($resource_lock) } grep { $_->is_mandatory } @backends),
@@ -215,6 +218,7 @@ subtest 'with both locked, second optional fails to unlock' => sub {
 
         my $unlocked = Genome::Sys::Lock->unlock_resource(
             resource_lock => $resource_lock,
+            scope => 'site',
         );
         ok($unlocked, 'unlocked');
         ok(!(all { $_->has_lock($resource_lock) } grep { $_->is_mandatory } @backends),
@@ -242,6 +246,7 @@ subtest 'with both locked, first mandatory fails to unlock' => sub {
 
         my $unlocked = Genome::Sys::Lock->unlock_resource(
             resource_lock => $resource_lock,
+            scope => 'site',
         );
         ok(!$unlocked, 'unlocked failed');
     });
@@ -267,6 +272,7 @@ subtest 'with both locked, second mandatory fails to unlock' => sub {
 
         my $unlocked = Genome::Sys::Lock->unlock_resource(
             resource_lock => $resource_lock,
+            scope => 'site',
         );
         ok(!$unlocked, 'unlocked failed');
     });

--- a/lib/perl/Genome/Sys/Lock/NessyBackend.t
+++ b/lib/perl/Genome/Sys/Lock/NessyBackend.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Genome::Sys::Lock::NessyBackend;
+use Genome::Utility::Text qw(rand_string);
 use Test::More;
 
 if ($ENV{GENOME_NESSY_SERVER}) {
@@ -15,7 +16,7 @@ use List::Util qw(shuffle);
 subtest 'basic test' => sub {
     plan tests => 2;
 
-    my $resource_name = 'NessLock.t/' . random_string();
+    my $resource_name = 'NessLock.t/' . rand_string();
     diag 'resource = ' . $resource_name;
 
     my $n = Genome::Sys::Lock::NessyBackend->new(
@@ -39,7 +40,7 @@ subtest 'instance validation' => sub {
 
     my (@r, @n);
     for (1..2) {
-        push @r, 'NessLock.t/' . random_string();
+        push @r, 'NessLock.t/' . rand_string();
         push @n, Genome::Sys::Lock::NessyBackend->new(
             url => $ENV{GENOME_NESSY_SERVER},
             is_mandatory => 1,
@@ -65,8 +66,3 @@ subtest 'instance validation' => sub {
     $n[0]->unlock($r[0]);
     $n[1]->unlock($r[1]);
 };
-
-sub random_string {
-    my @chars = map { (shuffle 'a'..'z', 'A'..'Z', 0..9)[0] } 1..10;
-    return join('', @chars);
-}

--- a/lib/perl/Genome/Sys/LockMigrationProxy.pm
+++ b/lib/perl/Genome/Sys/LockMigrationProxy.pm
@@ -26,6 +26,9 @@ A hash reference containing the constructor parameters for the desired/new lock.
 
 sub new {
     my $class = shift;
+    if (ref $class) {
+        croak 'new() should be called as a class method';
+    }
     my %params = validate(@_, {
         old => { type => HASHREF },
         new => { type => HASHREF },

--- a/lib/perl/Genome/Sys/LockMigrationProxy.pm
+++ b/lib/perl/Genome/Sys/LockMigrationProxy.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Carp qw(croak);
+use Genome::Sys::Lock qw();
 use Genome::Sys::LockProxy qw();
 use Params::Validate qw(validate validate_with HASHREF);
 
@@ -53,11 +54,7 @@ sub lock {
     my $self = shift;
     my %params = validate_with(
         params => \@_,
-        spec => {
-            block_sleep => 0,
-            max_try => 0,
-            wait_announce_interval => 0,
-        },
+        spec => Genome::Sys::Lock::PROXY_LOCK_PARAMS_SPEC(),
     );
 
     unless ($self->{old}->lock(%params)) {

--- a/lib/perl/Genome/Sys/LockMigrationProxy.pm
+++ b/lib/perl/Genome/Sys/LockMigrationProxy.pm
@@ -1,0 +1,100 @@
+package Genome::Sys::LockMigrationProxy;
+
+use strict;
+use warnings;
+
+use Carp qw(croak);
+use Genome::Sys::LockProxy qw();
+use Params::Validate qw(validate validate_with HASHREF);
+
+=item new()
+
+Keyword Arguments:
+
+=over
+
+=item old
+
+A hash reference containing the constructor parameters for the existing/old lock.
+
+=item new
+
+A hash reference containing the constructor parameters for the desired/new lock.
+
+=cut
+
+sub new {
+    my $class = shift;
+    my %params = validate(@_, {
+        old => { type => HASHREF },
+        new => { type => HASHREF },
+    });
+
+    my $primoridal_ooze = {
+        old => Genome::Sys::LockProxy->new(%{$params{old}}),
+        new => Genome::Sys::LockProxy->new(%{$params{new}}),
+    };
+
+    return bless $primoridal_ooze, $class;
+}
+
+=item lock()
+
+C<lock()> is an instance method with optional parameters C<block_sleep>,
+C<max_try>, or C<wait_announce_interval>.  It behaves similar to
+C<Genome::Sys::Lock::lock_resource()> but on sucess C<lock()> returns an
+instance of C<Genome::Sys::LockMigrationProxy> that can later be unlocked with
+C<unlock()>.  Both the C<old> lock and the C<new> lock will be acquired, in
+that order, or neither will.
+
+=cut
+
+sub lock {
+    my $self = shift;
+    my %params = validate_with(
+        params => \@_,
+        spec => {
+            block_sleep => 0,
+            max_try => 0,
+            wait_announce_interval => 0,
+        },
+    );
+
+    unless ($self->{old}->lock(%params)) {
+        return;
+    }
+
+    unless ($self->{new}->lock(%params)) {
+        $self->{old}->unlock();
+        return;
+    }
+
+    return $self;
+}
+
+=item unlock()
+
+C<unlock()> is an instance method that will unlock both the C<new> lock and the
+C<old> lock, in that order, and should throw an exception if it fails to
+release either lock.
+
+=cut
+
+sub unlock {
+    my $self = shift;
+
+    unless ($self->{new}->unlock()) {
+        return;
+    }
+
+    # If old fails to unlock we can't relock new due to lack of context so I
+    # would like to die but I am hoping that unlock already does that as
+    # `lock_resource` is documented as doing.
+    unless ($self->{old}->unlock()) {
+        return;
+    }
+
+    return $self;
+}
+
+1;

--- a/lib/perl/Genome/Sys/LockMigrationProxy.t
+++ b/lib/perl/Genome/Sys/LockMigrationProxy.t
@@ -1,0 +1,170 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+use Genome;
+use Test::More tests => 3;
+
+use Genome::Sys::Lock qw();
+use Genome::Sys::Lock::MockBackend qw();
+use Genome::Sys::LockMigrationProxy qw();
+use List::Util qw(shuffle);
+use Scope::Guard qw();
+use Sub::Override qw();
+
+subtest 'old fails' => sub {
+    plan tests => 4;
+
+    my %backends = (
+        test_old => [ Genome::Sys::Lock::MockBackend->new() ],
+        test_new => [ Genome::Sys::Lock::MockBackend->new() ],
+    );
+    my $backend_guard = backend_guard();
+    my $scopes_guard = Sub::Override->new('Genome::Sys::Lock::scopes', sub { keys %backends });
+    Genome::Sys::Lock->set_backends(%backends);
+
+    my $resource = random_string();
+    my %lock_params = (
+        block_sleep => 0,
+        max_try => 0,
+    );
+
+    my $old_lock = Genome::Sys::Lock->lock_resource(
+        resource_lock => $resource,
+        scope => 'test_old',
+        %lock_params,
+    );
+    ok($old_lock, q(preemptively locked on 'test_old'));
+
+    my $success = Genome::Sys::LockMigrationProxy->new(
+        old => {
+            resource => $resource,
+            scope => 'test_old',
+        },
+        new => {
+            resource => $resource,
+            scope => 'test_new',
+        },
+    )->lock(%lock_params);
+    ok(!$success, q(failed to lock when 'test_old' was already locked));
+
+    $old_lock = Genome::Sys::Lock->lock_resource(
+        resource_lock => $resource,
+        scope => 'test_old',
+        %lock_params,
+    );
+    is($old_lock, undef, q(still locked on 'test_old'));
+
+    my $new_lock = Genome::Sys::Lock->lock_resource(
+        resource_lock => $resource,
+        scope => 'test_new',
+        %lock_params,
+    );
+    ok($new_lock, q(able to lock on 'test_new' after LockMigrationProxy failed to lock));
+};
+
+subtest 'new fails' => sub {
+    plan tests => 4;
+
+    my %backends = (
+        test_old => [ Genome::Sys::Lock::MockBackend->new() ],
+        test_new => [ Genome::Sys::Lock::MockBackend->new() ],
+    );
+    my $backend_guard = backend_guard();
+    my $scopes_guard = Sub::Override->new('Genome::Sys::Lock::scopes', sub { keys %backends });
+    Genome::Sys::Lock->set_backends(%backends);
+
+    my $resource = random_string();
+    my %lock_params = (
+        block_sleep => 0,
+        max_try => 0,
+    );
+
+    my $new_lock = Genome::Sys::Lock->lock_resource(
+        resource_lock => $resource,
+        scope => 'test_new',
+        %lock_params,
+    );
+    ok($new_lock, q(preemptively locked on 'test_new'));
+
+    my $success = Genome::Sys::LockMigrationProxy->new(
+        old => {
+            resource => $resource,
+            scope => 'test_old',
+        },
+        new => {
+            resource => $resource,
+            scope => 'test_new',
+        },
+    )->lock(%lock_params);
+    ok(!$success, q(failed to lock when 'test_new' was already locked));
+
+    my $old_lock = Genome::Sys::Lock->lock_resource(
+        resource_lock => $resource,
+        scope => 'test_old',
+        %lock_params,
+    );
+    ok($old_lock, q(able to lock on 'test_old' after LockMigrationProxy failed to lock));
+
+    $new_lock = Genome::Sys::Lock->lock_resource(
+        resource_lock => $resource,
+        scope => 'test_new',
+        %lock_params,
+    );
+    is($new_lock, undef, q(still locked on 'test_new'));
+};
+
+subtest 'both ok' => sub {
+    plan tests => 3;
+
+    my %backends = (
+        test_old => [ Genome::Sys::Lock::MockBackend->new() ],
+        test_new => [ Genome::Sys::Lock::MockBackend->new() ],
+    );
+    my $backend_guard = backend_guard();
+    my $scopes_guard = Sub::Override->new('Genome::Sys::Lock::scopes', sub { keys %backends });
+    Genome::Sys::Lock->set_backends(%backends);
+
+    my $resource = random_string();
+    my %lock_params = (
+        block_sleep => 0,
+        max_try => 0,
+    );
+
+    my $success = Genome::Sys::LockMigrationProxy->new(
+        old => {
+            resource => $resource,
+            scope => 'test_old',
+        },
+        new => {
+            resource => $resource,
+            scope => 'test_new',
+        },
+    )->lock(%lock_params);
+    ok($success, q(successfully locked LockMigrationProxy));
+
+    my $old_lock = Genome::Sys::Lock->lock_resource(
+        resource_lock => $resource,
+        scope => 'test_old',
+        %lock_params,
+    );
+    is($old_lock, undef, q(failed to lock on 'test_old' after LockMigrationProxy locked));
+
+    my $new_lock = Genome::Sys::Lock->lock_resource(
+        resource_lock => $resource,
+        scope => 'test_new',
+        %lock_params,
+    );
+    is($new_lock, undef, q(failed to lock on 'test_new' after LockMigrationProxy locked));
+};
+
+sub random_string {
+    my @chars = map { (shuffle 'a'..'z', 'A'..'Z', 0..9)[0] } 1..10;
+    return join('', @chars);
+}
+
+sub backend_guard {
+    my %old_backends = Genome::Sys::Lock::all_backends();
+    return Scope::Guard->new(sub { Genome::Sys::Lock->set_backends(%old_backends) });
+}

--- a/lib/perl/Genome/Sys/LockMigrationProxy.t
+++ b/lib/perl/Genome/Sys/LockMigrationProxy.t
@@ -9,6 +9,7 @@ use Test::More tests => 3;
 use Genome::Sys::Lock qw();
 use Genome::Sys::Lock::MockBackend qw();
 use Genome::Sys::LockMigrationProxy qw();
+use Genome::Utility::Text qw(rand_string);
 use List::Util qw(shuffle);
 use Scope::Guard qw();
 use Sub::Override qw();
@@ -24,7 +25,7 @@ subtest 'old fails' => sub {
     my $scopes_guard = Sub::Override->new('Genome::Sys::Lock::scopes', sub { keys %backends });
     Genome::Sys::Lock->set_backends(%backends);
 
-    my $resource = random_string();
+    my $resource = rand_string();
     my %lock_params = (
         block_sleep => 0,
         max_try => 0,
@@ -75,7 +76,7 @@ subtest 'new fails' => sub {
     my $scopes_guard = Sub::Override->new('Genome::Sys::Lock::scopes', sub { keys %backends });
     Genome::Sys::Lock->set_backends(%backends);
 
-    my $resource = random_string();
+    my $resource = rand_string();
     my %lock_params = (
         block_sleep => 0,
         max_try => 0,
@@ -126,7 +127,7 @@ subtest 'both ok' => sub {
     my $scopes_guard = Sub::Override->new('Genome::Sys::Lock::scopes', sub { keys %backends });
     Genome::Sys::Lock->set_backends(%backends);
 
-    my $resource = random_string();
+    my $resource = rand_string();
     my %lock_params = (
         block_sleep => 0,
         max_try => 0,
@@ -158,11 +159,6 @@ subtest 'both ok' => sub {
     );
     is($new_lock, undef, q(failed to lock on 'test_new' after LockMigrationProxy locked));
 };
-
-sub random_string {
-    my @chars = map { (shuffle 'a'..'z', 'A'..'Z', 0..9)[0] } 1..10;
-    return join('', @chars);
-}
 
 sub backend_guard {
     my %old_backends = Genome::Sys::Lock::all_backends();

--- a/lib/perl/Genome/Sys/LockProxy.pm
+++ b/lib/perl/Genome/Sys/LockProxy.pm
@@ -3,6 +3,7 @@ package Genome::Sys::LockProxy;
 use strict;
 use warnings;
 
+use Carp qw(croak);
 use Genome::Sys::Lock qw();
 use Params::Validate qw(validate_with);
 use Scalar::Util qw(blessed);
@@ -25,6 +26,9 @@ C<scope> is the scope to which the lock is bound.  See C<Genome::Sys::Lock::scop
 
 sub new {
     my $class = shift;
+    if (ref $class) {
+        croak 'new() should be called as a class method';
+    }
     my %params = validate_with(
         params => \@_,
         spec => Genome::Sys::Lock::PROXY_CONSTRUCTOR_PARAMS_SPEC(),

--- a/lib/perl/Genome/Sys/LockProxy.pm
+++ b/lib/perl/Genome/Sys/LockProxy.pm
@@ -25,11 +25,9 @@ C<scope> is the scope to which the lock is bound.  See C<Genome::Sys::Lock::scop
 
 sub new {
     my $class = shift;
-    my $spec = Genome::Sys::Lock::LOCK_RESOURCE_PARAMS_SPEC();
-    $spec->{resource} = delete $spec->{resource_lock};
     my %params = validate_with(
         params => \@_,
-        spec => $spec,
+        spec => Genome::Sys::Lock::PROXY_CONSTRUCTOR_PARAMS_SPEC(),
     );
     return bless \%params, $class;
 }
@@ -70,11 +68,7 @@ sub lock {
     my $self = shift;
     my %params = validate_with(
         params => \@_,
-        spec => {
-            block_sleep => 0,
-            max_try => 0,
-            wait_announce_interval => 0,
-        },
+        spec => Genome::Sys::Lock::PROXY_LOCK_PARAMS_SPEC(),
     );
     my $locked = Genome::Sys::Lock->lock_resource(%params,
         resource_lock => $self->resource,

--- a/lib/perl/Genome/Sys/LockProxy.pm
+++ b/lib/perl/Genome/Sys/LockProxy.pm
@@ -1,0 +1,106 @@
+package Genome::Sys::LockProxy;
+
+use strict;
+use warnings;
+
+use Genome::Sys::Lock qw();
+use Params::Validate qw(validate_with);
+use Scalar::Util qw(blessed);
+
+=item new()
+
+Keyword Arguments:
+
+=over
+
+=item resource
+
+C<resource> is a unique identifier for some resource.
+
+=item scope
+
+C<scope> is the scope to which the lock is bound.  See C<Genome::Sys::Lock::scopes()> for valid scopes.
+
+=cut
+
+sub new {
+    my $class = shift;
+    my $spec = Genome::Sys::Lock::LOCK_RESOURCE_PARAMS_SPEC();
+    $spec->{resource} = delete $spec->{resource_lock};
+    my %params = validate_with(
+        params => \@_,
+        spec => $spec,
+    );
+    return bless \%params, $class;
+}
+
+=item resource
+
+Accesor for the C<resource> field.
+
+=cut
+
+sub resource {
+    my $self = shift;
+    return $self->{resource};
+}
+
+=item scope
+
+Accesor for the C<scope> field.
+
+=cut
+
+sub scope {
+    my $self = shift;
+    return $self->{scope};
+}
+
+=item lock()
+
+C<lock()> is an instance method with optional parameters C<block_sleep>,
+C<max_try>, or C<wait_announce_interval>.  It behaves similar to
+C<Genome::Sys::Lock::lock_resource()> but on sucess C<lock()> returns an
+instance of C<Genome::Sys::LockProxy> that can later be unlocked with
+C<unlock()>.
+
+=cut
+
+sub lock {
+    my $self = shift;
+    my %params = validate_with(
+        params => \@_,
+        spec => {
+            block_sleep => 0,
+            max_try => 0,
+            wait_announce_interval => 0,
+        },
+    );
+    my $locked = Genome::Sys::Lock->lock_resource(%params,
+        resource_lock => $self->resource,
+        scope => $self->scope,
+    );
+    if ($locked) {
+        return $self;
+    }
+    else {
+        return;
+    }
+}
+
+=item unlock()
+
+C<unlock()> is an instance method that behaves identical to
+C<Genome::Sys::Lock::unlock_resource()>.
+
+=cut
+
+sub unlock {
+    my $self = shift;
+    return ! ! Genome::Sys::Lock->unlock_resource(
+        resource_lock => $self->resource,
+        scope => $self->scope,
+    );
+}
+
+1;

--- a/lib/perl/Genome/Sys/LockProxy.t
+++ b/lib/perl/Genome/Sys/LockProxy.t
@@ -9,6 +9,7 @@ use Test::More tests => 5;
 use Genome::Sys::Lock qw();
 use Genome::Sys::LockProxy qw();
 use Genome::Sys::Lock::MockBackend qw();
+use Genome::Utility::Text qw(rand_string);
 use List::Util qw(shuffle);
 use Scope::Guard qw();
 use Sub::Override qw();
@@ -20,7 +21,7 @@ my $backend_guard = backend_guard();
 Genome::Sys::Lock->set_backends(%backends);
 
 my $lock = Genome::Sys::LockProxy->new(
-    resource => random_string(),
+    resource => rand_string(),
     scope => 'site',
 );
 
@@ -29,11 +30,6 @@ ok(!$lock->lock, 'second lock fails');
 ok($lock->unlock, 'unlock succeeds');
 ok($lock->lock, 'lock after unlock succeeds');
 ok($lock->unlock, 'final unlock succeeds');
-
-sub random_string {
-    my @chars = map { (shuffle 'a'..'z', 'A'..'Z', 0..9)[0] } 1..10;
-    return join('', @chars);
-}
 
 sub backend_guard {
     my %old_backends = Genome::Sys::Lock::all_backends();

--- a/lib/perl/Genome/Sys/LockProxy.t
+++ b/lib/perl/Genome/Sys/LockProxy.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+use Genome;
+use Test::More tests => 5;
+
+use Genome::Sys::Lock qw();
+use Genome::Sys::LockProxy qw();
+use Genome::Sys::Lock::MockBackend qw();
+use List::Util qw(shuffle);
+use Scope::Guard qw();
+use Sub::Override qw();
+
+my %backends = (
+    site => [ Genome::Sys::Lock::MockBackend->new() ],
+);
+my $backend_guard = backend_guard();
+Genome::Sys::Lock->set_backends(%backends);
+
+my $lock = Genome::Sys::LockProxy->new(
+    resource => random_string(),
+    scope => 'site',
+);
+
+ok($lock->lock, 'lock succeeds');
+ok(!$lock->lock, 'second lock fails');
+ok($lock->unlock, 'unlock succeeds');
+ok($lock->lock, 'lock after unlock succeeds');
+ok($lock->unlock, 'final unlock succeeds');
+
+sub random_string {
+    my @chars = map { (shuffle 'a'..'z', 'A'..'Z', 0..9)[0] } 1..10;
+    return join('', @chars);
+}
+
+sub backend_guard {
+    my %old_backends = Genome::Sys::Lock::all_backends();
+    return Scope::Guard->new(sub { Genome::Sys::Lock->set_backends(%old_backends) });
+}

--- a/lib/perl/Genome/Utility/Text.pm
+++ b/lib/perl/Genome/Utility/Text.pm
@@ -6,7 +6,7 @@ use warnings;
 use POSIX "floor";
 use List::Util 'max';
 require Carp;
-use Params::Validate qw(:types);
+use Params::Validate qw(validate :types);
 
 require Exporter;
 our @ISA = qw(Exporter);
@@ -17,6 +17,7 @@ our @EXPORT_OK = qw(camel_case_to_string
                     param_string_to_hash
                     sanitize_string_for_filesystem
                     find_diff_pos
+                    rand_string
                     side_by_side
                     string_to_camel_case
                     strip_color
@@ -158,6 +159,16 @@ sub find_diff_pos {
         push @diff_pos, $-[0];
     }
     return @diff_pos;
+}
+
+sub rand_string {
+    my %params = validate(@_, {
+        length => { default => 10 },
+        chars  => { default => ['a'..'z', 'A'..'Z', 0..9] },
+    });
+    my $n = @{$params{chars}};
+    my @chars = map { $params{chars}->[rand $n] } 1..$params{length};
+    return join('', @chars);
 }
 
 # put text side_by_side

--- a/lib/perl/Genome/Utility/Text.t
+++ b/lib/perl/Genome/Utility/Text.t
@@ -65,4 +65,14 @@ subtest justify_spacer => sub {
     is(justify('12345', 'center', 9, '.', '  '), '  12345  ', 'Center justification works');
 };
 
+subtest rand_string => sub {
+    plan tests => 5;
+    my $func = \&Genome::Utility::Text::rand_string;
+    ok(length($func->()) > 0, 'default length is greater than zero');
+    is(length($func->(length =>  5)),  5, 'specifying length works');
+    is(length($func->(length => 13)), 13, 'specifying length works');
+    like($func->(chars => [0..9]), qr(^\d+$),        'specifying chars works');
+    like($func->(chars => ['a'..'z']), qr(^[a-z]+$), 'specifying chars works');
+};
+
 done_testing();

--- a/lib/perl/PAP/Command/UploadResult.pm
+++ b/lib/perl/PAP/Command/UploadResult.pm
@@ -7,6 +7,7 @@ use Bio::DB::BioDB;
 use Bio::DB::Query::BioQuery;
 
 use Genome::Sys;
+use Genome::Sys::LockProxy qw();
 
 class PAP::Command::UploadResult {
     is  => 'PAP::Command',
@@ -48,22 +49,22 @@ sub execute {
     my $self = shift;
 
     my $lock_path = "PAP_Command/UploadResult";
-    my $lock = Genome::Sys->lock_resource(
+    my $lock = Genome::Sys::LockProxy->new(
         resource_lock => $lock_path,
+        scope => 'site',
+    )->lock(
         block_sleep => 90,
         max_try => 10_000,
-        scope => 'site',
     );
     unless ($lock) {
         die "Failed to get the lock to upload to BioSQL";
     }
 
-    my $commit_observer;
-    my $unlock_sub = sub {
-        Genome::Sys->unlock_resource(resource_lock => $lock);
-        $commit_observer->delete;
-    };
-    $commit_observer = UR::Context->process->add_observer(aspect => 'commit', callback => $unlock_sub);
+    my $commit_observer = UR::Context->process->add_observer(
+        aspect => 'commit',
+        callback => sub { $lock->unlock() },
+        once => 1,
+    );
     unless ($commit_observer) {
         $self->error_message("Failed to add commit observer to unlock $lock.");
     }


### PR DESCRIPTION
The primary goal is to cleanup/finish the scoping of locks that was started
previously with the addition of the `scope` option and the definition of the
`site`, `tgisan`, and `unknown` scopes.  I believe the goal being to have just
`site` and `host` scopes at this time.

This will require migrating locks from one scope to another at dozens of
locations.  We have also had occasions where we need to migrate from one
resource (name) to another.  So I am trying to make a helper class,
`Genome::Sys::LockMigrationProxy`, to make these types of migrations almost trivial.

As part of that work I needed to lift the restriction on not allowing
locks at multiple scopes.  In trying to do that I discovered that
`unlock_resource` was looking up the scope instead of requiring it as an
argument.  Really a lock is defined by the resource (name) and the scope so I
created an object to encapsulate those, `Genome::Sys::LockProxy`.

Related PRs:

- genome/genome#386
- genome/genome#527
- genome/genome#514 and genome/genome#537