### PR TITLE
Change ON_TARGET merge strategy to uniq-concat

### DIFF
--- a/lib/perl/Genome/VariantReporting/Suite/Vep/joinx_merge.strategy
+++ b/lib/perl/Genome/VariantReporting/Suite/Vep/joinx_merge.strategy
@@ -1,3 +1,4 @@
 default=enforce-equal
 info.CSQ=uniq-concat
 info.SEG_DUP=enforce-equal-unordered
+info.ON_TARGET=uniq-concat


### PR DESCRIPTION
Currently joinx fails during merging if two alternate alleles have different ON_TARGET annotations because we are using the enforce-equal merge strategy. 

Using the uniq-concat strategy will create a unique list of the ON_TARGET annotations for all alternate alleles. This will yield incorrect results in the downstream variant reports if one alternate allele is on target and the other isn't. However, in order to quickly move forward with CLE validation this option was chosen by Dave Larson. Ultimately we will probably want to make the ON_TARGET info field a per-allele field but this will require more development.

This is a CLE blocker so a fast turnaround would be appreciated.