### PR TITLE
Add shortcut to adaptor class

### DIFF
--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/Adaptor.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/Adaptor.pm
@@ -27,8 +27,7 @@ class Genome::VariantReporting::Suite::BamReadcount::Adaptor {
 
 sub shortcut {
     my $self = shift;
-    $self->resolve_plan_attributes;
-    return 1;
+    return $self->execute;
 }
 
 sub execute {

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/Adaptor.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/Adaptor.pm
@@ -25,6 +25,12 @@ class Genome::VariantReporting::Suite::BamReadcount::Adaptor {
     ],
 };
 
+sub shortcut {
+    my $self = shift;
+    $self->resolve_plan_attributes;
+    return 1;
+}
+
 sub execute {
     my $self = shift;
 


### PR DESCRIPTION
I noticed this was being submitted every time as a separate lsf job.  There is no reason why this should ever need to run with lots of resources.