### PR TITLE
Refactor per-lane bam locking out of Merged.pm and into AlignmentResult.pm

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1969,15 +1969,20 @@ sub lock_bam_file_access {
     unless ($self->get_merged_alignment_results) {
         my @bams = $self->alignment_bam_file_paths;
         unless (@bams) {
-            die $self->error_message("Alignment result with class (%s) and id (%s) has neither ".
-                "merged results nor valid bam paths. This likely means that this alignment result ".
-                "needs to be removed and realigned because data has been lost. ".
-                "Please create an apipe-support ticket for this.", $self->class, $self->id);
-            #There is no way to recreate per lane bam if merged bam
-            #does not exist and per lane bam is removed. Software
-            #result of this per lane alignment needs to be removed and
-            #this per lane instrument data needs to be realigned
-            #with that aligner.
+            if ($self->get_merged_alignment_results) {
+                return 1;
+            }
+            else {
+                die $self->error_message("Alignment result with class (%s) and id (%s) has neither ".
+                    "merged results nor valid bam paths. This likely means that this alignment result ".
+                    "needs to be removed and realigned because data has been lost. ".
+                    "Please create an apipe-support ticket for this.", $self->class, $self->id);
+                #There is no way to recreate per lane bam if merged bam
+                #does not exist and per lane bam is removed. Software
+                #result of this per lane alignment needs to be removed and
+                #this per lane instrument data needs to be realigned
+                #with that aligner.
+            }
         }
 
         #This locking is moved from merged AR to per lane AR, during

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -2005,8 +2005,6 @@ sub lock_bam_file_access {
         if ($self->get_merged_alignment_results) {
             $lock->unlock();
         } else {
-            # The problem here is if we commit BEFORE merge is done, we unlock too early.
-            # However, if we unlock any other way we may fail to unlock more often and leave old locks.
             UR::Context->process->add_observer(
                 aspect   => 'commit',
                 once     => 1,

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1963,5 +1963,61 @@ sub add_to_temporary_input_files_queue {
     return 1;
 }
 
+sub lock_bam_file_access {
+    my $self = shift;
+
+    unless ($self->get_merged_alignment_results) {
+        my @bams = $self->alignment_bam_file_paths;
+        unless (@bams) {
+            die $self->error_message("Alignment result with class (%s) and id (%s) has neither ".
+                "merged results nor valid bam paths. This likely means that this alignment result ".
+                "needs to be removed and realigned because data has been lost. ".
+                "Please create an apipe-support ticket for this.", $self->class, $self->id);
+            #There is no way to recreate per lane bam if merged bam
+            #does not exist and per lane bam is removed. Software
+            #result of this per lane alignment needs to be removed and
+            #this per lane instrument data needs to be realigned
+            #with that aligner.
+        }
+
+        #This locking is moved from merged AR to per lane AR, during
+        #the transition two lock names need be handled properly. This
+        #temporary code change need to be reverted after code is promoted
+        
+        my ($old_resource, $new_resource) = map{File::Spec->join('genome', $_, 'lock-per-lane-alignment-'.$self->id)}('Genome::InstrumentData::AlignmentResult::Merged', __PACKAGE__);
+        my $lock = Genome::Sys::LockMigrationProxy->new(
+            old => {
+                resource => $old_resource,
+                scope    => 'site',
+            },
+            new => {
+                resource => $new_resource,
+                scope    => 'site',
+            },
+        )->lock(
+            max_try       => 288, # Try for 48 hours every 10 minutes
+            block_sleep   => 600,
+        );
+        die $self->error_message("Unable to acquire the lock for per lane alignment result id (%s) !", $self->id) unless $lock;
+
+        # If the build before us successfully created a merged alignment result, we no longer need a lock
+        # If it failed, we will add an observer just as the first build did.
+        if ($self->get_merged_alignment_results) {
+            $lock->unlock();
+        } else {
+            # The problem here is if we commit BEFORE merge is done, we unlock too early.
+            # However, if we unlock any other way we may fail to unlock more often and leave old locks.
+            UR::Context->process->add_observer(
+                aspect   => 'commit',
+                once     => 1,
+                callback => sub {
+                    $lock->unlock();
+                }
+            );
+        }
+    }
+    return 1;
+}
+
 1;
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -804,48 +804,8 @@ sub _lock_per_lane_alignments {
     my $self = shift;
 
     for my $alignment ($self->collect_individual_alignments) {
-        unless ($alignment->get_merged_alignment_results) {
-            my @bams = $alignment->alignment_bam_file_paths;
-            unless (@bams) {
-               die $self->error_message("Alignment result with class (%s) and id (%s) has neither ".
-                   "merged results nor valid bam paths. This likely means that this alignment result ".
-                   "needs to be removed and realigned because data has been lost. ".
-                   "Please create an apipe-support ticket for this.", $alignment->class, $alignment->id);
-               #There is no way to recreate per lane bam if merged bam
-               #does not exist and per lane bam is removed. Software
-               #result of this per lane alignment needs to be removed and
-               #this per lane instrument data needs to be realigned
-               #with that aligner.
-            }
-
-            my $resource = File::Spec->join('genome', __PACKAGE__, 'lock-per-lane-alignment-'.$alignment->id);
-            my $lock = Genome::Sys::LockProxy->new(
-                resource => $resource,
-                scope => 'site',
-            )->lock(
-                max_try       => 288, # Try for 48 hours every 10 minutes
-                block_sleep   => 600,
-            );
-            die $self->error_message("Unable to acquire the lock for per lane alignment result id (%s) !", $alignment->id) unless $lock;
-
-            # If the build before us successfully created a merged alignment result, we no longer need a lock
-            # If it failed, we will add an observer just as the first build did.
-            if ($alignment->get_merged_alignment_results) {
-                $lock->unlock();
-            } else {
-                # The problem here is if we commit BEFORE merge is done, we unlock too early.
-                # However, if we unlock any other way we may fail to unlock more often and leave old locks.
-                UR::Context->process->add_observer(
-                    aspect   => 'commit',
-                    once => 1,
-                    callback => sub {
-                        $lock->unlock();
-                    }
-                );
-            }
-        }
+        $alignment->lock_bam_file_access;
     }
-
     return 1;
 }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -264,7 +264,6 @@ sub create {
                     die $self->error_message("Fail to run flagstat on $bam_path");
                 }
             }
-            $alignment->_reallocate_disk_allocation;
             $self->_remove_per_lane_bam_post_commit($bam_path, $alignment);
         }
     }


### PR DESCRIPTION
This PR refactors per-lane bam locking code out of G::I::AR::Merged and into G::I::AlignmentResult and handles both old and new lock during the migration. It also removes an extra reallocation. This PR replaces the old PR#574.