### PR TITLE
Deduplicate histogram and metrics processing subroutines.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -480,7 +480,7 @@ sub _parse_metrics_file_into_hashref {
     my $metrics_fh = Genome::Sys->open_file_for_reading($metrics_file);
 
     my $metric_key_index;
-    unless ($metric_header_as_key) {
+    unless (defined $metric_header_as_key) {
         if ($class->can('_metric_header_as_key')) {
             $metric_header_as_key = $class->_metric_header_as_key;
         } else {

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -461,7 +461,23 @@ MESSAGE
 sub parse_file_into_metrics_hashref {
     my ($class,$metrics_file,$metric_header_as_key) = @_;
 
-    my $is_fh = Genome::Sys->open_file_for_reading($metrics_file);
+    my $header_regex = qr(^## METRICS CLASS);
+
+    return $class->_parse_metrics_file_into_hashref($metrics_file, $metric_header_as_key, $header_regex);
+}
+
+sub parse_metrics_file_into_histogram_hashref {
+    my ($class,$metrics_file,$metric_header_as_key) = @_;
+
+    my $header_regex = qr(^## HISTOGRAM);
+
+    return $class->_parse_metrics_file_into_hashref($metrics_file, $metric_header_as_key, $header_regex);
+}
+
+sub _parse_metrics_file_into_hashref {
+    my ($class, $metrics_file, $metric_header_as_key, $header_regex) = @_;
+
+    my $metrics_fh = Genome::Sys->open_file_for_reading($metrics_file);
 
     my $metric_key_index;
     unless ($metric_header_as_key) {
@@ -475,10 +491,10 @@ sub parse_file_into_metrics_hashref {
 
     my @headers;
     my %data;
-    while (my $line = $is_fh->getline) {
+    while (my $line = $metrics_fh->getline) {
         chomp($line);
-        if ($line =~ /^## METRICS CLASS/) {
-            my $next_line = $is_fh->getline;
+        if ($line =~ $header_regex) {
+            my $next_line = $metrics_fh->getline;
             chomp($next_line);
             @headers = split("\t",$next_line);
             for (my $i = 0; $i < scalar(@headers); $i++) {
@@ -490,6 +506,7 @@ sub parse_file_into_metrics_hashref {
             }
             next;
         }
+
         if (@headers) {
             if ($line =~ /^\s*$/) {
                 last;
@@ -504,60 +521,7 @@ sub parse_file_into_metrics_hashref {
             }
         }
     }
-    return \%data;
-}
 
-sub parse_metrics_file_into_histogram_hashref {
-    my ($class,$metrics_file,$metric_header_as_key) = @_;
-
-    my $as_fh = Genome::Sys->open_file_for_reading($metrics_file);
-    my $metric_key_index;
-
-    unless ($metric_header_as_key) {
-        if ($class->can('_metric_header_as_key')) {
-            $metric_header_as_key = $class->_metric_header_as_key;
-        } else {
-            $class->debug_message('Assuming the first column is the key for the histogram hashref in file: '. $metrics_file);
-            $metric_key_index = 0;
-        }
-    }
-
-    my @headers;
-    my %data;
-    while (my $line = $as_fh->getline) {
-        chomp($line);
-        if ($line =~ /^## HISTOGRAM/) {
-            my $next_line = $as_fh->getline;
-            chomp($next_line);
-            @headers = split("\t",$next_line);
-            for (my $i = 0; $i < scalar(@headers); $i++) {
-                unless (defined($metric_key_index)) {
-                    if ($headers[$i] eq $metric_header_as_key) {
-                        $metric_key_index = $i;
-                    }
-                }
-            }
-            next;
-        }
-        if (@headers) {
-            if ($line =~ /^\s*$/) {
-                last;
-            } else {
-                my $category;
-                my @values = split("\t",$line);
-                unless (scalar(@values) == scalar(@headers)) {
-                    $DB::single=1;
-                    next;
-                }
-                my $metric_key = $headers[$metric_key_index] .'-'. $values[$metric_key_index];
-                for (my $i = 0; $i < scalar(@values); $i++) {
-                    my $header = $headers[$i];
-                    my $value = $values[$i];
-                    $data{$metric_key}{$header} = $value;
-                }
-            }
-        }
-    }
     return \%data;
 }
 


### PR DESCRIPTION
[As promised in #611,] This PR is a second attempt at cleaning up the duplicate subroutines for metrics processing.

One thing of note: this no longer silently skips rows where the number of headers and number of values don't match in the "histogram" case.