### PR TITLE
Make LaneQC request revivified per-lane bams

### DIFF
--- a/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CopyNumber.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CopyNumber.pm
@@ -88,8 +88,11 @@ sub execute {
             my $instrument_data_id = $alignment->instrument_data_id;    
             my @bams = $alignment->alignment_bam_file_paths;
             unless(@bams) {
-                $self->error_message("No alignment bam for $alignment_id");
-                return;
+                @bams = $alignment->revivified_alignment_bam_file_path;
+                unless(@bams) {
+                    $self->error_message("No alignment bam for $alignment_id");
+                    return;
+                }
             }
             else {
                 my $alignment_count = @bams;


### PR DESCRIPTION
This is replacement logic for custom snapshot genome-3587-laneqc-fix. The logic from this custom snapshot was never made into a commit because the revivification method was being refactored to be easier to call (it handles its own tempdir now).

The old custom snapshot logic is located here /gsc/scripts/opt/genome/snapshots/old/genome-3587-laneqc-fix/0001-Hack-to-get-LaneQC-to-succeed-more-often.patch. This PR should mirror that logic with less code now.

