### PR TITLE
SGMS: configure email addresses for build reports.

### DIFF
--- a/lib/perl/Genome/Env/GENOME_DISK_GROUP_BENCHMARKING.pm
+++ b/lib/perl/Genome/Env/GENOME_DISK_GROUP_BENCHMARKING.pm
@@ -1,4 +1,0 @@
-package Genome::Env::GENOME_DISK_GROUP_BENCHMARKING;
-use base 'Genome::Env::Required';
-
-1;

--- a/lib/perl/Genome/Env/GENOME_DISK_GROUP_READS.pm
+++ b/lib/perl/Genome/Env/GENOME_DISK_GROUP_READS.pm
@@ -1,4 +1,0 @@
-package Genome::Env::GENOME_DISK_GROUP_READS;
-use base 'Genome::Env::Required';
-
-1;

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1868,8 +1868,8 @@ sub generate_send_and_save_report {
     my $email_confirmation = Genome::Report::Email->send_report(
         report => $report,
         to => $to->id,
-        from => 'apipe@'.Genome::Config::domain(),
-        replyto => 'noreply@'.Genome::Config::domain(),
+        from => $ENV{GENOME_EMAIL_NOREPLY},
+        replyto => $ENV{GENOME_EMAIL_NOREPLY},
         # maybe not the best/correct place for this information but....
         xsl_files => [ $generator->get_xsl_file_for_html ],
     );

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1868,7 +1868,7 @@ sub generate_send_and_save_report {
     my $email_confirmation = Genome::Report::Email->send_report(
         report => $report,
         to => $to->id,
-        from => $ENV{GENOME_EMAIL_NOREPLY},
+        from => $ENV{GENOME_EMAIL_PIPELINE},
         replyto => $ENV{GENOME_EMAIL_NOREPLY},
         # maybe not the best/correct place for this information but....
         xsl_files => [ $generator->get_xsl_file_for_html ],


### PR DESCRIPTION
The current *from* address evaluates to something like "apipe@ip-XX-XX" on AWS where ip-XX-XX is the `hostname`. Addresses created this way fail validation in Genome::Report::Email which uses Email::Valid.
This PR proposes to use an environment variable for specifying the email address.

Note - This PR is based on the SGMS branch on not master. This is an SGMS specific change.