### PR TITLE
Disable sqlite_use_immediate_transaction to restore old behaviour.

### DIFF
--- a/lib/perl/Genome/DataSource/Meta.pm
+++ b/lib/perl/Genome/DataSource/Meta.pm
@@ -6,12 +6,27 @@ package Genome::DataSource::Meta;
 use strict;
 use warnings;
 
+use version;
+
 use UR;
+use DBD::SQLite;
 
 UR::Object::Type->define(
     class_name => 'Genome::DataSource::Meta',
     is => ['UR::DataSource::Meta'],
 );
 
+sub _dbi_connect_args {
+    my $self = shift;
+
+    my @connection = $self->SUPER::_dbi_connect_args(@_);
+
+    if(version->parse($DBD::SQLite::VERSION) >= version->parse('1.38_01')) {
+        my $connect_attr = $connection[3] ||= {};
+        $connect_attr->{sqlite_use_immediate_transaction} = 0;
+    }
+
+    return @connection;
+}
 
 1;


### PR DESCRIPTION
As part of testing this on `trusty`, the MetaDB was sometimes deadlocking itself between processes.  This was caused by a newer `DBD::SQLite` behaviour where it [acquires a lock immediately](http://search.cpan.org/~ishigaki/DBD-SQLite-1.46/lib/DBD/SQLite.pm#Transaction_and_Database_Locking) upon the first read/write from the DB.  (This had the side-effect of causing failures if the MetaDB was read-only.)  This flag restores the old behaviour we're used to on `lucid`.

There may be other ways of avoiding this problem (such as setting `AutoCommit` unless we're intending to make changes).