### PR TITLE
remove 'unknown' and 'tgisan' lock scopes

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Genome;
 use Genome::Sys::LockProxy qw();
-use Genome::Sys::LockMigrationProxy qw();
 use File::Path;
 use File::Copy;
 
@@ -394,15 +393,9 @@ sub full_consensus_sam_index_path {
         
         $self->warning_message("no failx file at $idx_file!");
 
-        my $lock = Genome::Sys::LockMigrationProxy->new(
-            old => {
-                resource => $data_dir.'/lock_for_faidx',
-                scope => 'unknown',
-            },
-            new => {
-                resource => 'reference-sequence-' . $self->id . '-faidx',
-                scope => 'site',
-            },
+        my $lock = Genome::Sys::LockProxy->new(
+            resource => 'reference-sequence-' . $self->id . '-faidx',
+            scope => 'site',
         )->lock(
             max_try       => 2,
         );
@@ -466,28 +459,18 @@ sub get_sequence_dictionary {
 
     $self->warning_message("No seqdict at path $path.  Creating...");
 
-    my %old_seqdict = (
-        resource => $seqdict_dir_path."/lock_for_seqdict-$file_type",
-        scope => 'unknown',
-    );
     my %new_seqdict = (
         resource => 'reference-sequence-' . $self->id . '-seqdict',
         scope => 'site',
     );
-    my $lock = Genome::Sys::LockMigrationProxy->new(
-        old => { %old_seqdict },
-        new => { %new_seqdict },
-    )->lock(
+    my $lock = Genome::Sys::LockProxy->new(%new_seqdict)->lock(
         max_try => 2,
     );
 
     # if it couldn't get the lock after 2 tries, pop a message and keep trying as much as it takes
     unless ($lock) {
         $self->status_message("Couldn't get a lock after 2 tries, waiting some more...");
-        $lock = Genome::Sys::LockMigrationProxy->new(
-            old => { %old_seqdict },
-            new => { %new_seqdict },
-        );
+        $lock = Genome::Sys::LockProxy->new(%new_seqdict)->lock();
         unless($lock) {
             $self->error_message("Failed to lock resource: $seqdict_dir_path");
             return;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -787,15 +787,9 @@ sub verify_or_create_local_cache {
     $self->status_message('Lock local cache directory');
     my $lock_name = $self->local_cache_lock;
     $self->status_message('Lock name: '.$lock_name);
-    my $lock = Genome::Sys::LockMigrationProxy->new(
-        old => {
-            resource => $lock_name,
-            scope => 'tgisan',
-        },
-        new => {
-            resource => $lock_name,
-            scope => 'host',
-        },
+    my $lock = Genome::Sys::LockProxy->new(
+        resource => $lock_name,
+        scope => 'host',
     )->lock(
         max_try => 20, # 20 x 180 sec each = 1hr
         block_sleep => 180,

--- a/lib/perl/Genome/Site/SGMS.pm
+++ b/lib/perl/Genome/Site/SGMS.pm
@@ -18,8 +18,4 @@ Genome::Sys::Lock->add_backend('site',
     Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
         parent_dir => $ENV{GENOME_SITE_LOCK_DIR}));
 
-Genome::Sys::Lock->add_backend('unknown',
-    Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
-        parent_dir => '/'));
-
 1;

--- a/lib/perl/Genome/Site/SGMS.pm
+++ b/lib/perl/Genome/Site/SGMS.pm
@@ -18,10 +18,6 @@ Genome::Sys::Lock->add_backend('site',
     Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
         parent_dir => $ENV{GENOME_SITE_LOCK_DIR}));
 
-Genome::Sys::Lock->add_backend('tgisan',
-    Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
-        parent_dir => $ENV{GENOME_LOCK_DIR}));
-
 Genome::Sys::Lock->add_backend('unknown',
     Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
         parent_dir => '/'));

--- a/lib/perl/Genome/Site/TGI/Extension/Sys/Lock.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys/Lock.pm
@@ -23,10 +23,6 @@ Genome::Sys::Lock->add_backend('site',
     Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
         parent_dir => $ENV{GENOME_SITE_LOCK_DIR}));
 
-Genome::Sys::Lock->add_backend('tgisan',
-    Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
-        parent_dir => $ENV{GENOME_FS_LOCAL_NETWORK_CACHE}));
-
 Genome::Sys::Lock->add_backend('unknown',
     Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
         parent_dir => '/'));

--- a/lib/perl/Genome/Site/TGI/Extension/Sys/Lock.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys/Lock.pm
@@ -23,11 +23,6 @@ Genome::Sys::Lock->add_backend('site',
     Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
         parent_dir => $ENV{GENOME_SITE_LOCK_DIR}));
 
-Genome::Sys::Lock->add_backend('unknown',
-    Genome::Sys::Lock::FileBackend->new(is_mandatory => 1,
-        parent_dir => '/'));
-
-
 if ($ENV{GENOME_NESSY_SERVER}) {
     require Genome::Sys::Lock::NessyBackend;
     my $is_mandatory = $ENV{GENOME_NESSY_MANDATORY} ? 1 : 0;

--- a/lib/perl/Genome/Sys/Lock.pm
+++ b/lib/perl/Genome/Sys/Lock.pm
@@ -219,7 +219,6 @@ sub scopes {
     return qw(
         host
         site
-        tgisan
         unknown
     );
 }

--- a/lib/perl/Genome/Sys/Lock.pm
+++ b/lib/perl/Genome/Sys/Lock.pm
@@ -219,7 +219,6 @@ sub scopes {
     return qw(
         host
         site
-        unknown
     );
 }
 


### PR DESCRIPTION
Due to the maintenance window all snapshots prior to genome-3591 have been
archived which means it's safe to remove these lock scopes now.