### PR TITLE
disable diagnostics when using compare_ok with binary files

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.t
@@ -89,7 +89,10 @@ my $merged_alignment_result = $pkg->create(@params, _user_data_for_nested_result
 isa_ok($merged_alignment_result, $pkg, 'produced merged alignment result');
 
 subtest 'testing merge without filter_name' => sub {
-    compare_ok($merged_alignment_result->bam_file, File::Spec->join($expected_dir, '-120573001.bam'), 'merged bam matches expected result');
+    compare_ok($merged_alignment_result->bam_file, File::Spec->join($expected_dir, '-120573001.bam'),
+        name => 'merged bam matches expected result',
+        diag => 0,
+    );
     compare_ok($merged_alignment_result->merged_alignment_bam_flagstat, File::Spec->join($expected_dir, '-120573001.bam.flagstat'), 'flagstat matches expected result');
 
     my @individual_alignments = $merged_alignment_result->collect_individual_alignments;
@@ -135,7 +138,10 @@ subtest 'testing merge with filter_name' => sub {
     is(scalar @filtered_individual_alignments, 2, 'got back expected number of alignments');
 
     #same expected files since we faked the alignment results to use the same data
-    compare_ok($filtered_alignment_result->bam_file, File::Spec->join($expected_dir, '-120573001.bam'), 'merged bam matches expected result');
+    compare_ok($filtered_alignment_result->bam_file, File::Spec->join($expected_dir, '-120573001.bam'),
+        name => 'merged bam matches expected result',
+        diag => 0,
+    );
     compare_ok($filtered_alignment_result->merged_alignment_bam_flagstat, File::Spec->join($expected_dir, '-120573001.bam.flagstat'), 'flagstat matches expected result');
 
     for my $i (@filtered_individual_alignments) {

--- a/lib/perl/Genome/Utility/Test.pm
+++ b/lib/perl/Genome/Utility/Test.pm
@@ -471,16 +471,16 @@ Compare two files line-by-line
   compare_ok($file_1, $file_2)
 
 With no options, it directly compares two files.  At the first difference, it
-will stop and print a diagnostic message about the difference (if diag => 1
+will stop and print a diagnostic message about the difference (unless C<diag =E<gt> 1>
 is passed as an option).
 
 Options include
 
 =over
 
-=item diag => 1 || 0
+=item diag => 0
 
-Do or do not print a diag() message if the files are different
+Disable printing of diagnostic message if the files are different.
 
 =item filters => [ string1, string2, ..., regex1, regex2, ...]
 
@@ -496,10 +496,6 @@ another string before the line comparison is done.
 =item name
 
 Specify a name for a test but requires 'name' key.
-
-=item diag
-
-Disable diag output when a diff is encountered. Added this in case people want to surpress any output.
 
 =item test
 


### PR DESCRIPTION
We should disable diagnostics when using `compare_ok()` with binary files.