### PR TITLE
When Tiering in SomVar only Consider Results we "Use"

### DIFF
--- a/lib/perl/Genome/Model/SomaticVariation/Command/TierVariants.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/TierVariants.pm
@@ -189,7 +189,7 @@ sub params_for_result {
     my $variant_type = shift;
     my $build = $self->build;
 
-    my @results = List::MoreUtils::uniq $build->results;
+    my @results = List::MoreUtils::uniq map { $_->software_result } $build->result_users(label => 'uses');
     my $target_class;
     if($qual eq 'hq') {
         $target_class = 'Genome::Model::Tools::DetectVariants2::Classify::PreviouslyDiscovered';

--- a/lib/perl/Genome/Model/SomaticVariation/Command/TierVariants.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/TierVariants.pm
@@ -189,7 +189,9 @@ sub params_for_result {
     my $variant_type = shift;
     my $build = $self->build;
 
-    my @results = List::MoreUtils::uniq map { $_->software_result } $build->result_users(label => 'uses');
+    my @results = Genome::SoftwareResult->get([
+        map $_->software_result_id, $build->result_users(label => 'uses')
+    ]);
     my $target_class;
     if($qual eq 'hq') {
         $target_class = 'Genome::Model::Tools::DetectVariants2::Classify::PreviouslyDiscovered';


### PR DESCRIPTION
The specific scenario motivating this PR is that the `copy-number-with-bam-window` detector runs two mini DV2s inside of itself.  The results generated by those detectors were previously not linked to the build, but the user-tracking system means that the build is now their `creator`.  Since all the official DV2 results should [have the `uses` label applied](https://github.com/genome/genome/blob/166fc8310843c2f73f34e887731b9fc2bbdd9a07/lib/perl/Genome/Model/SomaticVariation/Command/DetectVariants.pm#L87-L90), limit our search here to those results.