### PR TITLE
Fix more typos.

### DIFF
--- a/lib/perl/Genome/Model/Command/Report/List.pm
+++ b/lib/perl/Genome/Model/Command/Report/List.pm
@@ -180,14 +180,14 @@ sub _list_reports_for_build {
     my $self = shift;
     
     my $type_name = $self->build->model->type_name;
-    my @availble_report_generators = Genome::Model::Report::get_report_names_for_type_name($type_name);
+    my @available_report_generators = Genome::Model::Report::get_report_names_for_type_name($type_name);
 
-    unless ( @availble_report_generators ) { # ok
+    unless ( @available_report_generators ) { # ok
         print "Model type ($type_name) does not have any reports.\n";
         return 1;
     }
     
-    my %reports = map { $_ => [] } @availble_report_generators;
+    my %reports = map { $_ => [] } @available_report_generators;
     for my $report ( $self->build->reports ) {
         my ($report_subclass) = $report->get_generator =~ m#::([\w\d]+)$#;
         my $report_generator = Genome::Utility::Text::camel_case_to_string($report_subclass);
@@ -199,7 +199,7 @@ sub _list_reports_for_build {
     $self->_print_header_for_build
         or return;
 
-    for my $report_name ( @availble_report_generators ) {
+    for my $report_name ( @available_report_generators ) {
         $self->_print_reports($report_name, $reports{$report_name})
             or return;
     }

--- a/lib/perl/Genome/Model/Tools/Consed/TracesToConsed.pm
+++ b/lib/perl/Genome/Model/Tools/Consed/TracesToConsed.pm
@@ -857,7 +857,7 @@ sub get_dw(%) {
     #--- Check for handle, retry and die if failed ---
     if (! $dbh) {
 	$dbh=DBI->connect('dbi:Oracle:dwrac',$user,$pwd,{AutoCommit => 0,RaiseError=>0,RowCacheSize=>0,ora_check_sql => 0});
-	die " Could not connect to OLTP database on 2 attempt, Quiting ... \n" if (! $dbh);
+	die " Could not connect to OLTP database on 2 attempt, Quitting ... \n" if (! $dbh);
     }
     
     #--- Set handle to deal with blob ---
@@ -925,7 +925,7 @@ sub get_oltp(@) {
     #--- Check for handle, retry and die if failed ---
     if (! $dbh) {
 	$dbh=DBI->connect('dbi:Oracle:gscprod',$user,$pwd,{AutoCommit => 0,RaiseError=>0,RowCacheSize=>0,ora_check_sql => 0});
-	die " Could not connect to OLTP database on 2 attempt, Quiting ... \n" if (! $dbh);
+	die " Could not connect to OLTP database on 2 attempt, Quitting ... \n" if (! $dbh);
     }
     
     #--- sql to get info from oltp using amplicon ---

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Dispatcher.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Dispatcher.pm
@@ -214,7 +214,7 @@ sub _detect_variants {
     # handle the case of doing multi-sample detection on single-sample
     # detectors, where we need a merge
     if ($single_sample_detector_count and scalar(@alignment_results)) {
-        die "Single-sample detector supplied with multi-sample inputs. This cannot be handled properly. Quiting!";
+        die "Single-sample detector supplied with multi-sample inputs. This cannot be handled properly. Quitting!";
         return 1;
     }
 


### PR DESCRIPTION
These are other places in the system that spelled `quitting` and `available` similarly to #669.

(I'll resist going further down the rabbit-hole by cleaning up `gmt consed traces-to-consed`.)