### PR TITLE
GMT Integration of VCF Evaluation (part 1)

### DIFF
--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -107,7 +107,6 @@ class Genome::Model::Tools::Vcf::EvaluateVcf {
         rawstats => {
             is => "HASH",
             doc => "The raw stats generated during primary execution",
-            is_optional => '1',
         },
     ],
 };

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -103,10 +103,11 @@ class Genome::Model::Tools::Vcf::EvaluateVcf {
         },
     ],
 
-    has_output => [
+    has_transient_optional_output => [
         rawstats => {
             is => "HASH",
             doc => "The raw stats generated during primary execution",
+            is_optional => '1',
         },
     ],
 };

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -447,7 +447,6 @@ sub count {
 
 sub _run {
     my $cmd = shift;
-
     return Genome::Sys->shellcmd(cmd => $cmd);
 }
 

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -85,6 +85,7 @@ class Genome::Model::Tools::Vcf::EvaluateVcf {
             is => "Integer",
             doc => "Use this number as the size of the TN BED "
                    . "file rather than calculating on the fly",
+            is_optional => '1',
         },
 
         pass_only_expression => {
@@ -163,7 +164,8 @@ sub execute {
         $new_sample
         );
 
-    my $tn_bed_size = $self->bed_size("$tn_bed.roi.bed.gz");
+    my $tn_bed_size = $self->true_negative_size
+      || $self->bed_size("${tn_bed}.roi.bed.gz");
 
     my $false_positives_in_roi = $self->number_within_roi(
         $final_input_file,

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -637,7 +637,7 @@ sub help_detail {
 
     One way to measure the overall accuracy of a genomic pipeline is to
     compare variant calls generated from a special input data set with
-    already known variants.  The special data set is referred as a "gold
+    already known variants.  The special data set is called a "gold
     standard", and the process of comparing the pipeline obtained variant
     calls to the known gold standard variant calls is called "validation".
 
@@ -658,7 +658,7 @@ sub help_detail {
     file of true negative positions.
 
     Genotype comparisons are done using [joinx vcf-compare][2]. This program
-    reports an exact and a partial genotype match to the gold standard VCF.
+    reports an exact and a partial genotype match to the gold-standard VCF.
     Exact matches are straightforward: if both samples report the variant
     then it is an exact match. Partial matches are more complex: joinx
     reports the number of unique, matching alternate alleles at each site

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -301,10 +301,9 @@ sub _make_bad_indel_filter {
 
 sub restrict {
     my ($self, $input_file, $roi_file, $output_file) = @_;
-    my $dir = Genome::Model::Tools::BedTools->path_for_bedtools_version($self->bedtools_version);
-    my $exe = File::Spec->catfile($dir, "bin", "bedtools");
+    my $bedtools = $self->bedtools;
     $DB::single = 1;
-    my @args = ($exe, "intersect", "-header", "-a", $input_file, "-b", $roi_file, "> $output_file");
+    my @args = ($bedtools, "intersect", "-header", "-a", $input_file, "-b", $roi_file, "> $output_file");
     Genome::Sys->shellcmd( cmd => join(" ", @args) );
 
     $DB::single = 1;

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -98,8 +98,6 @@ class Genome::Model::Tools::Vcf::EvaluateVcf {
 sub execute {
     my $self = shift;
 
-    $self->_setup_prg_tools();
-
     my $vcf = $self->vcf;
     my $roi = $self->roi;
     my $gold_vcf = $self->gold_vcf;
@@ -216,11 +214,6 @@ sub reference {
     my $self = shift;
     return "/gscmnt/ams1102/info/model_data/"
            . "2869585698/build106942997/all_sequences.fa";
-}
-
-sub _setup_prg_tools {
-    my $self = shift;
-    $REFERENCE = $self->reference();
 }
 
 sub _process_input_file {

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -250,8 +250,8 @@ sub _clean_vcf {
 
     $self->status_message("Cleaning vcf $input_file => $output_file");
     $DB::single = 1;
-    my $reader = new Genome::File::Vcf::Reader($input_file);
-    my $writer = new Genome::File::Vcf::Writer($output_file, $reader->header);
+    my $reader = Genome::File::Vcf::Reader->new($input_file);
+    my $writer = Genome::File::Vcf::Writer->new($output_file, $reader->header);
 
     $reader->add_filter(_make_bad_indel_filter($self->roi)) if $self->clean_indels;
     $reader->add_filter(_make_per_allele_info_filter($reader->header));
@@ -282,7 +282,7 @@ sub _make_bad_indel_filter {
     my %bed_ends;
 
     # This is compressed!
-    my $fh = new IO::Zlib;
+    my $fh = IO::Zlib->new;
     $fh->open($roi_file, "rb") or die "Unable to open BED file $roi_file for removal of bad indel lines\n";
     while(my $bedline = $fh->getline) {
         chomp $bedline;

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -7,6 +7,8 @@ use Genome::File::Vcf::Reader;
 use Genome::File::Vcf::Writer;
 use Genome;
 use Genome::Sys::ShellPipeline;
+use IO::File;
+use IO::Zlib;
 use Path::Class;
 use Genome::Model::Tools::Vcf::VcfCompare;
 

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -123,22 +123,22 @@ sub execute {
     my $gold_sample = $self->gold_sample;
     my $clean_indels = $self->clean_indels;
 
-    my $output_dir = $self->output_directory;
+    my $output_dir = Path::Class::Dir->new($self->output_directory);
 
     die "Output dir $output_dir does not exist" unless -d $output_dir;
-    my $orig_file = "$output_dir/orig.vcf";
-    my $input_file = "$output_dir/clean.vcf";
-    my $final_input_file = "$output_dir/final.vcf";
-    my $final_gold_file = "$output_dir/gold-final.vcf";
-    my $final_tn_file = "$output_dir/tn-final.bed";
-    my $variants_dir = "$output_dir/variants";
-    my $fp_roi_file = "$output_dir/fp_in_roi.vcf";
-    my $compare_file = "$output_dir/compare.txt";
+    my $orig_file = $output_dir->file("orig.vcf")->stringify;
+    my $input_file = $output_dir->file("clean.vcf")->stringify;
+    my $final_input_file = $output_dir->file("final.vcf")->stringify;
+    my $final_gold_file = $output_dir->file("gold-final.vcf")->stringify;
+    my $final_tn_file = $output_dir->file("tn-final.bed")->stringify;
+    my $variants_dir = $output_dir->subdir("variants")->stringify;
+    my $fp_roi_file = $output_dir->file("fp_in_roi.vcf")->stringify;
+    my $compare_file = $output_dir->file("compare.txt")->stringify;
 
     Genome::Sys->create_directory($variants_dir);
-    Genome::Sys->create_symlink($vcf, "$output_dir/orig.vcf");
-    Genome::Sys->create_symlink($roi, "$output_dir/roi.bed");
-    Genome::Sys->create_symlink($gold_vcf, "$output_dir/gold.vcf");
+    Genome::Sys->create_symlink($vcf, $orig_file);
+    Genome::Sys->create_symlink($roi, $output_dir->file("roi.bed")->stringify);
+    Genome::Sys->create_symlink($gold_vcf, $output_dir->file("gold.vcf")->stringify);
 
     $self->restrict($tn_bed, $roi, $final_tn_file);
 

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -301,7 +301,6 @@ sub restrict {
     return 1;
 }
 
-
 sub restrict_commands {
     my $self = shift;
     my ($input_file, $roi_file) = @_;
@@ -426,10 +425,3 @@ sub _run {
 1;
 
 __END__
-
-# idas -- refactoring note
-# The pure subroutines are :
-#      _make_per_allele_info_filter
-#      _make_bad_indel_filter
-#      count
-#      _run

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -361,27 +361,6 @@ sub pass_only_commands {
     return ("$vcffilter $expression $input_file");
 }
 
-
-sub restrict_input_file {
-    my ($input_file, $roi_file, $output_file, $sample, $filter_exp)  = @_;
-    my @cmds = (
-        restrict_commands($input_file, $roi_file),
-        restrict_to_sample_commands("/dev/stdin", $sample),
-        pass_only_commands("/dev/stdin", $filter_exp),
-        allelic_primitives_commands("/dev/stdin"),
-        normalize_vcf_commands("/dev/stdin", $REFERENCE),
-        sort_commands("/dev/stdin"),
-        restrict_commands("stdin", $roi_file),
-        "bgzip -c",
-        );
-
-    my $cmd = Genome::Sys::ShellPipeline->create(
-        pipe_commands => \@cmds,
-        redirects => " > $output_file",
-        );
-    $cmd->execute;
-}
-
 sub compare_partial {
     my $self = shift;
     my ($input_file, $variant_directory, $gold_file, $output_file, $gold_sample, $eval_sample, $new_sample) = @_;

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -630,13 +630,27 @@ sub help_detail {
     BACKGROUND
     ==========
 
-    For validation, it is important to compare calls from the pipeline +
-    reporting framework and calculate sensitivity, specificity and positive
-    predictive value of the pipeline's calls versus the gold standard.
-    The standard currency for doing this is a VCF file. A procedure was
-    developed for simplifying callsets and then comparing them to each
-    other. It roughly follows the recommendations of NIST as detailed in the
-    [Genome In a Bottle paper][1].
+    Modern genomic pipelines are composed of continually advancing next
+    generation sequencing technologies and software tools.  As pipelines
+    evolve, it is important, especially in a clinical setting, to
+    systematically assess the accuracy and reproducibility of the variant
+    calls that are produced as the end product.
+
+    One way to measure the overall accuracy of a genomic pipeline is to
+    compare variant calls generated from a special input data set with
+    already known variants.  The special data set is referred as a "gold
+    standard", and the process of comparing the pipeline obtained variant
+    calls to the known gold standard variant calls is called "validation".
+
+    The validation process categorizes whether a given variant call
+    produced by a genomic pipeline is correctly identified or missed.  The
+    classifications can be measured overall by the statstical notions of
+    sensitivity, specificity, and positive predictive value (PPV).
+
+    The standard format for storing variant calls is a VCF file.
+    A procedure to validate VCF files against each other is performed in
+    this script.  It roughly follows the NIST recommendations as described
+    in the [Genome in a Bottle paper][1].
 
     METHODOLOGY
     ===========
@@ -646,15 +660,15 @@ sub help_detail {
 
     Genotype comparisons are done using [joinx vcf-compare][2]. This program
     reports an exact and a partial genotype match to the gold standard VCF.
-    Exact matches are straightforward, if both samples report the variant than
-    it is an exact match. Partial matches are more complex, joinx reports the
-    number of unique, matching alternate alleles at each site giving a zygosity
-    independent measure of concordance. For example, a heterozygous variant in
-    the gold sample and a homozygous variant in the evaluation sample would
-    yield a single partial match.
+    Exact matches are straightforward: if both samples report the variant
+    then it is an exact match. Partial matches are more complex: joinx
+    reports the number of unique, matching alternate alleles at each site
+    giving a zygosity-independent measure of concordance. For example, a
+    heterozygous variant in the gold sample and a homozygous variant in the
+    evaluation sample would yield a single partial match.
 
-    In order to calculate metrics, the following calculations were used and are
-    further detailed in Output Formats below:
+    In order to calculate metrics, the following calculations are used and
+    are further detailed in Output Formats below:
 
     Metric                      Calculation
     -------------------------   --------------
@@ -668,7 +682,7 @@ sub help_detail {
         FP = False Positives
         TN = True Negatives
         
-    The TP, FP and TN counts are explicitly define as:
+    The TP, FP and TN counts are explicitly defined as:
 
     True Positive
     -------------
@@ -701,7 +715,7 @@ sub help_detail {
     6. Use the --pass-only-expression to restrict the evaluation VCF to only
        those variants passing the expression.
     7. Break complex indels into simpler ones using vcflib vcfallelicprimitives.
-    8. Resort the file.
+    8. Re-sort the file.
     9. Re-restrict to the ROI.
     10. Compare the resulting VCF to the ROI-restricted gold VCF using
         joinx vcf-compare.

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -1,0 +1,401 @@
+package Genome::Model::Tools::Vcf::EvaluateVcf;
+
+use strict;
+use warnings;
+
+use Genome::File::Vcf::Reader;
+use Genome::File::Vcf::Writer;
+use Genome;
+use Genome::Sys::ShellPipeline;
+use IO::File;
+use IO::Zlib;
+use Getopt::Long;
+use File::Basename;
+use File::Spec;
+use File::Temp qw(tempdir);
+use Genome::Model::Tools::Vcf::VcfCompare;
+
+
+my $JOINX = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin/joinx";
+my $BEDTOOLS = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin/bedtools";
+my $VCFLIB = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin";
+my $REFERENCE = "/gscmnt/ams1102/info/model_data/2869585698/build106942997/all_sequences.fa";
+
+class Genome::Model::Tools::Vcf::EvaluateVcf {
+    is => "Command::V2",
+    has_input => [
+        bedtools_version => {
+            is => "Text",
+            doc => "Bedtools version to use",
+            default_value => "2.17.0",
+        },
+
+        joinx_version => {
+            is => "Text",
+            doc => "Joinx version to use",
+            default_value => "v1.10",
+        },
+
+        vcf => {
+            is => "Text",
+            doc => "Vcf file to analyze",
+        },
+
+        output_directory => {
+            is => "Text",
+            doc => "Output directory to write to",
+            is_output => 1,
+        },
+
+        old_sample => {
+            is => "Text",
+            doc => "Sample name in input vcf file",
+        },
+
+        new_sample => {
+            is => "Text",
+            doc => "Sample to use in output files",
+        },
+
+        gold_vcf => {
+            is => "Text",
+            doc => "Gold standard vcf to compare to",
+        },
+
+        gold_sample => {
+            is => "Text",
+            doc => "Sample name in gold standard vcf file",
+        },
+
+        roi => {
+            is => "Text",
+            doc => "Region of interest bed file",
+        },
+
+        true_negative_bed => {
+            is => "Text",
+            doc => "True negatives bed file",
+        },
+
+        pass_only_expression => {
+            is => "Text",
+            doc => "Expression for vcflib/vcffilter to select only passing (unfiltered) variants",
+            default_value => q{-g 'FT = PASS | FT = .'},
+        },
+
+        clean_indels => {
+            is => "Text",
+            doc => "If set, attempt to cleanup indels",
+            default_value => 0,
+        },
+    ]
+};
+
+
+sub _process_input_file {
+    my ($self, $input_file, $output_file) = @_;
+    my @cmds = (
+        restrict_commands($input_file, $self->roi),
+        restrict_to_sample_commands("/dev/stdin", $self->old_sample),
+        pass_only_commands("/dev/stdin", $self->pass_only_expression),
+        allelic_primitives_commands("/dev/stdin"),
+        normalize_vcf_commands("/dev/stdin", $REFERENCE),
+        sort_commands("/dev/stdin"),
+        restrict_commands("stdin", $self->roi),
+        "bgzip -c",
+        );
+
+    my $cmd = Genome::Sys::ShellPipeline->create(
+        pipe_commands => \@cmds,
+        redirects => " > $output_file",
+        );
+    $cmd->execute;
+
+}
+
+sub _clean_vcf {
+    my ($self, $input_file, $output_file) = @_;
+
+    $self->status_message("Cleaning vcf $input_file => $output_file");
+    $DB::single = 1;
+    my $reader = new Genome::File::Vcf::Reader($input_file);
+    my $writer = new Genome::File::Vcf::Writer($output_file, $reader->header);
+
+    $reader->add_filter(_make_bad_indel_filter($self->roi)) if $self->clean_indels;
+    $reader->add_filter(_make_per_allele_info_filter($reader->header));
+
+    while (my $entry = $reader->next) {
+        $writer->write($entry);
+    }
+    $writer->close;
+}
+
+sub _make_per_allele_info_filter {
+    my ($header) = @_;
+
+    my $info = $header->info_types;
+    my @remove = grep {$info->{$_}{number} =~ /^(A|R)$/} keys %$info;
+
+    return sub {
+        my $entry = shift;
+        my $info_hash = $entry->info;
+        delete @{$entry}{@remove};
+        return $entry;
+    };
+}
+
+sub _make_bad_indel_filter {
+    my ($roi_file) = @_;
+
+    my %bed_ends;
+
+    # This is compressed!
+    my $fh = new IO::Zlib;
+    $fh->open($roi_file, "rb") or die "Unable to open BED file $roi_file for removal of bad indel lines\n";
+    while(my $bedline = $fh->getline) {
+        chomp $bedline;
+        my ($chr, $start, $stop) = split "\t", $bedline;
+        $bed_ends{"$chr\t$stop"} = 1;
+    }
+    $fh->close;
+
+    return sub {
+        my $entry = shift;
+        my $x = sprintf "%s\t%s", $entry->{chrom}, $entry->{position};
+        return if exists $bed_ends{$x};
+        return $entry;
+    }
+}
+
+my $bgzip_pipe_cmd = "| bgzip -c ";
+
+sub execute {
+    my $self = shift;
+
+    my $vcf = $self->vcf;
+    my $roi = $self->roi;
+    my $gold_vcf = $self->gold_vcf;
+    my $tn_bed = $self->true_negative_bed;
+    my $old_sample = $self->old_sample;
+    my $new_sample = $self->new_sample;
+    my $gold_sample = $self->gold_sample;
+    my $clean_indels = $self->clean_indels;
+
+    my $output_dir = $self->output_directory;
+
+    die "Output dir $output_dir does not exist" unless -d $output_dir;
+    my $orig_file = "$output_dir/orig.vcf";
+    my $input_file = "$output_dir/clean.vcf";
+    my $final_input_file = "$output_dir/final.vcf";
+    my $final_gold_file = "$output_dir/gold-final.vcf";
+    my $final_tn_file = "$output_dir/tn-final.bed";
+    my $variants_dir = "$output_dir/variants";
+    my $fp_roi_file = "$output_dir/fp_in_roi.vcf";
+    my $compare_file = "$output_dir/compare.txt";
+
+    Genome::Sys->create_directory($variants_dir);
+    Genome::Sys->create_symlink($vcf, "$output_dir/orig.vcf");
+    Genome::Sys->create_symlink($roi, "$output_dir/roi.bed");
+    Genome::Sys->create_symlink($gold_vcf, "$output_dir/gold.vcf");
+
+    $self->restrict($tn_bed, $roi, $final_tn_file);
+
+
+    # input file processing
+    my $tmp = Genome::Sys->create_temp_file_path;
+    $self->_clean_vcf($orig_file, $tmp);
+    $self->_process_input_file($tmp, $final_input_file);
+
+    # Gold file processing
+    #  this should be cleaned here because, presumably, allelic primitives has already been run.
+    $self->restrict($gold_vcf, $roi, $tmp);
+    $self->_clean_vcf($tmp, $final_gold_file);
+
+
+    compare_partial(
+        $final_input_file,
+        $variants_dir,
+        $final_gold_file,
+        $compare_file,
+        $gold_sample,
+        $old_sample,
+        $new_sample
+        );
+
+    my $tn_bed_size = bed_size("$tn_bed.roi.bed.gz");
+
+    my $false_positives_in_roi = number_within_roi(
+        $final_input_file,
+        $final_tn_file,
+        $fp_roi_file,
+        );
+
+    my %results = true_positives($final_input_file, $final_gold_file, $compare_file, $new_sample);
+
+    print join("\t",
+        # Exact matches
+        $results{true_positive_exact},
+
+        # All true cases
+        $results{true_positive_exact} + $results{false_negative_exact},
+
+        # Exact sensitivty
+        $results{true_positive_exact} / ($results{true_positive_exact} + $results{false_negative_exact}),
+
+        $results{true_positive_partial},
+        $results{true_positive_partial} + $results{false_negative_partial},
+        $results{true_positive_partial} / ($results{true_positive_partial} + $results{false_negative_partial}),
+        $results{false_positive_exact},
+        $results{false_positive_partial},
+        $tn_bed_size,
+        #exact specificity, these are not strictly accurate as the tn_bed may be significantly smaller than the target space ROI
+        ($tn_bed_size - $results{false_positive_exact}) / $tn_bed_size,
+        ($tn_bed_size - $results{false_positive_partial}) / $tn_bed_size,
+        $results{true_positive_exact} / ($results{false_positive_exact} + $results{true_positive_exact}),
+        $results{true_positive_partial} / ($results{false_positive_partial} + $results{true_positive_partial}),
+        $false_positives_in_roi,
+        ($tn_bed_size - $false_positives_in_roi) / $tn_bed_size, #this is more accurate than the other specificity measures, but doesn't take partial into account
+    ), "\n";
+
+    return 1;
+}
+
+sub restrict {
+    my ($self, $input_file, $roi_file, $output_file) = @_;
+    my $dir = Genome::Model::Tools::BedTools->path_for_bedtools_version($self->bedtools_version);
+    my $exe = File::Spec->catfile($dir, "bin", "bedtools");
+    $DB::single = 1;
+    my @args = ($exe, "intersect", "-header", "-a", $input_file, "-b", $roi_file, "> $output_file");
+    Genome::Sys->shellcmd( cmd => join(" ", @args) );
+
+    $DB::single = 1;
+    return 1;
+}
+
+
+sub restrict_commands {
+    my ($input_file, $roi_file) = @_;
+    return ("$BEDTOOLS intersect -header -a $input_file -b $roi_file");
+}
+
+sub restrict_to_sample_commands {
+    my ($input_file, $sample) = @_;
+    return ("$VCFLIB/vcfkeepsamples $input_file $sample");
+}
+
+sub normalize_vcf_commands {
+    my ($input_file, $reference, $output_file) = @_;
+    return ("$JOINX vcf-normalize-indels -f $reference $input_file");
+}
+
+sub sort_commands {
+    my ($input_file) = @_;
+    return ("$JOINX sort $input_file");
+}
+
+sub allelic_primitives_commands {
+    my ($input_file) = @_;
+    return (
+        "$VCFLIB/vcfallelicprimitives -t ALLELICPRIMITIVE /dev/stdin",
+        "$VCFLIB/vcffixup - ",
+        "$VCFLIB/vcffilter -f 'AC > 0'"
+        );
+}
+
+sub pass_only_commands {
+    my ($input_file, $expression) = @_;
+    return ("$VCFLIB/vcffilter $expression $input_file");
+}
+
+
+sub restrict_input_file {
+    my ($input_file, $roi_file, $output_file, $sample, $filter_exp)  = @_;
+    my @cmds = (
+        restrict_commands($input_file, $roi_file),
+        restrict_to_sample_commands("/dev/stdin", $sample),
+        pass_only_commands("/dev/stdin", $filter_exp),
+        allelic_primitives_commands("/dev/stdin"),
+        normalize_vcf_commands("/dev/stdin", $REFERENCE),
+        sort_commands("/dev/stdin"),
+        restrict_commands("stdin", $roi_file),
+        "bgzip -c",
+        );
+
+    my $cmd = Genome::Sys::ShellPipeline->create(
+        pipe_commands => \@cmds,
+        redirects => " > $output_file",
+        );
+    $cmd->execute;
+}
+
+sub compare_partial {
+    my ($input_file, $variant_directory, $gold_file, $output_file, $gold_sample, $eval_sample, $new_sample) = @_;
+    my $rename_option = "";
+    if($new_sample) {
+        if($gold_sample) {
+            $rename_option .= " -R $gold_sample=$new_sample";
+        }
+        if($eval_sample) {
+            $rename_option .= " -R $eval_sample=$new_sample";
+        }
+    }
+    _run("$JOINX vcf-compare $rename_option -d $variant_directory $input_file $gold_file -s $new_sample > $output_file");
+}
+
+sub true_positives {
+    my ($input_file, $gold_file, $joinx_output, $new_sample) = @_;
+    my $table = Genome::Model::Tools::Vcf::VcfCompare->new($joinx_output);
+    #for now only do perfect matches
+    return (
+        false_positive_exact => $table->unique_count($input_file, "exact_match", $new_sample),
+        false_negative_exact => $table->unique_count($gold_file, "exact_match", $new_sample),
+        true_positive_exact => $table->joint_count("exact_match", $new_sample),
+        false_positive_partial => $table->unique_count($input_file, "partial_match", $new_sample),
+        false_negative_partial => $table->unique_count($gold_file, "partial_match", $new_sample),
+        true_positive_partial => $table->joint_count("partial_match", $new_sample),
+        false_positive_partial_miss => $table->unique_count($input_file, "partial_miss", $new_sample),
+        false_negative_partial_miss => $table->unique_count($gold_file, "partial_miss", $new_sample),
+        false_positive_complete_miss => $table->unique_count($input_file, "complete_miss", $new_sample),
+        false_negative_complete_miss => $table->unique_count($gold_file, "complete_miss", $new_sample),
+    );
+}
+
+
+sub number_within_roi {
+    my ($input_file, $roi, $output_file) = @_;
+    _run("zcat $input_file | $BEDTOOLS intersect -header -a stdin -b $roi $bgzip_pipe_cmd > $output_file");
+    return count($output_file);
+}
+
+sub bed_size {
+    my $bed = shift;
+    my $count = 0;
+    my $fh = IO::File->new("zcat $bed |") or die "Unable to open $bed to calculate size\n";
+    while(my $line  = $fh->getline) {
+        chomp $line;
+        my ($chr, $start, $stop) = split "\t", $line;
+        $count += $stop-$start;
+    }
+    $fh->close;
+    return $count;
+}
+
+sub count {
+    my $file = shift;
+    my @results = `zgrep -v '^#' $file | cut -f1,2,3 | sort -u | wc -l`;
+    chomp $results[0];
+    return $results[0];
+}
+
+sub print_versions {
+    print `$JOINX --version`;
+    print `$BEDTOOLS --version`;
+}
+
+sub _run {
+    my $cmd = shift;
+
+    return Genome::Sys->shellcmd(cmd => $cmd);
+}
+
+1;

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -17,7 +17,6 @@ use Path::Class;
 use Genome::Model::Tools::Vcf::VcfCompare;
 
 
-my $bgzip_pipe_cmd = "| bgzip -c ";
 
 class Genome::Model::Tools::Vcf::EvaluateVcf {
     is => "Command::V2",
@@ -388,11 +387,11 @@ sub true_positives {
     );
 }
 
-
 sub number_within_roi {
     my $self = shift;
     my ($input_file, $roi, $output_file) = @_;
     my $bedtools = $self->bedtools;
+    my $bgzip_pipe_cmd = "| bgzip -c ";
     _run("zcat $input_file | $bedtools intersect -header -a stdin -b $roi $bgzip_pipe_cmd > $output_file");
     return count($output_file);
 }

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -270,7 +270,6 @@ sub _clean_vcf {
     my ($self, $input_file, $output_file) = @_;
 
     $self->status_message("Cleaning vcf $input_file => $output_file");
-    $DB::single = 1;
     my $reader = Genome::File::Vcf::Reader->new($input_file);
     my $writer = Genome::File::Vcf::Writer->new($output_file, $reader->header);
 

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -15,11 +15,15 @@ use File::Spec;
 use File::Temp qw(tempdir);
 use Path::Class;
 use Genome::Model::Tools::Vcf::VcfCompare;
-use String::TT qw(strip);
 
 class Genome::Model::Tools::Vcf::EvaluateVcf {
     is => "Command::V2",
     has_input => [
+        reference => {
+            is => 'Genome::Model::Build::ReferenceSequence',
+            doc => 'a reference sequence of interest.',
+        },
+
         bedtools_version => {
             is => "Text",
             doc => "Bedtools version to use",
@@ -235,10 +239,10 @@ sub vcflib_tool {
     return $path;
 }
 
-sub reference {
+sub reference_path {
     my $self = shift;
-    return "/gscmnt/ams1102/info/model_data/"
-           . "2869585698/build106942997/all_sequences.fa";
+    my $path = $self->reference->full_consensus_path('fa');
+    return $path;
 }
 
 sub _process_input_file {
@@ -248,7 +252,7 @@ sub _process_input_file {
         $self->restrict_to_sample_commands("/dev/stdin", $self->old_sample),
         $self->pass_only_commands("/dev/stdin", $self->pass_only_expression),
         $self->allelic_primitives_commands("/dev/stdin"),
-        $self->normalize_vcf_commands("/dev/stdin", $self->reference),
+        $self->normalize_vcf_commands("/dev/stdin", $self->reference_path),
         $self->sort_commands("/dev/stdin"),
         $self->restrict_commands("stdin", $self->roi),
         "bgzip -c",

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -424,3 +424,12 @@ sub _run {
 }
 
 1;
+
+__END__
+
+# idas -- refactoring note
+# The pure subroutines are :
+#      _make_per_allele_info_filter
+#      _make_bad_indel_filter
+#      count
+#      _run

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -155,7 +155,12 @@ sub execute {
         $fp_roi_file,
         );
 
-    my %results = $self->true_positives($final_input_file, $final_gold_file, $compare_file, $new_sample);
+    my %results = $self->true_positives(
+        $final_input_file,
+        $final_gold_file,
+        $compare_file,
+        $new_sample
+    );
 
     print join("\t",
         # Exact matches

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -7,12 +7,6 @@ use Genome::File::Vcf::Reader;
 use Genome::File::Vcf::Writer;
 use Genome;
 use Genome::Sys::ShellPipeline;
-use IO::File;
-use IO::Zlib;
-use Getopt::Long;
-use File::Basename;
-use File::Spec;
-use File::Temp qw(tempdir);
 use Path::Class;
 use Genome::Model::Tools::Vcf::VcfCompare;
 

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -366,7 +366,7 @@ sub allelic_primitives_commands {
     my $vcffilter = $self->vcflib_tool('vcffilter');
 
     return (
-        "$vcfallelicprimitives -t ALLELICPRIMITIVE /dev/stdin",
+        "$vcfallelicprimitives -t ALLELICPRIMITIVE $input_file",
         "$vcffixup - ",
         "$vcffilter -f 'AC > 0'"
         );

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -435,6 +435,7 @@ sub bed_size {
     return $count;
 }
 
+# H E L P E R  F U N C T I O N S ##############################################
 sub count {
     my $file = shift;
     my @results = `zgrep -v '^#' $file | cut -f1,2,3 | sort -u | wc -l`;

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -196,7 +196,7 @@ sub bedtools {
     my $base = Genome::Model::Tools::BedTools->path_for_bedtools_version(
         $self->bedtools_version
     );
-    my $base = Path::Class::Dir->new($base);
+    $base = Path::Class::Dir->new($base);
     my $prg = $base->subdir('bin')->file('bedtools');
     return $prg->stringify;
 }

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -643,7 +643,7 @@ sub help_detail {
 
     The validation process categorizes whether a given variant call
     produced by a genomic pipeline is correctly identified or missed.  The
-    classifications can be measured overall by the statstical notions of
+    classifications can be measured overall by the statistical notions of
     sensitivity, specificity, and positive predictive value (PPV).
 
     The standard format for storing variant calls is a VCF file.

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -16,10 +16,8 @@ use File::Temp qw(tempdir);
 use Genome::Model::Tools::Vcf::VcfCompare;
 
 
-my $JOINX = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin/joinx";
-my $BEDTOOLS = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin/bedtools";
-my $VCFLIB = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin";
-my $REFERENCE = "/gscmnt/ams1102/info/model_data/2869585698/build106942997/all_sequences.fa";
+my ($JOINX, $BEDTOOLS, $VCFLIB, $REFERENCE);
+my $bgzip_pipe_cmd = "| bgzip -c ";
 
 class Genome::Model::Tools::Vcf::EvaluateVcf {
     is => "Command::V2",
@@ -91,10 +89,10 @@ class Genome::Model::Tools::Vcf::EvaluateVcf {
     ]
 };
 
-my $bgzip_pipe_cmd = "| bgzip -c ";
-
 sub execute {
     my $self = shift;
+
+    $self->_setup_prg_tools();
 
     my $vcf = $self->vcf;
     my $roi = $self->roi;
@@ -182,6 +180,35 @@ sub execute {
     ), "\n";
 
     return 1;
+}
+
+sub joinx {
+    my $self = shift;
+    return "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin/joinx"
+}
+
+sub bedtools {
+    my $self = shift;
+    return "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin/bedtools";
+}
+
+sub vcflib {
+    my $self = shift;
+    return "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/bin";
+}
+
+sub reference {
+    my $self = shift;
+    return "/gscmnt/ams1102/info/model_data/"
+           . "2869585698/build106942997/all_sequences.fa";
+}
+
+sub _setup_prg_tools {
+    my $self = shift;
+    $JOINX = $self->joinx();
+    $BEDTOOLS = $self->bedtools();
+    $VCFLIB = $self->vcflib();
+    $REFERENCE = $self->reference();
 }
 
 sub _process_input_file {

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -30,7 +30,7 @@ class Genome::Model::Tools::Vcf::EvaluateVcf {
         joinx_version => {
             is => "Text",
             doc => "Joinx version to use",
-            default_value => "v1.10",
+            default_value => "1.11",
         },
 
         vcflib_version => {

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -322,12 +322,10 @@ sub _make_bad_indel_filter {
 
 sub restrict {
     my ($self, $input_file, $roi_file, $output_file) = @_;
-    my $bedtools = $self->bedtools;
-    $DB::single = 1;
-    my @args = ($bedtools, "intersect", "-header", "-a", $input_file, "-b", $roi_file, "> $output_file");
-    Genome::Sys->shellcmd( cmd => join(" ", @args) );
+    my $cmd = $self->restrict_commands($input_file, $roi_file);
+    $cmd .= " > $output_file";
+    Genome::Sys->shellcmd( cmd => $cmd );
 
-    $DB::single = 1;
     return 1;
 }
 

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -443,11 +443,6 @@ sub count {
     return $results[0];
 }
 
-sub print_versions {
-    print `$JOINX --version`;
-    print `$BEDTOOLS --version`;
-}
-
 sub _run {
     my $cmd = shift;
 

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -17,7 +17,6 @@ use Path::Class;
 use Genome::Model::Tools::Vcf::VcfCompare;
 
 
-my ($REFERENCE);
 my $bgzip_pipe_cmd = "| bgzip -c ";
 
 class Genome::Model::Tools::Vcf::EvaluateVcf {
@@ -231,7 +230,7 @@ sub _process_input_file {
         $self->restrict_to_sample_commands("/dev/stdin", $self->old_sample),
         $self->pass_only_commands("/dev/stdin", $self->pass_only_expression),
         $self->allelic_primitives_commands("/dev/stdin"),
-        $self->normalize_vcf_commands("/dev/stdin", $REFERENCE),
+        $self->normalize_vcf_commands("/dev/stdin", $self->reference),
         $self->sort_commands("/dev/stdin"),
         $self->restrict_commands("stdin", $self->roi),
         "bgzip -c",

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
@@ -1,31 +1,109 @@
 #!/usr/bin/env genome-perl
 
+# P R A G M A S ###############################################################
 use strict;
 use warnings;
 
+# M O D U L E S ###############################################################
+use Test::More;
 use Path::Class;
 use above 'Genome';
-use Genome::Model::Tools::Vcf::EvaluateVcf;
+#use Genome::Model::Tools::Vcf::EvaluateVcf;
 
-my $vcf = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/src/vcf-evaluation/tmp/small.vcf.gz";
-#/gscmnt/gc13028/info/model_data/6195f53ff81046959a3bfee124c186f6/buildf60b23fdb26c45f486cf2d5937a7502b/variants/snvs.vcf.gz";
+# M A I N #####################################################################
 
-my $output_dir = Path::Class::Dir->new('/tmp/vcf/test');
-if (-e $output_dir) {
-    $output_dir->rmtree;
+#This is a bare minimum test that just compiles Perl and the UR class.
+use_ok('Genome::Model::Tools::Vcf::EvaluateVcf');
+
+SKIP: {
+    skip "this is a long-running test", 18;
+    run_evaluate_vcf();
 }
-$output_dir->mkpath;
 
-my $cmd = Genome::Model::Tools::Vcf::EvaluateVcf->create(
-        vcf => $vcf,
-        old_sample => "H_IJ-NA12878",
-        new_sample => "NA12878",
-        gold_vcf => "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/gold/snvs.vcf.gz",
-        gold_sample => "NA12878",
-        roi => "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/gold/highconf.bed.gz",
-        true_negative_bed => "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/gold/tn.bed.gz",
-        #output_directory => "/gscmnt/gc2801/analytics/idas/vcf/test",
-        output_directory => "/tmp/vcf/test",
+done_testing();
+
+# S U B R O U T I N E S #######################################################
+sub run_evaluate_vcf {
+    my ($vcf, $gold_vcf, $roi, $true_negative_bed, $output_dir) =
+      setup_evaluate_vcf_params();
+
+    my $cmd = Genome::Model::Tools::Vcf::EvaluateVcf->create(
+        vcf               => $vcf->stringify,
+        old_sample        => "H_IJ-NA12878",
+        new_sample        => "NA12878",
+        gold_vcf          => $gold_vcf->stringify,
+        gold_sample       => "NA12878",
+        roi               => $roi->stringify,
+        true_negative_bed => $true_negative_bed->stringify,
+        output_directory  => $output_dir->stringify,
     );
+    ok($cmd, 'Got a Genome::Model::Tools::Vcf::EvaluateVcf instance');
+    diag('executing command');
+    ok($cmd->execute, 'successfully ran execute');
+    my $stats = $cmd->rawstats;
+    ok($stats, 'got the raw statistics from vcf evaluation');
 
-$cmd->execute;
+    is($cmd->stat_true_positive_found_exact(),
+        28820, 'true_positive_found_exact passes');
+
+    is($cmd->stat_total_true_positive_exact(),
+        2741358, 'total_true_positive_exact passes');
+
+    is($cmd->stat_sensitivity_exact(),
+        0.0105130376988339, 'sensitivity_exact passes');
+
+    is($cmd->stat_true_positive_found_partial(),
+        28843, 'true_positive_found_partial passes');
+
+    is($cmd->stat_total_true_positive_partial(),
+        2741984, 'total_true_positive_partial passes');
+
+    is($cmd->stat_sensitivity_partial(),
+        0.0105190256398287, 'sensitivity_partial passes');
+
+    is($cmd->stat_false_positive_exact(), 139, 'false_positive_exact passes');
+
+    is($cmd->stat_false_positive_partial(),
+        116, 'false_positive_partial passes');
+
+    is($cmd->stat_true_negatives(), 2191931600, 'true_negatives passes');
+
+    is($cmd->stat_exact_specificity(),
+        0.999999936585612, 'exact_specificity passes');
+
+    is($cmd->stat_partial_specificity(),
+        0.999999947078641, 'partial_specificity passes');
+
+    is($cmd->stat_exact_ppv(),   0.995200110501053, 'exact_ppv passes');
+
+    is($cmd->stat_partial_ppv(), 0.995994336821023, 'partial_ppv passes');
+    
+    is($cmd->stat_vcf_lines_overlapping_tn(),
+        47, 'vcf_lines_overlapping_tn passes');
+
+    is($cmd->stat_lines_specificity_in_tn_only(),
+        0.999999978557725, 'lines_specificity_in_tn_only passes');
+}
+
+sub setup_evaluate_vcf_params {
+    # inputs
+    my $base_dir =
+      Path::Class::Dir->new('/gscmnt/gc2801/analytics/tabbott/vcf-evaluate');
+
+    # Input VCF is based on original vcf file:
+    #/gscmnt/gc13028/info/model_data/6195f53ff81046959a3bfee124c186f6/buildf60b23fdb26c45f486cf2d5937a7502b/variants/snvs.vcf.gz";
+    my $vcf = $base_dir->file("src/vcf-evaluation/tmp/small.vcf.gz");
+
+    my $gold_vcf = $base_dir->file("gold/snvs.vcf.gz");
+    my $roi = $base_dir->file("gold/highconf.bed.gz");
+    my $true_negative_bed = $base_dir->file("gold/tn.bed.gz");
+
+    # output directory
+    my $output_dir = Path::Class::Dir->new('/tmp/vcf/test');
+    if (-e $output_dir) {
+        $output_dir->rmtree;
+    }
+    $output_dir->mkpath;
+
+    return ($vcf, $gold_vcf, $roi, $true_negative_bed, $output_dir);
+}

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
@@ -24,7 +24,7 @@ done_testing();
 
 # S U B R O U T I N E S #######################################################
 sub run_evaluate_vcf {
-    my ($vcf, $gold_vcf, $roi, $true_negative_bed, $output_dir) =
+    my ($vcf, $gold_vcf, $roi, $true_negative_bed, $output_dir, $ref) =
       setup_evaluate_vcf_params();
 
     my $cmd = Genome::Model::Tools::Vcf::EvaluateVcf->create(
@@ -36,6 +36,7 @@ sub run_evaluate_vcf {
         roi               => $roi->stringify,
         true_negative_bed => $true_negative_bed->stringify,
         output_directory  => $output_dir->stringify,
+        reference         => $ref,
     );
     ok($cmd, 'Got a Genome::Model::Tools::Vcf::EvaluateVcf instance');
     diag('executing command');
@@ -105,5 +106,7 @@ sub setup_evaluate_vcf_params {
     }
     $output_dir->mkpath;
 
-    return ($vcf, $gold_vcf, $roi, $true_negative_bed, $output_dir);
+    my $ref = Genome::Model::Build::ReferenceSequence->get(106942997);
+
+    return ($vcf, $gold_vcf, $roi, $true_negative_bed, $output_dir, $ref);
 }

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
@@ -3,11 +3,18 @@
 use strict;
 use warnings;
 
+use Path::Class;
 use above 'Genome';
 use Genome::Model::Tools::Vcf::EvaluateVcf;
 
 my $vcf = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/src/vcf-evaluation/tmp/small.vcf.gz";
 #/gscmnt/gc13028/info/model_data/6195f53ff81046959a3bfee124c186f6/buildf60b23fdb26c45f486cf2d5937a7502b/variants/snvs.vcf.gz";
+
+my $output_dir = Path::Class::Dir->new('/tmp/vcf/test');
+if (-e $output_dir) {
+    $output_dir->rmtree;
+}
+$output_dir->mkpath;
 
 my $cmd = Genome::Model::Tools::Vcf::EvaluateVcf->create(
         vcf => $vcf,
@@ -17,7 +24,8 @@ my $cmd = Genome::Model::Tools::Vcf::EvaluateVcf->create(
         gold_sample => "NA12878",
         roi => "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/gold/highconf.bed.gz",
         true_negative_bed => "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/gold/tn.bed.gz",
-        output_directory => "/gscmnt/gc2801/analytics/idas/vcf/test",
+        #output_directory => "/gscmnt/gc2801/analytics/idas/vcf/test",
+        output_directory => "/tmp/vcf/test",
     );
 
 $cmd->execute;

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+use above 'Genome';
+use Genome::Model::Tools::Vcf::EvaluateVcf;
+
+my $vcf = "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/src/vcf-evaluation/tmp/small.vcf.gz";
+#/gscmnt/gc13028/info/model_data/6195f53ff81046959a3bfee124c186f6/buildf60b23fdb26c45f486cf2d5937a7502b/variants/snvs.vcf.gz";
+
+my $cmd = Genome::Model::Tools::Vcf::EvaluateVcf->create(
+        vcf => $vcf,
+        old_sample => "H_IJ-NA12878",
+        new_sample => "NA12878",
+        gold_vcf => "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/gold/snvs.vcf.gz",
+        gold_sample => "NA12878",
+        roi => "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/gold/highconf.bed.gz",
+        true_negative_bed => "/gscmnt/gc2801/analytics/tabbott/vcf-evaluate/gold/tn.bed.gz",
+        output_directory => "/gscmnt/gc2801/analytics/idas/vcf/test",
+    );
+
+$cmd->execute;

--- a/lib/perl/Genome/Model/Tools/Vcf/VcfCompare.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/VcfCompare.pm
@@ -23,7 +23,6 @@ use IO::File;
 
 
 sub new {
-    $DB::single = 1;
     my ($class, $file) = @_;
 
     my $self;

--- a/lib/perl/Genome/Model/Tools/Vcf/VcfCompare.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/VcfCompare.pm
@@ -1,0 +1,87 @@
+package Genome::Model::Tools::Vcf::VcfCompare;
+
+#this package is for parsing of joinx's vcf-compare output
+
+use strict;
+use warnings;
+
+use IO::File;
+
+#File looks like the below:
+# 0	1	partial_match	369
+# 1	0	partial_match	316
+# 1	1	partial_match	16816
+# 0	1	exact_match	375
+# 1	0	exact_match	317
+# 1	1	exact_match	16810
+# 0	1	partial_miss	0
+# 1	0	partial_miss	5
+# 1	1	partial_miss	0
+# 0	1	complete_miss	369
+# 1	0	complete_miss	311
+# 1	1	complete_miss	0
+
+
+sub new {
+    $DB::single = 1;
+    my ($class, $file) = @_;
+
+    my $self;
+    my $fh = IO::File->new($file) or die "Unable to open $file to parse vcf-compare results\n";
+
+    my $header_line = $fh->getline;
+    chomp $header_line;
+    my ($file1_name, $file2_name, $type, @samples) = split "\t", $header_line;
+    $self->{_file_names} = [$file1_name, $file2_name]; 
+
+    while(my $line = $fh->getline) {
+        chomp $line;
+        my ($file1, $file2, $type, @counts) = split "\t", $line;
+        @{$self->{_melty_table}{$file1}{$file2}{$type}}{@samples} = @counts;
+    }
+    bless $self, $class;
+}
+
+sub unique_count {
+    my ($self, $file, $type, $sample) = @_;
+    my $count_pointer = $self->{_melty_table};
+    for my $name (@{$self->{_file_names}}) {
+        if($name eq $file) {
+            $count_pointer = $count_pointer->{1};
+        }
+        else {
+            $count_pointer = $count_pointer->{0};
+        }
+        unless(defined $count_pointer) {
+            die "$file not present in joinx output\n";
+        }
+    }
+    if(exists($count_pointer->{$type})) {
+        if(exists($count_pointer->{$type}{$sample})) {
+            return $count_pointer->{$type}{$sample};
+        }
+        else {
+            die "$sample not present in joinx output\n";
+        }
+    }
+    else {
+        die "$type not valid in joinx output\n";
+    }
+}
+
+sub joint_count {
+    my ($self, $type, $sample) = @_;
+    if(exists($self->{_melty_table}{1}{1}{$type})) {
+        if(exists($self->{_melty_table}{1}{1}{$type}{$sample})) {
+            return $self->{_melty_table}{1}{1}{$type}{$sample};
+        }
+        else {
+            die "$sample not present in joinx output\n";
+        }
+    }
+    else {
+        die "$type not valid in joinx output\n";
+    }
+}
+
+1;

--- a/lib/perl/Genome/Model/Tools/Vcflib.pm
+++ b/lib/perl/Genome/Model/Tools/Vcflib.pm
@@ -169,14 +169,14 @@ sub get_version_toolset {
         }
     );
 
-    if (exists $toolset{$version}) {
-        return $toolset{$version}
+    unless (exists $toolset{$version}) {
+        die $self->error_message(
+            "Couldn't find the vcflib tool set for version: '%s'",
+            $version
+        );
     }
 
-    die $self->error_message(
-        "Couldn't find the vcflib tool set for version: '%s'",
-        $version
-    );
+    return $toolset{$version};
 }
 
 1;

--- a/lib/perl/Genome/Model/Tools/Vcflib.pm
+++ b/lib/perl/Genome/Model/Tools/Vcflib.pm
@@ -14,7 +14,7 @@ class Genome::Model::Tools::Vcflib {
             is            => 'Version',
             is_optional   => 1,
             default_value => $DEFAULT,
-            doc           => "Version of tophat to use, default is $DEFAULT"
+            doc           => "Version of vcflib to use, default is $DEFAULT"
         },
     ],
 };

--- a/lib/perl/Genome/Model/Tools/Vcflib.pm
+++ b/lib/perl/Genome/Model/Tools/Vcflib.pm
@@ -65,7 +65,7 @@ sub get_version_toolset {
     my ($self, $version) = @_;
     my %toolset = (
         '1.0' => {
-            # script tools
+            # core programs
             'vcf2dag'                    => '/usr/bin/vcf2dag1.0',
             'vcf2fasta'                  => '/usr/bin/vcf2fasta1.0',
             'vcf2tsv'                    => '/usr/bin/vcf2tsv1.0',

--- a/lib/perl/Genome/Model/Tools/Vcflib.pm
+++ b/lib/perl/Genome/Model/Tools/Vcflib.pm
@@ -1,0 +1,182 @@
+package Genome::Model::Tools::Vcflib;
+
+use strict;
+use warnings;
+
+use Genome;
+
+my $DEFAULT = '1.0';
+
+class Genome::Model::Tools::Vcflib {
+    is  => 'Command::V2',
+    has => [
+        use_version => {
+            is            => 'Version',
+            is_optional   => 1,
+            default_value => $DEFAULT,
+            doc           => "Version of tophat to use, default is $DEFAULT"
+        },
+    ],
+};
+
+sub help_brief {
+    return "interface to a set of VCF-related tools that are part of vcflib";
+}
+
+sub help_synopsis {
+    my $self = shift;
+    return <<"EOS"
+genome-model tools vcflib ...
+EOS
+}
+
+sub help_detail {
+    return <<EOS
+    See the programs that are part of the vcflib project at
+
+        https://github.com/ekg/vcflib.
+    
+    Version 1.0 represents the state of the github repository at commit
+    "b1e9b31d2d95f957f86cdfd1e7c9ec25b4950ee8".
+EOS
+}
+
+sub vcflib_tool_path {
+    my ($self, $tool, $version) = @_;
+
+    my $v = $version || $self->use_version;
+    unless ($v) {
+        die $self->error_message("no vcflib tool version specified!");
+    }
+
+    my $toolset = $self->get_version_toolset($v);
+    unless (exists $toolset->{$tool}) {
+        die $self->error_message(
+            "no vcflib tool named '%s' exists in version '%s'!",
+            $tool, $v
+        );
+    }
+
+    my $path = $toolset->{$tool};
+    return $path;
+}
+
+sub get_version_toolset {
+    my ($self, $version) = @_;
+    my %toolset = (
+        '1.0' => {
+            # script tools
+            'vcf2dag'                    => '/usr/bin/vcf2dag1.0',
+            'vcf2fasta'                  => '/usr/bin/vcf2fasta1.0',
+            'vcf2tsv'                    => '/usr/bin/vcf2tsv1.0',
+            'vcfaddinfo'                 => '/usr/bin/vcfaddinfo1.0',
+            'vcfafpath'                  => '/usr/bin/vcfafpath1.0',
+            'vcfallelicprimitives'       => '/usr/bin/vcfallelicprimitives1.0',
+            'vcfaltcount'                => '/usr/bin/vcfaltcount1.0',
+            'vcfannotate'                => '/usr/bin/vcfannotate1.0',
+            'vcfannotategenotypes'       => '/usr/bin/vcfannotategenotypes1.0',
+            'vcfbreakmulti'              => '/usr/bin/vcfbreakmulti1.0',
+            'vcfcat'                     => '/usr/bin/vcfcat1.0',
+            'vcfcheck'                   => '/usr/bin/vcfcheck1.0',
+            'vcfclassify'                => '/usr/bin/vcfclassify1.0',
+            'vcfcleancomplex'            => '/usr/bin/vcfcleancomplex1.0',
+            'vcfcombine'                 => '/usr/bin/vcfcombine1.0',
+            'vcfcommonsamples'           => '/usr/bin/vcfcommonsamples1.0',
+            'vcfcountalleles'            => '/usr/bin/vcfcountalleles1.0',
+            'vcfcreatemulti'             => '/usr/bin/vcfcreatemulti1.0',
+            'vcfdistance'                => '/usr/bin/vcfdistance1.0',
+            'vcfecho'                    => '/usr/bin/vcfecho1.0',
+            'vcfentropy'                 => '/usr/bin/vcfentropy1.0',
+            'vcfevenregions'             => '/usr/bin/vcfevenregions1.0',
+            'vcffilter'                  => '/usr/bin/vcffilter1.0',
+            'vcffixup'                   => '/usr/bin/vcffixup1.0',
+            'vcfflatten'                 => '/usr/bin/vcfflatten1.0',
+            'vcfgeno2alleles'            => '/usr/bin/vcfgeno2alleles1.0',
+            'vcfgeno2haplo'              => '/usr/bin/vcfgeno2haplo1.0',
+            'vcfgenosamplenames'         => '/usr/bin/vcfgenosamplenames1.0',
+            'vcfgenosummarize'           => '/usr/bin/vcfgenosummarize1.0',
+            'vcfgenotypecompare'         => '/usr/bin/vcfgenotypecompare1.0',
+            'vcfgenotypes'               => '/usr/bin/vcfgenotypes1.0',
+            'vcfglbound'                 => '/usr/bin/vcfglbound1.0',
+            'vcfglxgt'                   => '/usr/bin/vcfglxgt1.0',
+            'vcfhetcount'                => '/usr/bin/vcfhetcount1.0',
+            'vcfhethomratio'             => '/usr/bin/vcfhethomratio1.0',
+            'vcfindex'                   => '/usr/bin/vcfindex1.0',
+            'vcfinfo2qual'               => '/usr/bin/vcfinfo2qual1.0',
+            'vcfinfosummarize'           => '/usr/bin/vcfinfosummarize1.0',
+            'vcfintersect'               => '/usr/bin/vcfintersect1.0',
+            'vcfkeepgeno'                => '/usr/bin/vcfkeepgeno1.0',
+            'vcfkeepinfo'                => '/usr/bin/vcfkeepinfo1.0',
+            'vcfkeepsamples'             => '/usr/bin/vcfkeepsamples1.0',
+            'vcfleftalign'               => '/usr/bin/vcfleftalign1.0',
+            'vcflength'                  => '/usr/bin/vcflength1.0',
+            'vcfnumalt'                  => '/usr/bin/vcfnumalt1.0',
+            'vcfoverlay'                 => '/usr/bin/vcfoverlay1.0',
+            'vcfparsealts'               => '/usr/bin/vcfparsealts1.0',
+            'vcfprimers'                 => '/usr/bin/vcfprimers1.0',
+            'vcfqual2info'               => '/usr/bin/vcfqual2info1.0',
+            'vcfrandom'                  => '/usr/bin/vcfrandom1.0',
+            'vcfrandomsample'            => '/usr/bin/vcfrandomsample1.0',
+            'vcfremap'                   => '/usr/bin/vcfremap1.0',
+            'vcfremoveaberrantgenotypes' => '/usr/bin/vcfremoveaberrantgenotypes',
+            'vcfremovesamples'           => '/usr/bin/vcfremovesamples1.0',
+            'vcfroc'                     => '/usr/bin/vcfroc1.0',
+            'vcfsample2info'             => '/usr/bin/vcfsample2info1.0',
+            'vcfsamplediff'              => '/usr/bin/vcfsamplediff1.0',
+            'vcfsamplenames'             => '/usr/bin/vcfsamplenames1.0',
+            'vcfsitesummarize'           => '/usr/bin/vcfsitesummarize1.0',
+            'vcfstats'                   => '/usr/bin/vcfstats1.0',
+            'vcfstreamsort'              => '/usr/bin/vcfstreamsort1.0',
+            'vcfuniq'                    => '/usr/bin/vcfuniq1.0',
+            'vcfuniqalleles'             => '/usr/bin/vcfuniqalleles1.0',
+
+            # script tools
+            bed2region                   => '/usr/share/vcflib-tgi1.0/bed2region',
+            'plot_roc.r'                 => '/usr/share/vcflib-tgi1.0/plot_roc.r',
+            'vcf2bed.py'                 => '/usr/share/vcflib-tgi1.0/vcf2bed.py',
+            'vcf2sqlite.py'              => '/usr/share/vcflib-tgi1.0/vcf2sqlite.py',
+            vcf_strip_extra_headers      => '/usr/share/vcflib-tgi1.0/vcf_strip_extra_headers',
+            vcfbiallelic                 => '/usr/share/vcflib-tgi1.0/vcfbiallelic',
+            vcfclearid                   => '/usr/share/vcflib-tgi1.0/vcfclearid',
+            vcfclearinfo                 => '/usr/share/vcflib-tgi1.0/vcfclearinfo',
+            vcfcomplex                   => '/usr/share/vcflib-tgi1.0/vcfcomplex',
+            vcffirstheader               => '/usr/share/vcflib-tgi1.0/vcffirstheader',
+            'vcfgtcompare.sh'            => '/usr/share/vcflib-tgi1.0/vcfgtcompare.sh',
+            vcfindelproximity            => '/usr/share/vcflib-tgi1.0/vcfindelproximity',
+            vcfindels                    => '/usr/share/vcflib-tgi1.0/vcfindels',
+            vcfmultiallelic              => '/usr/share/vcflib-tgi1.0/vcfmultiallelic',
+            vcfmultiway                  => '/usr/share/vcflib-tgi1.0/vcfmultiway',
+            vcfmultiwayscripts           => '/usr/share/vcflib-tgi1.0/vcfmultiwayscripts',
+            vcfnobiallelicsnps           => '/usr/share/vcflib-tgi1.0/vcfnobiallelicsnps',
+            vcfnoindels                  => '/usr/share/vcflib-tgi1.0/vcfnoindels',
+            vcfnosnps                    => '/usr/share/vcflib-tgi1.0/vcfnosnps',
+            vcfnulldotslashdot           => '/usr/share/vcflib-tgi1.0/vcfnulldotslashdot',
+            'vcfplotaltdiscrepancy.r'    => '/usr/share/vcflib-tgi1.0/vcfplotaltdiscrepancy.r',
+            'vcfplotaltdiscrepancy.sh'   => '/usr/share/vcflib-tgi1.0/vcfplotaltdiscrepancy.sh',
+            'vcfplotsitediscrepancy.r'   => '/usr/share/vcflib-tgi1.0/vcfplotsitediscrepancy.r',
+            'vcfplottstv.sh'             => '/usr/share/vcflib-tgi1.0/vcfplottstv.sh',
+            'vcfprintaltdiscrepancy.r'   => '/usr/share/vcflib-tgi1.0/vcfprintaltdiscrepancy.r',
+            'vcfprintaltdiscrepancy.sh'  => '/usr/share/vcflib-tgi1.0/vcfprintaltdiscrepancy.sh',
+            vcfqualfilter                => '/usr/share/vcflib-tgi1.0/vcfqualfilter',
+            vcfregionreduce              => '/usr/share/vcflib-tgi1.0/vcfregionreduce',
+            vcfregionreduce_and_cut      => '/usr/share/vcflib-tgi1.0/vcfregionreduce_and_cut',
+            vcfregionreduce_pipe         => '/usr/share/vcflib-tgi1.0/vcfregionreduce_pipe',
+            vcfregionreduce_uncompressed => '/usr/share/vcflib-tgi1.0/vcfregionreduce_uncompressed',
+            vcfremovenonATGC             => '/usr/share/vcflib-tgi1.0/vcfremovenonATGC',
+            vcfsnps                      => '/usr/share/vcflib-tgi1.0/vcfsnps',
+            vcfsort                      => '/usr/share/vcflib-tgi1.0/vcfsort',
+            vcfvarstats                  => '/usr/share/vcflib-tgi1.0/vcfvarstats',
+        }
+    );
+
+    if (exists $toolset{$version}) {
+        return $toolset{$version}
+    }
+
+    die $self->error_message(
+        "Couldn't find the vcflib tool set for version: '%s'",
+        $version
+    );
+}
+
+1;


### PR DESCRIPTION
This is part 1 of a 2 to 3 part roll out to integrate the [VCF Evaluation scripts][1] within the genome codebase.  The aim of this pull request is to get [evaluate_vcf.pl][2] setup as a GMT.  [evaluate_vcf.pl][2] contains the core vcf comparison algorithm.  

Performance adjustments and [additional logic][3] that work on top of the core logic will be added in future pull requests.

This pull request introduces logic that has been created and/or modified by @ernfrid, @tabbott , and @indraniel .  With so many hands involved, there may be some style inconsistencies.  

[1]: https://github.com/genome/vcf-evaluation
[2]: https://github.com/genome/vcf-evaluation/blob/master/evaluate_vcf.pl
[3]: https://github.com/genome/vcf-evaluation/blob/master/evaluate_vcfs.pl