### PR TITLE
Refactor revivified_alignment_bam_file_paths to handle its own tempdir.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1662,7 +1662,7 @@ sub revivified_alignment_bam_file_paths {
 
     my $temp_allocation = $self->_get_temp_allocation($self->output_dir);
     UR::Context->process->add_observer(
-        aspect => 'commit',
+        aspect => 'pre-commit',
         callback => sub { $temp_allocation->delete; },
     );
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1648,7 +1648,7 @@ sub alignment_bam_file_paths {
 # This method will recreate the per-lane bam file and return the path.
 # This must be provided an allocation into which the bam will go (so that it can be cleaned up in the parent process once it is done).
 # The calling process is responsible for cleaning up the allocation after we are done with it.
-sub revivified_alignment_bam_file_paths {
+sub revivified_alignment_bam_file_path {
     my $self = shift;
 
     # If we have a merged alignment result, the per-lane bam can be regenerated and we will do so now

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -156,7 +156,6 @@ sub create {
     return unless ($self);
 
     $self->_lock_per_lane_alignments();
-    my @temp_allocations = ();
 
     try {
         #TODO In a future version collect relevant alignments from other merged alignment results when available
@@ -175,10 +174,8 @@ sub create {
             #handle duplicates on a per-library basis
             for my $alignment (@alignments) {
                 my $library = $alignment->instrument_data->library;
-                my $temp_allocation = $self->_get_temp_allocation($alignment->id, $self->output_dir);
-                push @{ $bams_per_library->{$library->id} }, $alignment->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
+                push @{ $bams_per_library->{$library->id} }, $alignment->revivified_alignment_bam_file_paths();
                 $libraries->{$library->id} = $library;
-                push @temp_allocations, $temp_allocation;
             }
 
             for my $library_id (keys %$bams_per_library) {
@@ -196,9 +193,7 @@ sub create {
         } else {
             #just collect the BAMs for a merge
             for my $alignment (@alignments) {
-                my $temp_allocation = $self->_get_temp_allocation($alignment->id, $self->output_dir);
-                push @bams_for_final_merge, $alignment->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
-                push @temp_allocations, $temp_allocation;
+                push @bams_for_final_merge, $alignment->revivified_alignment_bam_file_paths();
             }
         }
 
@@ -233,11 +228,6 @@ sub create {
     catch {
         $tx->rollback();
         die $class->error_message('Merge failed due to error: ' . $_);
-    }
-    finally {
-        for my $allocation (@temp_allocations) {
-            $allocation->delete;
-        }
     };
 
     $self->_reallocate_disk_allocation;
@@ -330,23 +320,6 @@ sub _remove_per_lane_bam {
         }
     }
     return 1;
-}
-
-sub _get_temp_allocation {
-    my ($self, $alignment_id, $output_dir) = @_;
-    return Genome::Disk::Allocation->create(
-        disk_group_name     => $ENV{GENOME_DISK_GROUP_ALIGNMENTS},
-        allocation_path     => 'merged/recreated_per_lane_bam/'.$alignment_id.'_'._get_uuid_string(),
-        kilobytes_requested => Genome::Sys->disk_usage_for_path($output_dir),
-        owner_class_name    => 'Genome::Sys::User',
-        owner_id            => Genome::Sys->username,
-    );
-}
-
-sub _get_uuid_string {
-    my $ug = Data::UUID->new();
-    my $uuid = $ug->create();
-    return $ug->to_string($uuid);
 }
 
 sub collect_individual_alignments {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -174,7 +174,7 @@ sub create {
             #handle duplicates on a per-library basis
             for my $alignment (@alignments) {
                 my $library = $alignment->instrument_data->library;
-                push @{ $bams_per_library->{$library->id} }, $alignment->revivified_alignment_bam_file_paths();
+                push @{ $bams_per_library->{$library->id} }, $alignment->revivified_alignment_bam_file_path;
                 $libraries->{$library->id} = $library;
             }
 
@@ -193,7 +193,7 @@ sub create {
         } else {
             #just collect the BAMs for a merge
             for my $alignment (@alignments) {
-                push @bams_for_final_merge, $alignment->revivified_alignment_bam_file_paths();
+                push @bams_for_final_merge, $alignment->revivified_alignment_bam_file_path;
             }
         }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
@@ -84,8 +84,8 @@ subtest 'test per lane bam removal and recreation' => sub {
 
     # The old and new paths should differ because the file has been revivified elsewhere
     my $old_path = File::Spec->join($ar2->output_dir, $per_lane_bam);
-    my $new_path = $ar2->revivified_alignment_bam_file_paths();
-    isnt($old_path, $new_path, 'AR2 revivified_alignment_bam_file_paths exist and the path has changed');
+    my $new_path = $ar2->revivified_alignment_bam_file_path;
+    isnt($old_path, $new_path, 'AR2 revivified_alignment_bam_file_path exist and the path has changed');
 
     for my $extension qw(.bam .bam.bai) {
         my $base = $per_lane_file_basename.$extension;
@@ -94,8 +94,8 @@ subtest 'test per lane bam removal and recreation' => sub {
         ok(!-s $file, "File $base removed ok as expected");
     }
 
-    my @revivified_bams = $ar2->revivified_alignment_bam_file_paths();
-    ok(-s $revivified_bams[0], 'AR2 revivified_alignment_bam_file_paths revivified as per lane bam ok');
+    my @revivified_bams = $ar2->revivified_alignment_bam_file_path;
+    ok(-s $revivified_bams[0], 'AR2 revivified_alignment_bam_file_path revivified as per lane bam ok');
 
     my $new_flagstat_file = Genome::Sys->create_temp_file_path;
     `samtools flagstat $revivified_bams[0] > $new_flagstat_file`;
@@ -237,7 +237,7 @@ subtest 'test per lane bam removal and recreation - AlignedBamResult accessors' 
     );
 
     # The revivified bam will be in a different location
-    my $new_path = $ar2->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
+    my $new_path = $ar2->revivified_alignment_bam_file_path(disk_allocation => $temp_allocation);
 
     SKIP: {
         # This test currently fails because the bam_path points to the original

--- a/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
@@ -82,17 +82,9 @@ subtest 'test per lane bam removal and recreation' => sub {
     Genome::Sys->copy_file(File::Spec->join($test_data_dir, 'ar2', $per_lane_header), $ar2_header);
     ok(-s $ar2_header, "$per_lane_header copied over ok");
 
-    my $temp_allocation_dir = Genome::Sys->create_temp_directory();
-    my $owner = Genome::Sys::User->get(username=>"apipe-tester");
-
-    my $temp_allocation = $allocation_class->generate_obj(
-        mount_path => $temp_allocation_dir,
-        owner => $owner,
-    );
-
     # The old and new paths should differ because the file has been revivified elsewhere
     my $old_path = File::Spec->join($ar2->output_dir, $per_lane_bam);
-    my $new_path = $ar2->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
+    my $new_path = $ar2->revivified_alignment_bam_file_paths();
     isnt($old_path, $new_path, 'AR2 revivified_alignment_bam_file_paths exist and the path has changed');
 
     for my $extension qw(.bam .bam.bai) {
@@ -102,8 +94,8 @@ subtest 'test per lane bam removal and recreation' => sub {
         ok(!-s $file, "File $base removed ok as expected");
     }
 
-    my @revivified_bams = $ar2->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
-    is_deeply(\@revivified_bams, [File::Spec->join($temp_allocation_dir, $per_lane_bam)], 'AR2 revivified_alignment_bam_file_paths revivified as per lane bam ok');
+    my @revivified_bams = $ar2->revivified_alignment_bam_file_paths();
+    ok(-s $revivified_bams[0], 'AR2 revivified_alignment_bam_file_paths revivified as per lane bam ok');
 
     my $new_flagstat_file = Genome::Sys->create_temp_file_path;
     `samtools flagstat $revivified_bams[0] > $new_flagstat_file`;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
@@ -228,24 +228,11 @@ sub get_test_alignment_results {
 }
 
 subtest 'test per lane bam removal and recreation - AlignedBamResult accessors' => sub {
-    my $temp_allocation_dir = Genome::Sys->create_temp_directory();
-    my $owner = Genome::Sys::User->get(username=>"apipe-tester");
-
-    my $temp_allocation = $allocation_class->generate_obj(
-        mount_path => $temp_allocation_dir,
-        owner => $owner,
-    );
-
-    # The revivified bam will be in a different location
+    # The old and new paths should differ because the file has been revivified elsewhere
+    my $old_path = File::Spec->join($ar2->output_dir, $per_lane_bam);
     my $new_path = $ar2->revivified_alignment_bam_file_path;
+    isnt($old_path, $new_path, 'AR2 revivified_alignment_bam_file_path exist and the path has changed');
 
-    SKIP: {
-        # This test currently fails because the bam_path points to the original
-        # output_dir. This will change once we have a universal method to get to
-        # the bam's path (which shouldn't be called bam_path)
-        skip "revivified bam path not implemented", 1;
-        is($ar2->bam_path, File::Spec->join($temp_allocation_dir, $per_lane_bam), 'bam_path correct after revivification');
-    }
     is($ar2->bam_flagstat_path, File::Spec->join($ar2->output_dir, $per_lane_flagstat), 'bam_flagstat_path correct after revivification');
     is($ar2->bam_md5_path, File::Spec->join($ar2->output_dir, 'all_sequences.bam.md5'), 'bam_md5_path correct after revivification');
 };

--- a/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
@@ -237,7 +237,7 @@ subtest 'test per lane bam removal and recreation - AlignedBamResult accessors' 
     );
 
     # The revivified bam will be in a different location
-    my $new_path = $ar2->revivified_alignment_bam_file_path(disk_allocation => $temp_allocation);
+    my $new_path = $ar2->revivified_alignment_bam_file_path;
 
     SKIP: {
         # This test currently fails because the bam_path points to the original

--- a/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
@@ -252,7 +252,7 @@ sub _run_htseq_count {
         $self->debug_message("No temp_scratch_directory found: name sort the BAM in temp space.");
 
         my $temp_allocation = Genome::InstrumentData::AlignmentResult::Merged->_get_temp_allocation($alignment_result->id, $output_dir);
-        my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_path(disk_allocation => $temp_allocation);
+        my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_path;
 
         my $sorted_bam_noprefix = "$tmp/all_sequences.namesorted";
         $sorted_bam = $sorted_bam_noprefix . '.bam';

--- a/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
@@ -252,7 +252,7 @@ sub _run_htseq_count {
         $self->debug_message("No temp_scratch_directory found: name sort the BAM in temp space.");
 
         my $temp_allocation = Genome::InstrumentData::AlignmentResult::Merged->_get_temp_allocation($alignment_result->id, $output_dir);
-        my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
+        my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_path(disk_allocation => $temp_allocation);
 
         my $sorted_bam_noprefix = "$tmp/all_sequences.namesorted";
         $sorted_bam = $sorted_bam_noprefix . '.bam';

--- a/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
@@ -251,7 +251,6 @@ sub _run_htseq_count {
         # a completed alignment result will need to have a sorted bam created
         $self->debug_message("No temp_scratch_directory found: name sort the BAM in temp space.");
 
-        my $temp_allocation = Genome::InstrumentData::AlignmentResult::Merged->_get_temp_allocation($alignment_result->id, $output_dir);
         my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_path;
 
         my $sorted_bam_noprefix = "$tmp/all_sequences.namesorted";

--- a/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
@@ -261,8 +261,6 @@ sub _run_htseq_count {
             input_files => [$unsorted_bam],
             output_files => [$sorted_bam],
         );
-
-        $temp_allocation->delete;
     }
 
     my @header = `$samtools_path view -H $sorted_bam`;


### PR DESCRIPTION
This PR allows `revivified_alignment_bam_file_paths` to handle its own temporary allocation to ease the burden on those who would call it.

Arguably we should refactor `revivified_alignment_bam_file_paths` and `alignment_bam_file_paths` into the same method with a `force` parameter but that is not yet included.