### PR TITLE
only build workflows should go in build workflow queue

### DIFF
--- a/lib/perl/Genome/Model/SmallRna/Command/ClusterCoverage.pm
+++ b/lib/perl/Genome/Model/SmallRna/Command/ClusterCoverage.pm
@@ -44,7 +44,7 @@ class Genome::Model::SmallRna::Command::ClusterCoverage {
 
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '-R \'select[mem>16000] rusage[mem=16000]\' -M 16000000 ',

--- a/lib/perl/Genome/Model/SmallRna/Command/StatsGenerator.pm
+++ b/lib/perl/Genome/Model/SmallRna/Command/StatsGenerator.pm
@@ -72,7 +72,7 @@ class Genome::Model::SmallRna::Command::StatsGenerator {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '-R \'select[mem>16000] rusage[mem=16000]\' -M 16000000 ',

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Polymutt.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Polymutt.pm
@@ -13,7 +13,7 @@ class Genome::Model::Tools::DetectVariants2::Polymutt {
     is => ['Genome::Model::Tools::DetectVariants2::Detector'],
     has_param => [
         lsf_queue=> {
-            default => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
     ],
 };

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/Consensus.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/Consensus.pm
@@ -102,7 +102,7 @@ class Genome::Model::Tools::SmrtAnalysis::Consensus {
     },
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/ConsensusReports.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/ConsensusReports.pm
@@ -30,7 +30,7 @@ class Genome::Model::Tools::SmrtAnalysis::ConsensusReports {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/Control.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/Control.pm
@@ -96,7 +96,7 @@ class Genome::Model::Tools::SmrtAnalysis::Control {
     },
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/ControlReports.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/ControlReports.pm
@@ -28,7 +28,7 @@ class Genome::Model::Tools::SmrtAnalysis::ControlReports {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/Filter.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/Filter.pm
@@ -43,7 +43,7 @@ class Genome::Model::Tools::SmrtAnalysis::Filter {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/FilterReports.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/FilterReports.pm
@@ -29,7 +29,7 @@ class Genome::Model::Tools::SmrtAnalysis::FilterReports {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/Mapping.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/Mapping.pm
@@ -80,7 +80,7 @@ class Genome::Model::Tools::SmrtAnalysis::Mapping {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/MappingReports.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/MappingReports.pm
@@ -32,7 +32,7 @@ class Genome::Model::Tools::SmrtAnalysis::MappingReports {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/Rccs.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/Rccs.pm
@@ -53,7 +53,7 @@ class Genome::Model::Tools::SmrtAnalysis::Rccs {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/SmrtAnalysis/RccsReports.pm
+++ b/lib/perl/Genome/Model/Tools/SmrtAnalysis/RccsReports.pm
@@ -25,7 +25,7 @@ class Genome::Model::Tools::SmrtAnalysis::RccsReports {
     ],
     has_optional_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
         lsf_resource => {
             default_value => '',

--- a/lib/perl/Genome/Model/Tools/Somatic/LaunchPindel.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/LaunchPindel.pm
@@ -93,7 +93,7 @@ sub execute {
             $self->debug_message("using $newlib include on bsub");
         }
         my $reference_build_id=$self->reference_sequence_build;
-        print `bsub -u $email_address -N -q $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW} "perl $include -S gmt detect-variants2 dispatcher --aligned-reads-input $tumor_bam    --control-aligned-reads-input $normal_bam --reference-build-id $reference_build_id --output-directory $output --indel-detection-strategy 'pindel 0.4 filtered by pindel-somatic-calls v1 then pindel-read-support v1'"`;
+        print `bsub -u $email_address -N -q $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW} "perl $include -S gmt detect-variants2 dispatcher --aligned-reads-input $tumor_bam    --control-aligned-reads-input $normal_bam --reference-build-id $reference_build_id --output-directory $output --indel-detection-strategy 'pindel 0.4 filtered by pindel-somatic-calls v1 then pindel-read-support v1'"`;
         return 1;
     }
 1;

--- a/lib/perl/Genome/ModelGroup/Command/RunPindel.pm
+++ b/lib/perl/Genome/ModelGroup/Command/RunPindel.pm
@@ -55,7 +55,7 @@ class Genome::ModelGroup::Command::RunPindel {
     ],
     has_param => [
         lsf_queue => {
-            default_value => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+            default_value => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         },
     ],
 };

--- a/lib/perl/Genome/Process/Command/Run.pm
+++ b/lib/perl/Genome/Process/Command/Run.pm
@@ -148,7 +148,7 @@ sub _bsub_in_pend_state {
         log_file => $self->workflow_process_out_log,
         hold_job => 1,
         project => $self->process->workflow_name,
-        queue => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
+        queue => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
         send_job_report => 1,
         never_rerunnable => 1,
     );

--- a/lib/perl/Genome/Process/Command/Run.pm
+++ b/lib/perl/Genome/Process/Command/Run.pm
@@ -148,7 +148,7 @@ sub _bsub_in_pend_state {
         log_file => $self->workflow_process_out_log,
         hold_job => 1,
         project => $self->process->workflow_name,
-        queue => $ENV{GENOME_LSF_QUEUE_DV2_WORKFLOW},
+        queue => $ENV{GENOME_LSF_QUEUE_BUILD_WORKFLOW},
         send_job_report => 1,
         never_rerunnable => 1,
     );


### PR DESCRIPTION
This doesn't really solve the problem pointed out in RT#104979 but instead
probably just moves it to another queue.  A better solution should be possible
after the LSF queues are redesigned in a couple weeks.