### PR TITLE
AnP Config Add: Pluralize tag-adding option.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddConfigBase.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddConfigBase.pm
@@ -17,7 +17,7 @@ class Genome::Config::AnalysisProject::Command::AddConfigBase {
         },
     ],
     has_optional_input => [
-        tag => {
+        tags => {
             is => 'Genome::Config::Tag',
             is_many => 1,
             doc => 'Tags to associate with the new configuration',
@@ -54,7 +54,7 @@ sub _create_profile_items {
 sub _apply_tags {
     my ($self, @profile_items) = @_;
     for my $profile_item (@profile_items) {
-        for my $tag ($self->tag){
+        for my $tag ($self->tags){
             $profile_item->add_tag($tag);
         }
     }

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddConfigFile.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddConfigFile.t
@@ -29,7 +29,7 @@ my $analysis_project = Genome::Config::AnalysisProject->create(
 my $cmd = $class->create(
     analysis_project => $analysis_project,
     config_file => $file,
-    tag => [$tag, $tag2],
+    tags => [$tag, $tag2],
 );
 
 $cmd->execute();

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.pm
@@ -36,7 +36,7 @@ This command is used to link standard configurations ("menu items") to an analys
 If run without specifying any menu items, an interactive prompt will allow selections from the list
 of all available menu items.
 
-(See also `genome config analysis-project add-config-file for adding a custom configuration.)
+(See also `genome config analysis-project add-config-file` for adding a custom configuration.)
 EOS
 }
 

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.t
@@ -34,7 +34,7 @@ my $cmd = $class->create(
     analysis_project => $ap,
     analysis_menu_items => [$item],
     reprocess_existing => 1,
-    tag => [$tag],
+    tags => [$tag],
 );
 
 $cmd->execute();


### PR DESCRIPTION
It has been requested that this be `--tags` instead of `--tag`.