### PR TITLE
Update GMT::Picard::CheckIlluminaDirectory

### DIFF
--- a/lib/perl/Genome/Model/Tools/Picard/CheckIlluminaDirectory.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CheckIlluminaDirectory.pm
@@ -1,7 +1,4 @@
-
 package Genome::Model::Tools::Picard::CheckIlluminaDirectory;
-
-# http://broadinstitute.github.io/picard/command-line-overview.html#CheckIlluminaDirectory
 
 use strict;
 use warnings FATAL => 'all';
@@ -9,19 +6,22 @@ use warnings FATAL => 'all';
 use Genome;
 
 class Genome::Model::Tools::Picard::CheckIlluminaDirectory {
-    is  => 'Genome::Model::Tools::Picard',
+    is  => 'Genome::Model::Tools::Picard::Base',
     has_input => [
         basecalls_directory => {
             is  => 'String',
-            doc => 'The basecalls output directory.',
+            doc => 'The basecalls output directory',
+            picard_param_name => 'BASECALLS_DIR',
         },
         lane => {
             is  => 'String',
-            doc => 'Lane number.',
+            doc => 'Lane number',
+            picard_param_name => 'LANES',
         },
         read_structure => {
             is  => 'String',
             doc => 'A description of the logical structure of clusters in an Illumina Run',
+            picard_param_name => 'READ_STRUCTURE',
         },
     ],
 };
@@ -37,38 +37,12 @@ sub help_detail {
 EOS
 }
 
-sub execute {
-    my $self = shift;
+sub _jar_name {
+    return 'CheckIlluminaDirectory.jar';
+}
 
-    my $jar_path = $self->picard_path . '/CheckIlluminaDirectory.jar';
-    unless (-e $jar_path) {
-        die('Failed to find '. $jar_path .'!  This command may not be available in version '. $self->use_version);
-    }
-
-    my %map_args = qw(
-        basecalls_directory basecalls_dir
-        lane lanes
-    );
-
-    my $args = join(' ',
-        map {
-            my $value = $self->$_;
-            my $arg = $map_args{$_} || $_;
-            defined($value) ? (uc($arg) . "='$value'") : ()
-        } sort qw(
-            basecalls_directory
-            lane
-            read_structure
-        )
-    );
-
-    my $cmd = $jar_path . " net.sf.picard.illumina.CheckIlluminaDirectory $args";
-    $self->run_java_vm(
-        cmd          => $cmd,
-    );
-    return 1;
+sub _java_class {
+    return qw(picard illumina CheckIlluminaDirectory);
 }
 
 1;
-__END__
-


### PR DESCRIPTION
It now uses `GMT::Picard::Base`.

We don't seem to use this module anywhere in Genome. Talking to @thepler it doesn't seem like LIMS is actively using it either.

We could remove the module altogether, although it's so simple now it doesn't seem particularly harmful to keep it around. It also currently has no tests. Unfortunately there doesn't seem to be much we can test beyond just running the tool. Todd pointed me to some ~~test~~ **production** data that works... it's several gigabytes:

```
$ gmt picard check-illumina-directory --basecalls-directory "$HOME/links/check-illumina-dir-example/Data/Intensities/BaseCalls" --use-version 1.113 --lane 1 --read-structure 151T6B
Using libraries at /gscuser/iferguso/git/genome/master/lib/perl
RUN: java -Xmx4096m -XX:MaxPermSize=64m -cp /usr/share/java/ant.jar:/usr/share/java/picard-tools1.113/CheckIlluminaDirectory.jar net.sf.picard.illumina.CheckIlluminaDirectory BASECALLS_DIR=/gscuser/iferguso/links/check-illumina-dir-example/Data/Intensities/BaseCalls LANES=1 MAX_RECORDS_IN_RAM=500000 READ_STRUCTURE=151T6B TMP_DIR=/tmp/gm-genome_sys-2015-04-02_15_54_06--uKe5/Picard-FXPp VALIDATION_STRINGENCY=SILENT
[Thu Apr 02 15:54:06 CDT 2015] net.sf.picard.illumina.CheckIlluminaDirectory BASECALLS_DIR=/gscuser/iferguso/links/check-illumina-dir-example/Data/Intensities/BaseCalls READ_STRUCTURE=151T6B LANES=[1] TMP_DIR=[/tmp/gm-genome_sys-2015-04-02_15_54_06--uKe5/Picard-FXPp] VALIDATION_STRINGENCY=SILENT MAX_RECORDS_IN_RAM=500000    FAKE_FILES=false LINK_LOCS=false VERBOSITY=INFO QUIET=false COMPRESSION_LEVEL=5 CREATE_INDEX=false CREATE_MD5_FILE=false
[Thu Apr 02 15:54:06 CDT 2015] Executing as iferguso@linus47.gsc.wustl.edu on Linux 2.6.35-31-generic amd64; Java HotSpot(TM) 64-Bit Server VM 1.6.0_18-b07; Picard version: 1.113(exported) JdkDeflater
INFO    2015-04-02 15:54:06     CheckIlluminaDirectory  Checking lanes(1 in basecalls directory (/gscuser/iferguso/links/check-illumina-dir-example/Data/Intensities/BaseCalls)

INFO    2015-04-02 15:54:06     CheckIlluminaDirectory  Expected cycles: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157
INFO    2015-04-02 15:54:06     CheckIlluminaDirectory  Checking lane 1
INFO    2015-04-02 15:54:06     CheckIlluminaDirectory  Expected tiles: 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1114, 1115, 1116, 1117, 1118, 1119, 2101, 2102, 2103, 2104, 2105, 2106, 2107, 2108, 2109, 2110, 2111, 2112, 2113, 2114, 2115, 2116, 2117, 2118, 2119
INFO    2015-04-02 15:54:08     CheckIlluminaDirectory  Lane 1 SUCCEEDED
INFO    2015-04-02 15:54:08     CheckIlluminaDirectory  SUCCEEDED!  All required files are present and non-empty.
[Thu Apr 02 15:54:08 CDT 2015] net.sf.picard.illumina.CheckIlluminaDirectory done. Elapsed time: 0.04 minutes.
Runtime.totalMemory()=93913088
```

We believe that data is probably PHI. It's not immediately clear how to generate fake test data that's significantly smaller (both in size and number of files... there are thousands of files in the `BaseCalls` tree).

Thoughts?