### PR TITLE
Make a class for merged AlignedBamResults and use it where appropriate

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignedBamResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignedBamResult/Merged.pm
@@ -1,0 +1,12 @@
+package Genome::InstrumentData::AlignedBamResult::Merged;
+
+use strict;
+use warnings;
+use Genome;
+
+class Genome::InstrumentData::AlignedBamResult::Merged {
+    is => 'Genome::InstrumentData::AlignedBamResult',
+    is_abstract => 1,
+};
+
+1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -15,7 +15,7 @@ use Genome;
 use Genome::Utility::Text; #quiet warning about deprecated use of autoload
 
 class Genome::InstrumentData::AlignmentResult::Merged {
-    is => ['Genome::InstrumentData::AlignedBamResult', 'Genome::SoftwareResult::WithNestedResults'],
+    is => ['Genome::InstrumentData::AlignedBamResult::Merged', 'Genome::SoftwareResult::WithNestedResults'],
     has => [
         instrument_data => {
             is => 'Genome::InstrumentData',

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/CoverageStats.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/CoverageStats.pm
@@ -59,7 +59,7 @@ class Genome::InstrumentData::AlignmentResult::Merged::CoverageStats {
     ],
     has => [
         alignment_result => {
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
             id_by => 'alignment_result_id',
             doc => 'the alignment data upon which to run coverage stats',
         },

--- a/lib/perl/Genome/InstrumentData/BamUtil/ClipOverlapResult.pm
+++ b/lib/perl/Genome/InstrumentData/BamUtil/ClipOverlapResult.pm
@@ -6,10 +6,10 @@ use warnings;
 use Genome;
 
 class Genome::InstrumentData::BamUtil::ClipOverlapResult {
-    is => 'Genome::InstrumentData::AlignedBamResult',
+    is => 'Genome::InstrumentData::AlignedBamResult::Merged',
     has_input => [
         bam_source => { # PROVIDES bam_path SHOULD be in aligned bam result, but would be incompatible with AR::Merged
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
         },
     ],
     has_param => [

--- a/lib/perl/Genome/InstrumentData/Command/RefineReads/ClipOverlap.pm
+++ b/lib/perl/Genome/InstrumentData/Command/RefineReads/ClipOverlap.pm
@@ -11,7 +11,7 @@ class Genome::InstrumentData::Command::RefineReads::ClipOverlap {
     is => 'Command::V2',
     has => [
         version => { is => 'Text', },
-        bam_source => { is => 'Genome::InstrumentData::AlignedBamResult', },
+        bam_source => { is => 'Genome::InstrumentData::AlignedBamResult::Merged', },
         result_users => { is => 'HASH' },
     ],
     has_optional => [

--- a/lib/perl/Genome/InstrumentData/Command/RefineReads/GatkBase.pm
+++ b/lib/perl/Genome/InstrumentData/Command/RefineReads/GatkBase.pm
@@ -12,7 +12,7 @@ class Genome::InstrumentData::Command::RefineReads::GatkBase {
     is_abstract => 1,
     has_input => {
         version => { is => 'Text', },
-        bam_source => { is => 'Genome::InstrumentData::AlignedBamResult', },
+        bam_source => { is => 'Genome::InstrumentData::AlignedBamResult::Merged', },
         result_users => { is => 'HASH' },
     },
     has_param => {
@@ -27,11 +27,11 @@ class Genome::InstrumentData::Command::RefineReads::GatkBase {
         params => { is => 'Text', }, # FIXME not used
     },
     has_many_optional_transient => {
-        results => { is => 'Genome::InstrumentData::AlignedBamResult', },
+        results => { is => 'Genome::InstrumentData::AlignedBamResult::Merged', },
     },
     has_optional_calculated => {
         final_result => { 
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
             calculate_from => [qw/ results /],
             calculate => q( my @results = $self->results; return $results[$#results]; ),
         },

--- a/lib/perl/Genome/InstrumentData/Composite.pm
+++ b/lib/perl/Genome/InstrumentData/Composite.pm
@@ -28,7 +28,7 @@ class Genome::InstrumentData::Composite {
             doc => 'When merging, collect instrument data together that share this property',
         },
         _merged_results => {
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
             is_transient => 1,
             is_optional => 1,
             doc => 'Holds the underlying merged results',
@@ -103,7 +103,7 @@ sub get_or_create {
     #    $result->add_user(label => 'uses', user => $self);
     #}
 
-    my @merged_results = grep(! $_->isa('Genome::InstrumentData::AlignmentResult'), grep($_->isa('Genome::InstrumentData::AlignedBamResult'), @all_results));
+    my @merged_results = grep($_->isa('Genome::InstrumentData::AlignedBamResult::Merged'), @all_results);
     $self->debug_message('Found '.@merged_results.' merged results');
     $self->_merged_results(\@merged_results);
 

--- a/lib/perl/Genome/InstrumentData/Gatk/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Gatk/Base.pm
@@ -6,10 +6,10 @@ use warnings;
 use Genome;
 
 class Genome::InstrumentData::Gatk::Base {
-    is => 'Genome::InstrumentData::AlignedBamResult',
+    is => 'Genome::InstrumentData::AlignedBamResult::Merged',
     has_input => [
         bam_source => { # PROVIDES bam_path SHOULD be in aligned bam result, but would be incompatible with AR::Merged
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
         },
     ],
     has_param => [

--- a/lib/perl/Genome/InstrumentData/VerifyBamIdResult.pm
+++ b/lib/perl/Genome/InstrumentData/VerifyBamIdResult.pm
@@ -15,7 +15,7 @@ class Genome::InstrumentData::VerifyBamIdResult {
     is => ['Genome::SoftwareResult::Stageable', 'Genome::SoftwareResult::WithNestedResults'],
     has_input => [
         aligned_bam_result => {
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
         },
         on_target_list => {
             is => "Genome::FeatureList",

--- a/lib/perl/Genome/Model/Build/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation.pm
@@ -92,26 +92,26 @@ class Genome::Model::Build::SomaticValidation {
         },
 
         merged_alignment_result => {
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
             via => 'result_users',
             to => 'software_result',
             where => [label => 'merged_alignment'],
         },
         control_merged_alignment_result => {
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
             via => 'result_users',
             to => 'software_result',
             where => [label => 'control_merged_alignment'],
         },
 
         coverage_stats_result => {
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignmentResult::Merged::CoverageStats',
             via => 'result_users',
             to => 'software_result',
             where => [label => 'coverage_stats_tumor'],
         },
         control_coverage_stats_result  => {
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignmentResult::Merged::CoverageStats',
             via => 'result_users',
             to => 'software_result',
             where => [label => 'coverage_stats_normal'],

--- a/lib/perl/Genome/Model/Build/SomaticValidation/IdentifyDnpResult.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation/IdentifyDnpResult.pm
@@ -22,7 +22,7 @@ class Genome::Model::Build::SomaticValidation::IdentifyDnpResult {
             id_by => 'dv2_result_id',
         },
         tumor_alignment_result => {
-            is => 'Genome::InstrumentData::AlignedBamResult',
+            is => 'Genome::InstrumentData::AlignedBamResult::Merged',
             id_by => 'tumor_aligment_result_id',
         },
     ],

--- a/lib/perl/Genome/Model/SomaticValidation/Command/IdentifyDnp.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/IdentifyDnp.pm
@@ -55,7 +55,7 @@ sub params_for_result {
     my $build = $self->build;
     my @result_users = Genome::SoftwareResult::User->get(user => $build);
     my @results = map($_->software_result, @result_users);
-    my @merged_results = grep { $_->isa('Genome::InstrumentData::AlignedBamResult') } @results;
+    my @merged_results = grep { $_->isa('Genome::InstrumentData::AlignedBamResult::Merged') } @results;
     my ($tumor_alignment_result) = grep( ($_->instrument_data)[0]->sample eq $build->tumor_sample, @merged_results);
 
     my $tumor_aligment_result_id = $tumor_alignment_result->id;

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/RunResult.pm
@@ -31,7 +31,7 @@ sub output_filename {
 
 sub aligned_bam_result {
     my $self = shift;
-    return Genome::InstrumentData::AlignedBamResult->get($self->aligned_bam_result_id);
+    return Genome::InstrumentData::AlignedBamResult::Merged->get($self->aligned_bam_result_id);
 }
 
 sub _run {


### PR DESCRIPTION
This allows us to differentiate between per-lane and merged aligned bam results.

This replaces https://github.com/genome/genome/pull/594 and will fix model tests. 