### PR TITLE
New command to find references that have the same chromosome names as a query file.

### DIFF
--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.pm
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.pm
@@ -75,10 +75,8 @@ sub execute {
     my @subsets;
     my @partials;
     while (my $reference = $reference_iterator->next) {
-        my $seqdict_path = File::Spec->join($reference->data_directory, 'seqdict', 'seqdict.sam');
-        next unless(-e $seqdict_path); #don't try to generate this now
-
-        my $reference_chromosomes = $reference->chromosome_array_ref;
+        my $reference_chromosomes = $reference->chromosome_array_ref(create_seqdict => 0);
+        next unless defined $reference_chromosomes;
 
         my ($matching, $only_query, $only_reference) = UR::Util::intersect_lists($query_chromosomes, $reference_chromosomes);
         if(@$only_query == 0 and @$only_reference == 0) {

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.pm
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.pm
@@ -1,0 +1,186 @@
+package Genome::Model::ReferenceSequence::Command::FindPotentialMatches;
+
+use strict;
+use warnings;
+
+use Genome;
+use Lingua::EN::Inflect;
+use UR::Util;
+
+class Genome::Model::ReferenceSequence::Command::FindPotentialMatches {
+    is => 'Command::V2',
+    has => [
+        query_file => {
+            is => 'FilePath',
+            doc => 'any TSV where the first column contains chromosome names',
+        },
+    ],
+    has_optional => [
+        taxon => {
+            is => 'Genome::Taxon',
+            doc => 'limit search to references matching this taxon',
+        },
+        include_subsets => {
+            is => 'Boolean',
+            doc => 'include references that contain a subset of the chromosome names in the query',
+            default_value => 0,
+        },
+        include_supersets => {
+            is => 'Boolean',
+            doc => 'include references that contain a superset of the chromosome names in the query',
+            default_value => 1,
+        },
+        include_partial_matches => {
+            is => 'Boolean',
+            doc => 'include references which contain any of the chromosome names in the query',
+            default_value => 0,
+        },
+    ],
+    has_transient_optional_output => [
+        exact_matches => {
+            is => 'ARRAY',
+            doc => 'Exact matches that were found',
+        },
+        supersets => {
+            is => 'ARRAY',
+            doc => 'Supersets that were found (or undef if --include-supersets was not used).',
+        },
+        subsets => {
+            is => 'ARRAY',
+            doc => 'Subsets that were found (or undef if --include-subsets was not used).',
+        },
+        partial_matches => {
+            is => 'ARRAY',
+            doc => 'Parial matches that were found (or undef if --include-partial-matches was not used).',
+        },
+    ],
+    doc => 'find reference sequences whose chromosome names match a file',
+};
+
+sub help_detail {
+    return <<EOHELP;
+This command searches through all reference sequences to find ones with chromosome names that match those present in a file.  This does not guarantee that the file actually comes from the references that match--only that the chromosome names are the same.  (For example, 1-22,X,Y will find multiple reference versions of the human reference which are supersets, but it cannot distinguish between them.)
+EOHELP
+}
+
+sub execute {
+    my $self = shift;
+
+    my $query_chromosomes = $self->_query_chromosomes;
+
+    my $reference_iterator = $self->_reference_iterator;
+
+    my @matches;
+    my @supersets;
+    my @subsets;
+    my @partials;
+    while (my $reference = $reference_iterator->next) {
+        my $seqdict_path = File::Spec->join($reference->data_directory, 'seqdict', 'seqdict.sam');
+        next unless(-e $seqdict_path); #don't try to generate this now
+
+        my $reference_chromosomes = $reference->chromosome_array_ref;
+
+        my ($matching, $only_query, $only_reference) = UR::Util::intersect_lists($query_chromosomes, $reference_chromosomes);
+        if(@$only_query == 0 and @$only_reference == 0) {
+            push @matches, $reference;
+        } elsif ($self->include_supersets and @$only_query == 0) {
+            push @supersets, [$reference, $only_reference];
+        } elsif ($self->include_subsets and @$only_reference == 0) {
+            push @subsets, [$reference, $only_query];
+        } elsif ($self->include_partial_matches and @$matching > 0) {
+            push @partials, [$reference, $only_query, $only_reference];
+        }
+    }
+
+    $self->exact_matches(\@matches);
+    $self->status_message(
+        'Found %s that exactly match.',
+        Lingua::EN::Inflect::NO('reference', scalar(@matches)),
+    );
+    for my $match (@matches) {
+        $self->status_message('  %s', $match->__display_name__);
+    }
+
+    if ($self->include_supersets) {
+        $self->supersets(\@supersets);
+        $self->status_message(
+            'Found %s that are supersets.',
+            Lingua::EN::Inflect::NO('reference', scalar(@supersets)),
+        );
+        for my $superset (@supersets) {
+            $self->status_message(
+                '  %s (extra: %s)',
+                $superset->[0]->__display_name__,
+                join(' ', @{$superset->[1]}),
+            );
+        }
+    }
+
+    if ($self->include_subsets) {
+        $self->subsets(\@subsets);
+        $self->status_message(
+            'Found %s that are subsets.',
+            Lingua::EN::Inflect::NO('reference', scalar(@subsets)),
+        );
+        for my $subset (@subsets) {
+            $self->status_message(
+                '  %s (missing: %s)',
+                $subset->[0]->__display_name__,
+                join(' ', @{$subset->[1]}),
+            );
+        }
+    }
+
+    if ($self->include_partial_matches) {
+        $self->partial_matches(\@partials);
+        $self->status_message(
+            'Found %s that are partial matches.',
+            Lingua::EN::Inflect::NO('reference', scalar(@partials)),
+        );
+        for my $partial (@partials) {
+            $self->status_message(
+                '  %s (missing: %s) (extra: %s)',
+                $partial->[0]->__display_name__,
+                join(' ', @{$partial->[1]}),
+                join(' ', @{$partial->[2]}),
+            );
+        }
+    }
+
+    return 1;
+}
+
+sub _query_chromosomes {
+    my $self = shift;
+
+    my $query_file = $self->query_file;
+    my $query_fh = Genome::Sys->open_file_for_reading($query_file);
+
+    my %chromosomes_found;
+    while (my $line = <$query_fh>) {
+        chomp $line;
+        my ($chr) = split("\t", $line);
+        $chromosomes_found{$chr} = 1;
+    }
+
+    my $query_chromosomes = [keys %chromosomes_found];
+    return $query_chromosomes;
+}
+
+sub _reference_iterator {
+    my $self = shift;
+
+    my @params = (
+        'is_rederivable !=' => 1,
+        status => 'Succeeded',
+        subclass_name => ['Genome::Model::Build::ReferenceSequence', 'Genome::Model::Build::ImportedReferenceSequence'],
+    );
+    if(my $taxon = $self->taxon) {
+        push @params, subject => $taxon;
+    }
+
+    my $iterator = Genome::Model::Build::ReferenceSequence->create_iterator(@params);
+    return $iterator;
+}
+
+1;

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t
@@ -7,6 +7,8 @@ BEGIN {
     $ENV{UR_DBI_NO_COMMIT} = 1;
 };
 
+use File::Spec;
+
 use Test::More tests => 3;
 use Test::Deep qw(cmp_bag);
 

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t
@@ -1,0 +1,101 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use Test::More tests => 3;
+use Test::Deep qw(cmp_bag);
+
+use above 'Genome';
+
+use Genome::Test::Factory::Build;
+use Genome::Test::Factory::Model::ReferenceSequence;
+
+my $pkg = 'Genome::Model::ReferenceSequence::Command::FindPotentialMatches';
+use_ok($pkg);
+
+my $taxon = Genome::Taxon->create(
+    name => 'test taxon for find-potential-matches',
+);
+
+my @refseqs;
+
+for (1..5) {
+    my $model = Genome::Test::Factory::Model::ReferenceSequence->setup_object(
+        subject => $taxon,
+    );
+    my $data_dir = File::Spec->join(__FILE__.'.d', $_);
+    my $build = Genome::Test::Factory::Build->setup_object(
+        model_id => $model->id,
+        data_directory => $data_dir,
+        status => 'Succeeded',
+    );
+
+    push @refseqs, $build;
+}
+
+subtest 'gather query chromosomes from file' => sub {
+    my $file_path = Genome::Sys->create_temp_file_path;
+    my @chromosome_list = (1..5, 'X', 'something|else');
+    Genome::Sys->write_file($file_path, map { "$_\tignored\tcolumns\there\n" } @chromosome_list);
+
+    my $cmd = $pkg->create(
+        query_file => $file_path,
+    );
+    isa_ok($cmd, $pkg);
+
+    my $result = $cmd->_query_chromosomes;
+    cmp_bag($result, \@chromosome_list, 'found expected chromosomes');
+};
+
+subtest 'command produces results' => sub {
+
+    my $file_path = Genome::Sys->create_temp_file_path;
+    my @chromosome_list = (1..4);
+    Genome::Sys->write_file($file_path, map { "$_\n" } @chromosome_list);
+
+    subtest 'command with default matching options' => sub {
+        my $cmd = $pkg->create(
+            taxon => $taxon,
+            query_file => $file_path,
+        );
+        isa_ok($cmd, $pkg);
+
+        ok($cmd->execute, 'executed command');
+
+        my $exact_matches = $cmd->exact_matches;
+        is(scalar(@$exact_matches), 1, 'found an exact match');
+        my $supersets = $cmd->supersets;
+        is(scalar(@$supersets), 1, 'found a superset');
+        my $subsets = $cmd->subsets;
+        is($subsets, undef, 'subsets not set when not requested');
+        my $partial_matches = $cmd->partial_matches;
+        is($partial_matches, undef, 'partial matches not set when not requested');
+    };
+
+    subtest 'command with all matching options' => sub {
+        my $cmd = $pkg->create(
+            taxon => $taxon,
+            query_file => $file_path,
+            include_subsets => 1,
+            include_supersets => 1,
+            include_partial_matches => 1,
+        );
+        isa_ok($cmd, $pkg);
+
+        ok($cmd->execute, 'executed command');
+
+        my $exact_matches = $cmd->exact_matches;
+        is(scalar(@$exact_matches), 1, 'found an exact match');
+        my $supersets = $cmd->supersets;
+        is(scalar(@$supersets), 1, 'found a superset');
+        my $subsets = $cmd->subsets;
+        is(scalar(@$subsets), 1, 'found a subset');
+        my $partial_matches = $cmd->partial_matches;
+        is(scalar(@$partial_matches), 1, 'found a partial match');
+    };
+};

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/1/seqdict/seqdict.sam
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/1/seqdict/seqdict.sam
@@ -1,0 +1,5 @@
+@HD	VN:1.0	SO:unsorted
+@SQ	SN:1	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:2	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:3	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:4	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/2/seqdict/seqdict.sam
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/2/seqdict/seqdict.sam
@@ -1,0 +1,3 @@
+@HD	VN:1.0	SO:unsorted
+@SQ	SN:1	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:2	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/3/seqdict/seqdict.sam
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/3/seqdict/seqdict.sam
@@ -1,0 +1,5 @@
+@HD	VN:1.0	SO:unsorted
+@SQ	SN:X	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:2	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:3	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:4	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/4/seqdict/seqdict.sam
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/4/seqdict/seqdict.sam
@@ -1,0 +1,7 @@
+@HD	VN:1.0	SO:unsorted
+@SQ	SN:1	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:2	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:3	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:4	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:X	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:Y	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/5/seqdict/seqdict.sam
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/FindPotentialMatches.t.d/5/seqdict/seqdict.sam
@@ -1,0 +1,3 @@
+@HD	VN:1.0	SO:unsorted
+@SQ	SN:X	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown
+@SQ	SN:Y	LN:1	UR:ftp://ftp.example.com/reference.fa.gz AS:reference	M5:1234567890abcdef1234567890abcdef	SP:Unknown


### PR DESCRIPTION
Sometimes one may have a BED (or other tab-delimited) file but be unsure what reference sequences were involved in its creation (e.g. human plus several viruses).  This tool helps narrow down the candidates.