### PR TITLE
Don't fail optional expert parameters as required during validation

### DIFF
--- a/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/experts/__test__
+++ b/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/experts/__test__
@@ -6,4 +6,6 @@
     (undocumented)
   [1m__planned__[0m
     (undocumented)
+  [1m__planned_optional__[0m
+    (undocumented)
 

--- a/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Command.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Command.pm
@@ -81,6 +81,13 @@ sub planned_names {
     return map {$_->property_name} @properties;
 }
 
+sub planned_required_names {
+    my $self = shift;
+
+    my @properties = $self->__meta__->properties(is_planned => 1, is_optional => 0);
+    return map {$_->property_name} @properties;
+}
+
 # TODO this is not covered by tests
 sub validate_with_plan_params {
     my ($self, $params) = validate_pos(@_, 1, 1);
@@ -95,13 +102,15 @@ sub validate_with_plan_params {
 
 sub __planned_errors__ {
     my ($self, $params) = validate_pos(@_, 1, 1);
-    my $needed = Set::Scalar->new($self->planned_names);
+    my $needed = Set::Scalar->new($self->planned_required_names);
     return Genome::VariantReporting::Framework::Utility::get_missing_errors($self->class, $params, $needed, "Parameters", "run"),
-        $self->_get_extra_errors($params, $needed);
+        $self->_get_extra_errors($params);
 }
 
 sub _get_extra_errors {
-    my ($self, $params, $needed) = validate_pos(@_, 1, 1, 1);
+    my ($self, $params) = validate_pos(@_, 1, 1);
+
+    my $needed = Set::Scalar->new($self->planned_names);
 
     my $have = Set::Scalar->new(keys %{$params});
     my @errors;

--- a/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Command.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Command.pm
@@ -88,18 +88,6 @@ sub planned_required_names {
     return map {$_->property_name} @properties;
 }
 
-# TODO this is not covered by tests
-sub validate_with_plan_params {
-    my ($self, $params) = validate_pos(@_, 1, 1);
-
-    my @errors = $self->__planned_errors__($params);
-    if (@errors) {
-        $self->print_errors(@errors);
-        die $self->error_message("Failed to validate_with_plan_params with params:\n" . Data::Dumper::Dumper $params);
-    }
-    return;
-}
-
 sub __planned_errors__ {
     my ($self, $params) = validate_pos(@_, 1, 1);
     my $needed = Set::Scalar->new($self->planned_required_names);

--- a/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Command.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Command.pm
@@ -78,19 +78,19 @@ sub planned_names {
     my $self = shift;
 
     my @properties = $self->__meta__->properties(is_planned => 1);
-    return map {$_->property_name} @properties;
+    return Set::Scalar->new(map {$_->property_name} @properties);
 }
 
 sub planned_required_names {
     my $self = shift;
 
     my @properties = $self->__meta__->properties(is_planned => 1, is_optional => 0);
-    return map {$_->property_name} @properties;
+    return Set::Scalar->new(map {$_->property_name} @properties);
 }
 
 sub __planned_errors__ {
     my ($self, $params) = validate_pos(@_, 1, 1);
-    my $needed = Set::Scalar->new($self->planned_required_names);
+    my $needed = $self->planned_required_names;
     return Genome::VariantReporting::Framework::Utility::get_missing_errors($self->class, $params, $needed, "Parameters", "run"),
         $self->_get_extra_errors($params);
 }
@@ -98,7 +98,7 @@ sub __planned_errors__ {
 sub _get_extra_errors {
     my ($self, $params) = validate_pos(@_, 1, 1);
 
-    my $needed = Set::Scalar->new($self->planned_names);
+    my $needed = $self->planned_names;
 
     my $have = Set::Scalar->new(keys %{$params});
     my @errors;

--- a/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Command.t
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Expert/Command.t
@@ -43,4 +43,6 @@ ok(!exists $input_hash{'variant_type_lookup'}, 'variant_type_lookup entry absent
 lives_ok { $obj->resolve_plan_attributes } 'resolve_plan_attributes execute successfully';
 is($obj->__planned__, 'foo', 'Value of __planned__ is as expected');
 
+is_deeply([$obj->__planned_errors__(($plan->expert_plans)[0]->run_params)], [], 'No planned errors found');
+
 done_testing();

--- a/lib/perl/Genome/VariantReporting/Framework/Test/Run.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Test/Run.pm
@@ -9,6 +9,7 @@ class Genome::VariantReporting::Framework::Test::Run {
     is => 'Genome::VariantReporting::Framework::Component::Expert::Command',
     has_planned_transient => [
         __planned__ => {},
+        __planned_optional__ => {is_optional => 1}
     ],
     has_transient => [
         __input__ => {

--- a/lib/perl/Genome/VariantReporting/Framework/Test/RunResult.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Test/RunResult.pm
@@ -15,6 +15,7 @@ class Genome::VariantReporting::Framework::Test::RunResult {
     ],
     has_param => [
         __planned__ => {},
+        __planned_optional__ => {is_optional => 1}
     ],
     has_transient_optional => [
         __input__ => {


### PR DESCRIPTION
This fixes a bug where any optional expert parameter would fail validation if it wasn't in the plan file.

See https://rt.gsc.wustl.edu/Ticket/Display.html?id=105348