### PR TITLE
A new method get_bam_file to handle lock and return revivified bam or copied in-place bam

### DIFF
--- a/lib/perl/Genome/Command.pm.opts
+++ b/lib/perl/Genome/Command.pm.opts
@@ -3355,13 +3355,6 @@ $Genome::Command::OPTS_SPEC = [
         'help!',
         undef
       ],
-      '>prepare-instrument-data',
-      [
-        'build=s',
-        undef,
-        'help!',
-        undef
-      ],
       '>copy-velvet-build',
       [
         'to=s',
@@ -10406,6 +10399,25 @@ $Genome::Command::OPTS_SPEC = [
       'files',
       'filter=s',
       'files',
+      'help!',
+      undef
+    ],
+    'help!',
+    undef
+  ],
+  '>ptero',
+  [
+    '>wrapper',
+    [
+      'command-class=s',
+      'files',
+      'method=s',
+      [
+        'execute',
+        'shortcut'
+      ],
+      'log-directory=s',
+      undef,
       'help!',
       undef
     ],

--- a/lib/perl/Genome/InstrumentData/AlignedBamResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignedBamResult.pm
@@ -50,6 +50,11 @@ class Genome::InstrumentData::AlignedBamResult {
     ],
 };
 
+sub get_bam_file {
+    my $self = shift;
+    return $self->bam_file;
+}
+
 sub instrument_data {
     die 'Abstract';
 }

--- a/lib/perl/Genome/InstrumentData/AlignedBamResult.t
+++ b/lib/perl/Genome/InstrumentData/AlignedBamResult.t
@@ -36,6 +36,7 @@ ok($aligned_bam_result, 'defined aligned bam result');
 my $bam_path = $aligned_bam_result->bam_path;
 is($bam_path, $tmpdir.'/'.$aligned_bam_result->id.'.bam', 'bam path named correctly');
 is($aligned_bam_result->bam_file, $bam_path, 'bam file is same as bam path');
