### PR TITLE
Fill a hole in the system of tracking result users

### DIFF
--- a/lib/perl/Genome/Model/SomaticVariation/Command/TierVariants.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/TierVariants.pm
@@ -236,6 +236,7 @@ sub link_result_to_build {
 
         Genome::Sys->create_symlink($f, join('/', $effects_dir, $name));
     }
+    $result->add_user(user => $build, label => 'uses');
 
     return 1;
 }


### PR DESCRIPTION
The build uses this result relationship to find the result later and this one seems to be missing.  I am running the model test as well to make sure it finds the correct results and fixes the diff.