### PR TITLE
fix bug exposed in newer Bash versions

### DIFF
--- a/bin/genome-env
+++ b/bin/genome-env
@@ -274,9 +274,9 @@ function assert_dir {
     fi
 }
 
-declare -a SUBMODULES
+declare -a SUBMODULES=()
 function append_submodule {
-    if test "${#SUBMODULES}" -gt 0
+    if test "${#SUBMODULES[@]}" -gt 0
     then
         SUBMODULES=("${SUBMODULES[@]}" "$@")
     else


### PR DESCRIPTION
@mcallaway discovered this bug when trying to use `genome-env` on a newer Bash
version,

    $ genome-env -D ...
    .../genome-env: line 279: SUBMODULES: unbound variable