### PR TITLE
Lock all SR User construction to enforce uniqueness.

### DIFF
--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
@@ -459,6 +459,7 @@ sub _process_and_link_alignments_to_build {
     my @errors;
 
     my $result_users = Genome::SoftwareResult::User->user_hash_for_build($build);
+    $result_users->{uses} = $build;
 
     my %segment_info;
     if (defined $self->instrument_data_segment_id) {
@@ -488,7 +489,7 @@ sub _process_and_link_alignments_to_build {
     }
 
     for my $alignment (@alignments) {
-        my $link = $alignment->add_user(user => $build, label => 'uses');
+        my $link = $alignment->user(user => $build, label => 'uses');
         if ($link) {
             $self->debug_message("Linked alignment " . $alignment->id . " to the build");
         }

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -10,6 +10,7 @@ use Carp qw();
 use Genome::Utility::Text;
 
 class Genome::SoftwareResult::User {
+    is => ['Genome::Utility::ObjectWithLockedConstruction'],
     table_name => 'result.user',
     id_by => [
         id => { is => 'Text', len => 32 },
@@ -192,6 +193,21 @@ sub user_hash_for_build {
         requestor => $build,
         sponsor   => $build->model->analysis_projects // Genome::Sys::User->get(username => $build->model->run_as),
     };
+}
+
+sub lock_id {
+    my $class = shift;
+
+    my $bx = $class->define_boolexpr(@_);
+
+    my $label = $bx->value_for('label');
+    if(length($label) >= 32) {
+        $label = Genome::Sys->md5sum_data($label);
+    }
+
+    return Genome::Utility::Text::sanitize_string_for_filesystem(
+        join('_', $label, $bx->value_for('user_id'), $bx->value_for('software_result_id'))
+    );
 }
 
 1;


### PR DESCRIPTION
This makes sure the user relationship is not created more than once.

I find the `linked alignment ... to the build` debug message to still be useful, but maybe we don't need to separately verify the user was created here?