### PR TITLE
use ENV variables to configure build email

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1853,8 +1853,8 @@ sub generate_send_and_save_report {
     my $email_confirmation = Genome::Report::Email->send_report(
         report => $report,
         to => $to->id,
-        from => 'apipe@'.Genome::Config::domain(),
-        replyto => 'noreply@'.Genome::Config::domain(),
+        from => $ENV{GENOME_EMAIL_PIPELINE},
+        replyto => $ENV{GENOME_EMAIL_NOREPLY},
         # maybe not the best/correct place for this information but....
         xsl_files => [ $generator->get_xsl_file_for_html ],
     );

--- a/lib/perl/Genome/Model/Build.t
+++ b/lib/perl/Genome/Model/Build.t
@@ -255,7 +255,7 @@ sub _test_expected_report_params {
     my %expected_params = (
         to => $build->the_master_event->user_name.'@'.Genome::Config::domain(),
         from => 'apipe@'.Genome::Config::domain(),
-        replyto => 'noreply@'.Genome::Config::domain(),
+        replyto => 'donotreply@'.Genome::Config::domain(),
     );
     my %got_params = map { $_ => $report_params->{$_} } keys %expected_params; 
     die 'No report params!' if not %got_params;


### PR DESCRIPTION
This is identical to #676 but this PR is based off of master.
Note - this will change the reply-to to `donotreply@genome.wustl.edu` instead of `noreply@genome.wustl.edu`