### PR TITLE
Fix test failure when running ./WorkflowBuilder/StreamGraph.t

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/StreamGraph.t
+++ b/lib/perl/Genome/WorkflowBuilder/StreamGraph.t
@@ -9,13 +9,14 @@ use strict;
 use warnings;
 
 use above "Genome";
+use File::Spec;
 use Test::More;
 use Genome::Utility::Test qw(compare_ok);
 
 my $pkg = 'Genome::WorkflowBuilder::StreamGraph';
 
 use_ok($pkg);
-my $test_dir = __FILE__.".d";
+my $test_dir = File::Spec->canonpath(__FILE__.".d");
 my $expected_out = File::Spec->join($test_dir, "out");
 my $expected_xml = File::Spec->join($test_dir, "xml");
 


### PR DESCRIPTION
The test would work when running like so:
```
$ genome-perl WorkflowBuilder/StreamGraph.t
```
But not like so:
```
$ genome-perl ./WorkflowBuilder/StreamGraph.t
```
(`WorkflowBuilder` versus `./WorkflowBuilder`)

Not sure if using `File::Spec->canonpath` is the best fix, but I think this should fix Perl tests, which appear to be calling this test with the `./`:
```
#   Failed test 'xml produced correctly'
#   at ./WorkflowBuilder/StreamGraph.t line 59.
```