+is($aligned_bam_result->get_bam_file, $bam_path, 'get_bam_file interface works');
 Genome::Sys->create_symlink($input_bam, $bam_path);
 ok(-s $bam_path, 'linked bam');
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1795,7 +1795,7 @@ sub _get_temp_allocation {
     );
     UR::Context->process->add_observer(
         aspect   => 'pre-commit',
-        once     => 1
+        once     => 1,
         callback => sub { $temp_allocation->delete; },
     );
     return $temp_allocation;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1794,7 +1794,8 @@ sub _get_temp_allocation {
         owner_id            => Genome::Sys->username,
     );
     UR::Context->process->add_observer(
-        aspect => 'pre-commit',
+        aspect   => 'pre-commit',
+        once     => 1
         callback => sub { $temp_allocation->delete; },
     );
     return $temp_allocation;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1642,7 +1642,8 @@ sub verify_alignment_data {
 
 # This will generally only return something until the first merge has deleted the original per-lane bam file
 sub alignment_bam_file_paths {
-    return glob(File::Spec->join(shift->output_dir, "*.bam"));
+    my $self = shift;
+    return glob(File::Spec->join($self->output_dir, "*.bam"));
 }
 
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1648,9 +1648,8 @@ sub alignment_bam_file_paths {
 # This method will recreate the per-lane bam file and return the path.
 # This must be provided an allocation into which the bam will go (so that it can be cleaned up in the parent process once it is done).
 # The calling process is responsible for cleaning up the allocation after we are done with it.
-sub revivified_alignment_bam_file_paths {
+sub revivified_alignment_bam_file_path {
     my $self = shift;
-    my %p = Params::Validate::validate(@_, {disk_allocation => { isa => 'Genome::Disk::Allocation'}});
 
     # If we have a merged alignment result, the per-lane bam can be regenerated and we will do so now
     # This is less efficient than using the in-place per-lane bam. However, it aids us in terms of
@@ -1661,8 +1660,14 @@ sub revivified_alignment_bam_file_paths {
         return @bams;
     }
 
-    my $revivified_bam = File::Spec->join($p{disk_allocation}->absolute_path, 'all_sequences.bam');
-    my $merged_bam    = $self->get_merged_bam_to_revivify_per_lane_bam;
+    my $temp_allocation = $self->_get_temp_allocation($self->output_dir);
+    UR::Context->process->add_observer(
+        aspect => 'pre-commit',
+        callback => sub { $temp_allocation->delete; },
+    );
+
+    my $revivified_bam = File::Spec->join($temp_allocation->absolute_path, 'all_sequences.bam');
+    my $merged_bam = $self->get_merged_bam_to_revivify_per_lane_bam;
 
     unless ($merged_bam and -s $merged_bam) {
         die $self->error_message('Failed to get valid merged bam to recreate per lane bam '.$self->id);
@@ -1693,6 +1698,22 @@ sub revivified_alignment_bam_file_paths {
     }
 }
 
+sub _get_temp_allocation {
+    my ($self, $output_dir) = @_;
+    return Genome::Disk::Allocation->create(
+        disk_group_name     => $ENV{GENOME_DISK_GROUP_ALIGNMENTS},
+        allocation_path     => 'merged/recreated_per_lane_bam/'.$self->id.'_'._get_uuid_string(),
+        kilobytes_requested => $self->bam_size || 100_000_000, # This should always be set, but just in case we reserve a lot
+        owner_class_name    => 'Genome::Sys::User',
+        owner_id            => Genome::Sys->username,
+    );
+}
+
+sub _get_uuid_string {
+    my $ug = Data::UUID->new();
+    my $uuid = $ug->create();
+    return $ug->to_string($uuid);
+}
 
 sub bam_header_path {
     return File::Spec->join(shift->output_dir, 'all_sequences.bam.header');

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/CufflinksExpression.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/CufflinksExpression.pm
@@ -90,11 +90,11 @@ sub execute {
     if (version->parse($alignment_result->aligner_version) >= version->parse('1.1.0')) {
         # Cufflinks v0.9.0 and later will work on sam or bam files
         if (version->parse($self->cufflinks_version) >= version->parse('0.9.0')) {
-            $tophat_file = $alignment_result->bam_file;
+            $tophat_file = $alignment_result->get_bam_file;
         } else {
             $tophat_file = Genome::Sys->create_temp_file_path($self->build->id .'.sam');
             my $bam_to_sam_cmd = Genome::Model::Tools::Sam::BamToSam->execute(
-                bam_file => $alignment_result->bam_file,
+                bam_file => $alignment_result->get_bam_file,
                 sam_file => $tophat_file,
             );
             unless ($bam_to_sam_cmd and $bam_to_sam_cmd->result) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/PicardRnaSeqMetrics.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/PicardRnaSeqMetrics.pm
@@ -91,7 +91,7 @@ sub execute {
     my $alignment_result = $self->alignment_result;
     my $picard_version = $self->picard_version;
     
-    my $bam_file = $alignment_result->bam_file;
+    my $bam_file = $alignment_result->get_bam_file;
     
     my $reference_fasta_file = $reference_build->full_consensus_path('fa');
     unless (-s $reference_fasta_file) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/TranscriptomeCoverage.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/TranscriptomeCoverage.pm
@@ -74,7 +74,7 @@ sub execute {
     my $annotation_build = $self->annotation_build;
 
     # Alignment inputs
-    my $bam_file = $self->alignment_result->bam_file;
+    my $bam_file = $self->alignment_result->get_bam_file;
 
     my $coverage_directory = $self->coverage_directory;
     unless (-d $coverage_directory) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -157,7 +157,6 @@ sub create {
     return unless ($self);
 
     $self->_lock_per_lane_alignments();
-    my @temp_allocations = ();
 
     try {
         #TODO In a future version collect relevant alignments from other merged alignment results when available
@@ -176,10 +175,8 @@ sub create {
             #handle duplicates on a per-library basis
             for my $alignment (@alignments) {
                 my $library = $alignment->instrument_data->library;
-                my $temp_allocation = $self->_get_temp_allocation($alignment->id, $self->output_dir);
-                push @{ $bams_per_library->{$library->id} }, $alignment->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
+                push @{ $bams_per_library->{$library->id} }, $alignment->revivified_alignment_bam_file_path;
                 $libraries->{$library->id} = $library;
-                push @temp_allocations, $temp_allocation;
             }
 
             for my $library_id (keys %$bams_per_library) {
@@ -197,9 +194,7 @@ sub create {
         } else {
             #just collect the BAMs for a merge
             for my $alignment (@alignments) {
-                my $temp_allocation = $self->_get_temp_allocation($alignment->id, $self->output_dir);
-                push @bams_for_final_merge, $alignment->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
-                push @temp_allocations, $temp_allocation;
+                push @bams_for_final_merge, $alignment->revivified_alignment_bam_file_path;
             }
         }
 
@@ -234,11 +229,6 @@ sub create {
     catch {
         $tx->rollback();
         die $class->error_message('Merge failed due to error: ' . $_);
-    }
-    finally {
-        for my $allocation (@temp_allocations) {
-            $allocation->delete;
-        }
     };
 
     $self->_reallocate_disk_allocation;
@@ -331,23 +321,6 @@ sub _remove_per_lane_bam {
         }
     }
     return 1;
-}
-
-sub _get_temp_allocation {
-    my ($self, $alignment_id, $output_dir) = @_;
-    return Genome::Disk::Allocation->create(
-        disk_group_name     => $ENV{GENOME_DISK_GROUP_ALIGNMENTS},
-        allocation_path     => 'merged/recreated_per_lane_bam/'.$alignment_id.'_'._get_uuid_string(),
-        kilobytes_requested => Genome::Sys->disk_usage_for_path($output_dir),
-        owner_class_name    => 'Genome::Sys::User',
-        owner_id            => Genome::Sys->username,
-    );
-}
-
-sub _get_uuid_string {
-    my $ug = Data::UUID->new();
-    my $uuid = $ug->create();
-    return $ug->to_string($uuid);
 }
 
 sub collect_individual_alignments {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.t
@@ -22,7 +22,7 @@ my $pkg = 'Genome::InstrumentData::AlignmentResult::Merged';
 use_ok($pkg);
 
 # Override methods for testing so we don't need to worry about commit observers in the unit test
-Sub::Install::install_sub({code => sub { my ($self, $bam_path) = @_; $self->_remove_per_lane_bam($bam_path); },
+Sub::Install::install_sub({code => sub { my ($self, $alignment) = @_; $alignment->remove_bam; },
         into => 'Genome::InstrumentData::AlignmentResult::Merged', as => '_remove_per_lane_bam_post_commit'});
 
 Sub::Install::install_sub({code => sub { return 1; },
@@ -46,7 +46,7 @@ my $aligner_version  = $aligner_tools_class_name->default_version;
 my $aligner_label    = $aligner_name.$aligner_version;
 $aligner_label       =~ s/\./\_/g;
 
-my $expected_base_dir = Genome::Utility::Test->data_dir_ok($pkg);
+my $expected_base_dir = Genome::Utility::Test->data_dir_ok($pkg, 'v1');
 my $expected_shortcut_path = $expected_base_dir .'/bwa/',
 my $expected_dir = $expected_base_dir .'/expected';
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/BamQc.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/BamQc.pm
@@ -148,10 +148,9 @@ sub create {
     );
 
     # use per lane instrument data id as link name
-    my @instrument_data = $self->alignment_result->instrument_data;
     my $lane_flag;
-    if (@instrument_data == 1) {
-        my $instr_data = $instrument_data[0];
+    if ($self->alignment_result->isa('Genome::InstrumentData::AlignmentResult')) {
+        my $instr_data = $self->alignment_result->instrument_data;
         $bam_qc_params{bam_link_name} = $instr_data->id;
         $lane_flag = 1;
     }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/CoverageStats.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/CoverageStats.pm
@@ -129,7 +129,7 @@ sub create {
     $self->_prepare_staging_directory;
 
     my $bed_file = $self->_dump_bed_file;
-    my $bam_file = $self->alignment_result->bam_file;
+    my $bam_file = $self->alignment_result->get_bam_file;
 
     die $self->error_message("Bed File ($bed_file) is missing") unless -s $bed_file;
     die $self->error_message("Bam File ($bam_file) is missing") unless -s $bam_file;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/RefCov.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/RefCov.pm
@@ -148,7 +148,7 @@ sub create {
     $self->_prepare_staging_directory;
 
     my $bed_file = $self->_dump_bed_file;
-    my $bam_file = $self->alignment_result->bam_file;
+    my $bam_file = $self->alignment_result->get_bam_file;
 
     die $self->error_message("Bed File ($bed_file) is missing") unless -s $bed_file;
     die $self->error_message("Bam File ($bam_file) is missing") unless -s $bam_file;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Tophat2AlignmentStats.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Tophat2AlignmentStats.pm
@@ -69,7 +69,7 @@ sub create {
 
     $self->_prepare_staging_directory;
 
-    my $bam_file = $self->alignment_result->bam_file;
+    my $bam_file = $self->alignment_result->get_bam_file;
     my $alignment_stats_file = $self->temp_staging_directory .'/alignment_stats.txt';
 
     my $cmd = Genome::Model::Tools::BioSamtools::Tophat2AlignmentStats->execute(

--- a/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
@@ -237,4 +237,39 @@ subtest 'test per lane bam removal and recreation - AlignedBamResult accessors' 
     is($ar2->bam_md5_path, File::Spec->join($ar2->output_dir, 'all_sequences.bam.md5'), 'bam_md5_path correct after revivification');
 };
 
+subtest 'test get_bam_file' => sub {
+    my $ar2_ori_bam_file = File::Spec->join($ar2->output_dir, $per_lane_bam);
+    my $ar2_bam_file     = $ar2->get_bam_file;
+    isnt($ar2_bam_file, $ar2_ori_bam_file, 'AR2 get_bam_file exists and is different from the result bam path');
+
+    my $new_flagstat_file = Genome::Sys->create_temp_file_path;
+    `samtools flagstat $ar2_bam_file > $new_flagstat_file`;
+    compare_ok($new_flagstat_file, File::Spec->join($ar2->output_dir, $per_lane_flagstat), 'AR2 get_bam_file flagstat ok');
+
+    #copy .bam and .bam.bai back to ar2 per lane alignment result
+    #output dir since previous merge removed per lane bam
+    for my $type ('', '.bai') {
+        my $ar2_base = $per_lane_bam.$type;
+        my $ar2_file = File::Spec->join($ar2->output_dir, $ar2_base);
+        Genome::Sys->copy_file(File::Spec->join($test_data_dir, 'ar2', $ar2_base), $ar2_file);
+        ok(-s $ar2_file, "$ar2_base copied over ok");
+    }
+
+    $merged_result->test_name($test_name.' changed');
+    my $ar2_copy_bam_file = $ar2->get_bam_file;
+    isnt($ar2_copy_bam_file, $ar2_ori_bam_file, 'AR2 get_bam_file returns copied bam file and is different from the result bam path');
+
+    for my $type ('', '.bai') {
+        my $base_name = $per_lane_bam.$type;
+        my $file      = $ar2_copy_bam_file.$type;
+        my $ar2_file  = File::Spec->join($ar2->output_dir, $base_name);
+        compare_ok($file, $ar2_file, "AR2 get_bam_file $base_name copied ok");
+    }
+    my $md5_ori_str  = `md5sum $ar2_ori_bam_file`;
+    ($md5_ori_str) = $md5_ori_str =~ /^(\S+)\s+/;
+    my $md5_copy_str = `md5sum $ar2_copy_bam_file`;
+    ($md5_copy_str) = $md5_copy_str =~ /^(\S+)\s+/;
+    is($md5_ori_str, $md5_copy_str, 'AR2 get_bam_file copied bam is exactly same as the original one');
+};
+
 done_testing();

--- a/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
@@ -265,11 +265,10 @@ subtest 'test get_bam_file' => sub {
         my $ar2_file  = File::Spec->join($ar2->output_dir, $base_name);
         compare_ok($file, $ar2_file, "AR2 get_bam_file $base_name copied ok");
     }
-    my $md5_ori_str  = `md5sum $ar2_ori_bam_file`;
-    ($md5_ori_str) = $md5_ori_str =~ /^(\S+)\s+/;
-    my $md5_copy_str = `md5sum $ar2_copy_bam_file`;
-    ($md5_copy_str) = $md5_copy_str =~ /^(\S+)\s+/;
-    is($md5_ori_str, $md5_copy_str, 'AR2 get_bam_file copied bam is exactly same as the original one');
+
+    my $md5_ori  = Genome::Sys->md5sum($ar2_ori_bam_file);
+    my $md5_copy = Genome::Sys->md5sum($ar2_copy_bam_file);
+    is($md5_ori, $md5_copy, 'AR2 get_bam_file copied bam is exactly same as the original one');
 };
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/VerifyBamIdResult.pm
+++ b/lib/perl/Genome/InstrumentData/VerifyBamIdResult.pm
@@ -118,7 +118,7 @@ sub _resolve_bam_file {
     my $self = shift;
     my $bam_result = $self->aligned_bam_result;
 
-    my $path = $bam_result->bam_path;
+    my $path = $bam_result->get_bam_file;
     unless (-s $path) {
         $self->_error("Could not get bam file for ".$bam_result->id);
     }

--- a/lib/perl/Genome/InstrumentData/VerifyBamIdResult.t
+++ b/lib/perl/Genome/InstrumentData/VerifyBamIdResult.t
@@ -86,7 +86,9 @@ sub test_metrics {
 sub setup_objects {
     my $test_dir = shift;
     my $bam_result_1 = Genome::Test::Factory::InstrumentData::MergedAlignmentResult->setup_object(
-        bam_path => File::Spec->join($test_dir, "1.bam"));
+        id => 1,
+        output_dir => $test_dir,
+    );
 
     my $model = Genome::Test::Factory::Model::GenotypeMicroarray->setup_object();
 

--- a/lib/perl/Genome/Model/Build/SomaticValidation/IdentifyDnpResult.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation/IdentifyDnpResult.pm
@@ -68,7 +68,7 @@ sub _snvs_hq_bed {
 
 sub _tumor_bam_file {
     my $self = shift;
-    my $bam_file = $self->tumor_alignment_result->bam_path;
+    my $bam_file = $self->tumor_alignment_result->get_bam_file;
     unless (defined $bam_file) {
         die $self->error_message("'whole_rmdup_bam_file' not defined for build's tumor_reference_alignment.");
     }

--- a/lib/perl/Genome/Model/ClinSeq/Command/GetBamReadCountsMatrix.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/GetBamReadCountsMatrix.pm
@@ -560,8 +560,8 @@ sub get_ref_align_builds{
       $bam_file = $build->whole_rmdup_bam_file;
     }elsif($build->can("alignment_result")){
       my $alignment_result = $build->alignment_result;
-      if ($alignment_result->can("bam_file")){
-        $bam_file = $alignment_result->bam_file;
+      if ($alignment_result->can("get_bam_file")){
+        $bam_file = $alignment_result->get_bam_file;
       }
     }
     if ($bam_file){

--- a/lib/perl/Genome/Model/DifferentialExpression/Command/Cuffdiff.pm
+++ b/lib/perl/Genome/Model/DifferentialExpression/Command/Cuffdiff.pm
@@ -55,7 +55,7 @@ sub execute {
             my $rna_seq_model = Genome::Model->get($model_id);
             # Or should we just fine the latest AlignmentResult....
             my $last_succeeded_build = $rna_seq_model->last_succeeded_build;
-            my $bam_file = $last_succeeded_build->alignment_result->bam_file;
+            my $bam_file = $last_succeeded_build->alignment_result->get_bam_file;
             push @condition_bam_file_paths, $bam_file;
         }
         my $condition_bam_files_string = join(',',@condition_bam_file_paths);

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/DeduplicateLibraries/Samtools.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/DeduplicateLibraries/Samtools.pm
@@ -65,7 +65,7 @@ sub execute {
         }
         my @alignments = $build->alignment_results_for_instrument_data($instrument_data);
         for my $alignment (@alignments) {
-            my @bams = $alignment->alignment_bam_file_paths;
+            my @bams = $alignment->get_bam_file;
             $self->debug_message("bam file paths: ". @bams);
 
             push @{$library_alignments{$library}}, @bams;  #for the dedup step
@@ -247,7 +247,7 @@ sub calculate_required_disk_allocation_kb {
     for my $instrument_data (@instrument_data) {
         my @alignments = $build->alignment_results_for_instrument_data($instrument_data);
         for my $alignment (@alignments) {
-            my @aln_bams = $alignment->alignment_bam_file_paths;
+            my @aln_bams = $alignment->get_bam_file;
             push @build_bams, @aln_bams;
         }
     }

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/RefCov.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/RefCov.pm
@@ -70,7 +70,7 @@ sub sorted_bam_files {
                 return;
             }
             for my $alignment (@alignments) {
-                push @sorted_bam_files, $alignment->alignment_bam_file_paths;
+                push @sorted_bam_files, $alignment->get_bam_file;
             }
         }
         $self->_sorted_bams(\@sorted_bam_files);

--- a/lib/perl/Genome/Model/Event/Build/RnaSeq/Coverage.pm
+++ b/lib/perl/Genome/Model/Event/Build/RnaSeq/Coverage.pm
@@ -21,7 +21,7 @@ sub execute {
     # Tophat v1.1.0 and later produces BAM output
     my $bam_file;
     if (version->parse($alignment_result->aligner_version) >= version->parse('1.1.0')) {
-        $bam_file = $alignment_result->bam_file;
+        $bam_file = $alignment_result->get_bam_file;
     } else {
         die('Coverage requires a BAM file produced by TopHat v1.1.0 or greater');
     }

--- a/lib/perl/Genome/Model/Event/Build/RnaSeq/Expression/Cufflinks.pm
+++ b/lib/perl/Genome/Model/Event/Build/RnaSeq/Expression/Cufflinks.pm
@@ -29,11 +29,11 @@ sub execute {
     if (version->parse($alignment_result->aligner_version) >= version->parse('1.1.0')) {
         # Cufflinks v0.9.0 and later will work on sam or bam files
         if (version->parse($self->model->expression_version) >= version->parse('0.9.0')) {
-            $tophat_file = $alignment_result->bam_file;
+            $tophat_file = $alignment_result->get_bam_file;
         } else {
             $tophat_file = Genome::Sys->create_temp_file_path($self->build->id .'.sam');
             my $convert_cmd = Genome::Model::Tools::Sam::BamToSam->execute(
-                bam_file => $alignment_result->bam_file,
+                bam_file => $alignment_result->get_bam_file,
                 sam_file => $tophat_file,
             );
             unless ($convert_cmd and $convert_cmd->result) {

--- a/lib/perl/Genome/Model/PhenotypeCorrelation.pm
+++ b/lib/perl/Genome/Model/PhenotypeCorrelation.pm
@@ -628,7 +628,7 @@ sub _find_or_generate_multisample_vcf {
 sub get_snp_list_for_something_close_to_this_result {
     my ($self, $alignment_result) = @_;
     my $return_snp_file;
-    my $bam_path = $alignment_result->bam_file;
+    my $bam_path = $alignment_result->get_bam_file;
     my $reference_build_id = $alignment_result->reference_build->id;
 
     # Try to find a snplist that was run with this bam
@@ -653,7 +653,7 @@ sub get_snp_list_for_something_close_to_this_result {
 
     # For every bam you found, look for an existing useable snp list
     for my $alignment_result (@more_alignment_results) {
-        $bam_path = $alignment_result->bam_file;
+        $bam_path = $alignment_result->get_bam_file;
         my @results = Genome::Model::Tools::DetectVariants2::Result::Filter->get(
             filter_name => "Genome::Model::Tools::DetectVariants2::Filter::SnpFilter",
             reference_build_id => $reference_build_id,

--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignmentStatsSummary.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignmentStatsSummary.pm
@@ -156,7 +156,7 @@ sub _alignment_metrics_from_result {
     if ($self->haploid_coverage && ($total_mapped_bases > 0) ) {
         # Stolen from Genome::Model::ReferenceAlignment::Report::Mapcheck;
         my $coverage = Genome::Model::Tools::Sam::Coverage->create(
-            aligned_reads_file=> $result->bam_path,
+            aligned_reads_file=> $result->get_bam_file,
             reference_file => $result->reference_build->full_consensus_path('fa'),
             return_output => 1,
             coverage_command => $ENV{GENOME_SW} . '/samtools/bamcheck/bamcheck-v0.13/bam-check -q 1',

--- a/lib/perl/Genome/Model/SomaticValidation/Command/Loh.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/Loh.pm
@@ -111,7 +111,7 @@ sub _fetch_control_snv_result {
     return unless $build->model->loh_snv_detection_strategy;
 
     my $alignment_result = $build->control_merged_alignment_result;
-    my $bam = $alignment_result->bam_file;
+    my $bam = $alignment_result->get_bam_file;
 
     my $dir = $build->data_directory .'/control_variants_for_loh';
     Genome::Sys->create_directory($dir);

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/AlignReads.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/AlignReads.pm
@@ -128,12 +128,12 @@ sub execute {
         my $sample = $i[0]->sample;
         if($sample eq $build->tumor_sample) {
             $self->merged_alignment_result_id($r->id);
-            $self->merged_bam_path($r->bam_file);
+            $self->merged_bam_path($r->get_bam_file);
             $r->add_user(label => 'sv_validation_merged_alignment', user => $build);
             Genome::Sys->create_symlink($r->output_dir, $build_alignment_dir . '/tumor');
         } elsif ($sample eq $build->normal_sample) {
             $self->control_merged_alignment_result_id($r->id);
-            $self->control_merged_bam_path($r->bam_file);
+            $self->control_merged_bam_path($r->get_bam_file);
             $r->add_user(label => 'sv_validation_control_merged_alignment', user => $build);
             Genome::Sys->create_symlink($r->output_dir, $build_alignment_dir . '/normal');
         } else {

--- a/lib/perl/Genome/Model/SomaticValidation/Command/VerifyBam.t
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/VerifyBam.t
@@ -80,10 +80,12 @@ sub setup_objects {
     $dbsnp_build->reference->allosome_names("X,Y,MT");
 
     my $merged_result1 = Genome::Test::Factory::InstrumentData::MergedAlignmentResult->setup_object(
-        bam_path => File::Spec->join($test_dir, "1.bam"),
+        id => 1,
+        output_dir => $test_dir,
     );
     my $merged_result2 = Genome::Test::Factory::InstrumentData::MergedAlignmentResult->setup_object(
-        bam_path => File::Spec->join($test_dir, "2.bam"),
+        id => 2,
+        output_dir => $test_dir,
     );
 
     my $pp = Genome::Test::Factory::ProcessingProfile::SomaticValidation->setup_object(

--- a/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CompareSnpsBuildLanes.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CompareSnpsBuildLanes.pm
@@ -131,8 +131,7 @@ sub execute {
             my $lane=$instrument_data->lane;
             my $flow_cell_id=$instrument_data->flow_cell_id;
             my $lane_name="$flow_cell_id"."_"."$lane";	
-            my @bam = $alignment->alignment_bam_file_paths;
-            my $alignment_file = $bam[0];
+            my $alignment_file = $alignment->get_bam_file;
 
             if ($alignment_file ne ""){
                 $self->error_message("$lane_name : $alignment_file");

--- a/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CopyNumber.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CopyNumber.pm
@@ -85,8 +85,8 @@ sub execute {
         for my $alignment (@alignments) {
             my $alignment_id = $alignment->id;
             my $reference = $alignment->reference_build->full_consensus_path('fa');
-            my $instrument_data_id = $alignment->instrument_data_id;    
-            my @bams = $alignment->alignment_bam_file_paths;
+            my $instrument_data_id = $alignment->instrument_data_id;
+            my @bams = $alignment->get_bam_file;
             unless(@bams) {
                 $self->error_message("No alignment bam for $alignment_id");
                 return;

--- a/lib/perl/Genome/Model/Tools/Analysis/LaneQc/EntireBuild.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/LaneQc/EntireBuild.pm
@@ -79,7 +79,7 @@ sub execute {
         for my $alignment (@alignments) {
             my $reference = $alignment->reference_build->full_consensus_path('fa');
             my $instrument_data_id = $alignment->instrument_data_id;    
-            my @bams = $alignment->alignment_bam_file_paths;
+            my @bams = $alignment->get_bam_file;
             unless(@bams) {
                 $self->error_message("No alignment bam for $lane_name");
                 return;

--- a/lib/perl/Genome/Model/Tools/BamQc/Run.pm
+++ b/lib/perl/Genome/Model/Tools/BamQc/Run.pm
@@ -143,7 +143,7 @@ sub execute {
     #TODO: Validate BAM sort order or at least throw a warning if not found
     #BAM header tag under @HD SO, valid values: unknown (default), unsorted, queryname and coordinate
 
-    my ($bam_basename, $bam_dirname, $bam_suffix) = File::Basename::fileparse($self->bam_file, qw/\.bam/);
+    my ($bam_basename, $bam_dirname, $bam_suffix) = File::Basename::fileparse($self->get_bam_file, qw/\.bam/);
     $bam_basename = $self->bam_link_name if $self->bam_link_name;
     my $file_basename = $output_directory .'/'. $bam_basename;
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Base.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Base.pm
@@ -202,7 +202,7 @@ sub _verify_inputs {
 
     my $errors = 0;
     for my $result (@alignment_results,@control_alignment_results) { 
-        my $bam = $result->bam_file; 
+        my $bam = $result->get_bam_file; 
         unless (Genome::Sys->validate_file_for_reading($bam)) {
             $self->error_message("BAM file unreadable: $bam for " . $result->__display_name__);
             $errors++;

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Polymutt.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Polymutt.pm
@@ -311,7 +311,7 @@ sub generate_glfs {
         my @instrument_data = $alignments[$i]->instrument_data;
         my $output_name = $self->output_directory . "/" . $instrument_data[0]->sample_name . ".glf";
         push @outputs, $output_name;
-        $inputs{"bam_$i"}=$alignments[$i]->bam_file;
+        $inputs{"bam_$i"}=$alignments[$i]->get_bam_file;
         $inputs{"output_glf_$i"}=$output_name;
         push @inputs, ("bam_$i", "output_glf_$i");
     }

--- a/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
@@ -251,8 +251,7 @@ sub _run_htseq_count {
         # a completed alignment result will need to have a sorted bam created
         $self->debug_message("No temp_scratch_directory found: name sort the BAM in temp space.");
 
-        my $temp_allocation = Genome::InstrumentData::AlignmentResult::Merged->_get_temp_allocation($alignment_result->id, $output_dir);
-        my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_paths(disk_allocation => $temp_allocation);
+        my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_path;
 
         my $sorted_bam_noprefix = "$tmp/all_sequences.namesorted";
         $sorted_bam = $sorted_bam_noprefix . '.bam';
@@ -262,8 +261,6 @@ sub _run_htseq_count {
             input_files => [$unsorted_bam],
             output_files => [$sorted_bam],
         );
-
-        $temp_allocation->delete;
     }
 
     my @header = `$samtools_path view -H $sorted_bam`;

--- a/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Htseq/Count/Result.pm
@@ -251,7 +251,7 @@ sub _run_htseq_count {
         # a completed alignment result will need to have a sorted bam created
         $self->debug_message("No temp_scratch_directory found: name sort the BAM in temp space.");
 
-        my ($unsorted_bam) = $alignment_result->revivified_alignment_bam_file_path;
+        my ($unsorted_bam) = $alignment_result->get_bam_file;
 
         my $sorted_bam_noprefix = "$tmp/all_sequences.namesorted";
         $sorted_bam = $sorted_bam_noprefix . '.bam';

--- a/lib/perl/Genome/Model/Tools/Somatic/ProcessSomaticVariation.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/ProcessSomaticVariation.pm
@@ -650,8 +650,8 @@ sub execute {
       $sample_name = $self->sample_name;
   }
   $self->status_message("processing model with sample_name: $sample_name");
-  my $tumor_bam = $tumor_build->merged_alignment_result->bam_file;
-  my $normal_bam = $normal_build->merged_alignment_result->bam_file;
+  my $tumor_bam = $tumor_build->merged_alignment_result->get_bam_file;
+  my $normal_bam = $normal_build->merged_alignment_result->get_bam_file;
   my $build_dir = $build->data_directory;
 
   my $igv_reference_name;

--- a/lib/perl/Genome/Qc/Tool.pm
+++ b/lib/perl/Genome/Qc/Tool.pm
@@ -18,7 +18,7 @@ class Genome::Qc::Tool {
         bam_file => {
             is => 'Path',
             calculate_from => [qw(alignment_result)],
-            calculate => q{return $alignment_result->bam_path},
+            calculate => q{return $alignment_result->get_bam_file},
         },
     ],
 };

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/RunResult.pm
@@ -45,7 +45,7 @@ sub _run {
     delete $params{test_name};
 
     Genome::Model::Tools::Sam::Readcount->execute(
-        bam_file => $self->aligned_bam_result->bam_file,
+        bam_file => $self->aligned_bam_result->get_bam_file,
         reference_fasta => $self->aligned_bam_result->reference_fasta,
         output_file => File::Spec->join($self->temp_staging_directory, $self->output_filename),
         region_list => $region_list,


### PR DESCRIPTION
A new method get_bam_file is added to G::I::AR to handle the per lane bam lock and return either revivified_alignment_bam_file_path or copied in-place bam path depending on get_merged_alignment_results.