### PR TITLE
reserve 8 GB memory for ClinSeq's MicroarrayCnv

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/MicroarrayCnv.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/MicroarrayCnv.pm
@@ -6,6 +6,11 @@ use Genome;
 
 class Genome::Model::ClinSeq::Command::MicroarrayCnv {
     is => 'Command::V2',
+    has_param => [
+        lsf_resource => {
+            default => "-R 'span[hosts=1] rusage[mem=8000]' -M 8000000",
+        }
+    ],
     has_input => [
         microarray_model_tumor => {
             is => 'Genome::Model::GenotypeMicroarray',


### PR DESCRIPTION
The MRS1 were failing due to reaching the default memory limit of 4 GB. As a
quick fix I increased memory to 16 GB and the models were run but only
consumed about 6.5 GB so for this change I've limited the reservation to 8 GB.

See [RT#105133][1] for additional context.

[1]: https://rt.gsc.wustl.edu/Ticket/Display.html?id=105133