### PR TITLE
Include QC failed reads when recreating per lane bam from merged bam

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1676,6 +1676,7 @@ sub revivified_alignment_bam_file_paths {
         picard_version      => $self->picard_version,
         bam_header          => $self->bam_header_path,
         comparison_flagstat => $self->flagstat_path,
+        include_qc_failed   => 1,
     );
 
     unless ($cmd->execute) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.pm
@@ -41,6 +41,12 @@ class Genome::InstrumentData::AlignmentResult::Command::RecreatePerLaneBam {
             is  => 'FilePath',
             doc => 'The path of flagstat file that is used to compare with that of recreated bam',
         },
+        include_qc_failed => {
+			is          => 'Boolean',
+			doc         => 'Include reads that were marked within the bam as having failed QC',
+			is_optional => 1,
+			default     => 0,
+		},
     ],
     has_transient_optional => [
         _temp_out_bam => {
@@ -131,6 +137,7 @@ sub _extract_readgroup_bam {
         output        => $temp_bam,
         read_group_id => $self->instrument_data_id,
         use_version   => $self->samtools_version,
+        include_qc_failed => $self->include_qc_failed,
     );
     
     unless ($extract->execute) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.pm
@@ -42,11 +42,11 @@ class Genome::InstrumentData::AlignmentResult::Command::RecreatePerLaneBam {
             doc => 'The path of flagstat file that is used to compare with that of recreated bam',
         },
         include_qc_failed => {
-			is          => 'Boolean',
-			doc         => 'Include reads that were marked within the bam as having failed QC',
-			is_optional => 1,
-			default     => 0,
-		},
+            is          => 'Boolean',
+            doc         => 'Include reads that were marked within the bam as having failed QC',
+            is_optional => 1,
+            default     => 0,
+        },
     ],
     has_transient_optional => [
         _temp_out_bam => {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.t
@@ -34,6 +34,7 @@ my %params = (
     picard_version      => '1.82',
     bam_header          => File::Spec->join($out_dir, $out_base.'.header'),
     comparison_flagstat => File::Spec->join($out_dir, $out_base.'.flagstat'),
+    include_qc_failed   => 1,
 );
 
 subtest 'testing command failure with invalid input' => sub {


### PR DESCRIPTION
Most of our in-house bams do not include qc-failed reads, but some bams do include those, while currently recreate_bam command has include_qc_failed turned off. This bug causes unexpected bam flagstat diff and bam recreation failing. This PR is to fix the bug and recreate per lane bam to its original.