### PR TITLE
Include the LQ results in the array so they get linked to the build

### DIFF
--- a/lib/perl/Genome/Model/SomaticVariation/Command/DetectVariants.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/DetectVariants.pm
@@ -83,7 +83,7 @@ sub execute{
         die $self->error_message("Failed to execute detect variants dispatcher with params:\n".Data::Dumper::Dumper \%params);
     }
     else {
-        my @results = $command->results, $command->lq_results;
+        my @results = ($command->results, $command->lq_results);
         push @results, map { Genome::Model::Tools::DetectVariants2::Result::Vcf->get(input_id => $_->id ); } @results;
         for my $result (@results) {
             $result->add_user(user => $build, label => 'uses');


### PR DESCRIPTION
```
$ perl -W -e 'my @x = 1,2;'
Useless use of a constant in void context at -e line 1.
```