### PR TITLE
Narrow down choices of convertible references by preferring an input.

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/Merge.pm
+++ b/lib/perl/Genome/FeatureList/Command/Merge.pm
@@ -6,6 +6,7 @@ use warnings;
 use feature qw(say);
 
 use List::MoreUtils qw(any uniq all);
+use UR::Util;
 use Genome;
 
 class Genome::FeatureList::Command::Merge {
@@ -193,9 +194,9 @@ sub _find_convertible_reference {
     }
 
     #prefer a reference from our original query set
-    my @preferred_references = grep { my $target = $_; any { $_ eq $target } @references } @convertible_references;
-    if (scalar(@preferred_references) eq 1) {
-        return $preferred_references[0];
+    my ($preferred_references) = UR::Util::intersect_lists(\@references, \@convertible_references);
+    if (scalar(@$preferred_references) eq 1) {
+        return $preferred_references->[0];
     }
 
     $class->_die_with_multiple_candidate_references(

--- a/lib/perl/Genome/FeatureList/Command/Merge.pm
+++ b/lib/perl/Genome/FeatureList/Command/Merge.pm
@@ -193,7 +193,7 @@ sub _find_convertible_reference {
     }
 
     #prefer a reference from our original query set
-    my @preferred_references = grep { my $target = $_; any { $_ eq $target } @_ } @convertible_references;
+    my @preferred_references = grep { my $target = $_; any { $_ eq $target } @references } @convertible_references;
     if (scalar(@preferred_references) eq 1) {
         return $preferred_references[0];
     }

--- a/lib/perl/Genome/FeatureList/Command/Merge.pm
+++ b/lib/perl/Genome/FeatureList/Command/Merge.pm
@@ -188,14 +188,20 @@ sub _find_convertible_reference {
         my $target = $_; all { $target->contains($_) || $available_conversions{$_->id}{$target->id} } @references;
     } @target_references;
 
-    if (scalar(@convertible_references) > 1) {
-        $class->_die_with_multiple_candidate_references(
-            'The references of the input feature-lists can be converted to multiple references:',
-            @convertible_references,
-        );
+    if (scalar(@convertible_references) < 2) {
+        return $convertible_references[0];
     }
 
-    return $convertible_references[0];
+    #prefer a reference from our original query set
+    my @preferred_references = grep { my $target = $_; any { $_ eq $target } @_ } @convertible_references;
+    if (scalar(@preferred_references) eq 1) {
+        return $preferred_references[0];
+    }
+
+    $class->_die_with_multiple_candidate_references(
+        'The references of the input feature-lists can be converted to multiple references:',
+        @convertible_references,
+    );
 }
 
 sub _find_combined_reference_with_conversions {


### PR DESCRIPTION
If there are many candidates for conversion but exactly one is in our original query set, then use it rather than force the user to choose.