### PR TITLE
Allow spaces in comments again.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Picard/MarkDuplicates.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/MarkDuplicates.pm
@@ -98,7 +98,7 @@ sub _cmdline_args {
     }
     # COMMENT supported in v1.77
     if ($self->include_comment && $self->version_at_least('1.77')) {
-        push @args, sprintf("COMMENT=%s", $self->include_comment);
+        push @args, sprintf("COMMENT='%s'", $self->include_comment);
     }
 
     return @args;

--- a/lib/perl/Genome/Model/Tools/Picard/MarkDuplicates.t
+++ b/lib/perl/Genome/Model/Tools/Picard/MarkDuplicates.t
@@ -28,6 +28,7 @@ my $cmd_1 = Genome::Model::Tools::Picard::MarkDuplicates->create(
     temp_directory => $tmp_dir->dirname,
     remove_duplicates => 1,
     use_version => "1.85",
+    include_comment => 'Testing Picard MarkDuplicates',
 );
 
 


### PR DESCRIPTION
I wonder if a longer-term solution might be to add a minimum version attribute to Picard properties and have the base class handle this instead of it being a special case?