### PR TITLE
Exclude yaml from trio process diffs

### DIFF
--- a/lib/perl/Genome/VariantReporting/Process/Trio.pm
+++ b/lib/perl/Genome/VariantReporting/Process/Trio.pm
@@ -141,6 +141,7 @@ sub special_compare_functions {
     my $self = shift;
     my @functions = $self->SUPER::special_compare_functions(@_);
     push @functions, qr(\.xml$) => sub {Genome::VariantReporting::Process::Trio::compare_igv_xml(@_)};
+    push @functions, qr(\.yaml$) => sub {return 0};
     return @functions;
 }
 

--- a/lib/perl/Genome/VariantReporting/Process/Trio.pm
+++ b/lib/perl/Genome/VariantReporting/Process/Trio.pm
@@ -140,7 +140,7 @@ sub get_cle_input_results {
 sub special_compare_functions {
     my $self = shift;
     my @functions = $self->SUPER::special_compare_functions(@_);
-    push @functions, qr(\.xml$) => sub {my ($a, $b) = @_; Genome::VariantReporting::Process::Trio::compare_igv_xml($a, $b)};
+    push @functions, qr(\.xml$) => sub {Genome::VariantReporting::Process::Trio::compare_igv_xml(@_)};
     return @functions;
 }
 


### PR DESCRIPTION
The yaml is just metadata, not a real output of the process.