### PR TITLE
Picard needs to know the name in the VCF.

### DIFF
--- a/lib/perl/Genome/Model/ReferenceAlignment/Command/GenotypeMicroarrayConcordance.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Command/GenotypeMicroarrayConcordance.pm
@@ -86,7 +86,7 @@ sub execute {
             call_vcf => $intersect_vcf,
             output => $output,
             truth_sample => $genotype_sample->name,
-            call_sample => $qc_build->model->subject->name,
+            call_sample => $qc_build->model->subject->name_in_vcf,
             min_dp => $self->minimum_depth,
             use_version => $self->picard_version,
         );


### PR DESCRIPTION
(This is different from the name for TCGA samples, for example.)