### PR TITLE
Create bam headers on demand

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1128,11 +1128,10 @@ sub create_bam_flagstat {
 sub create_bam_header {
     my $self = shift;
 
-    if (-s $self->bam_header_path) {
-        return 1;
-    }
-
+    return 1 if (-s $self->bam_header_path);
     my $lock = $self->get_bam_lock;
+    return 1 if (-s $self->bam_header_path);
+
     my $sam_path = Genome::Model::Tools::Sam->path_for_samtools_version($self->samtools_version);
 
     Genome::Sys->shellcmd(

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1101,9 +1101,9 @@ sub _create_bam_index {
 sub create_bam_flagstat {
     my ($self, $bam_file, $output_file) = @_;
 
+    my $lock = $self->get_bam_lock;
     unless (-s $bam_file) {
-        $self->error_message('BAM file ' . $bam_file . ' does not exist or is empty');
-        return;
+        die $self->error_message('BAM file (%s) does not exist or is empty', $bam_file);
     }
 
     if (-e $output_file) {
@@ -1122,6 +1122,8 @@ sub create_bam_flagstat {
         $self->error_message("Failed to create or execute flagstat command on bam: $bam_file");
         return;
     }
+
+    $lock->unlock;
     return 1;
 }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -240,9 +240,7 @@ sub create {
             $self->_size_up_allocation($alignment);
 
             $alignment->create_bam_header;
-            unless (-s $alignment->bam_flagstat_path) {
-                $alignment->create_bam_flagstat;
-            }
+            $alignment->create_bam_flagstat;
             $self->_remove_per_lane_bam_post_commit($alignment);
         }
     }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -241,7 +241,7 @@ sub create {
 
             $alignment->create_bam_header;
             unless (-s $alignment->bam_flagstat_path) {
-                $alignment->create_bam_flagstat($alignment->bam_path, $alignment->bam_flagstat_path);
+                $alignment->create_bam_flagstat;
             }
             $self->_remove_per_lane_bam_post_commit($alignment);
         }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -239,27 +239,9 @@ sub create {
             #Reserve some space beforehand for flagstat and header files
             $self->_size_up_allocation($alignment);
 
-            my $header = $bam_path . '.header';
-            unless (-s $header) {
-                my $sam_path = Genome::Model::Tools::Sam->path_for_samtools_version($self->samtools_version);
-                my $cmd = "$sam_path view -H $bam_path > $header";
-                Genome::Sys->shellcmd(
-                    cmd => $cmd,
-                    input_files  => [$bam_path],
-                    output_files => [$header],
-                );
-            }
-            my $flagstat = $bam_path . '.flagstat';
-            unless (-s $flagstat) {
-                my $cmd = Genome::Model::Tools::Sam::Flagstat->create(
-                    bam_file    => $bam_path,
-                    output_file => $flagstat,
-                    use_version => $self->samtools_version,
-                );
-
-                unless ($cmd->execute) {
-                    die $self->error_message("Fail to run flagstat on $bam_path");
-                }
+            $alignment->create_bam_header;
+            unless (-s $alignment->bam_flagstat_path) {
+                $alignment->create_bam_flagstat($alignment->bam_path, $alignment->bam_flagstat_path);
             }
             $self->_remove_per_lane_bam_post_commit($alignment);
         }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Nucmer.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Nucmer.pm
@@ -127,7 +127,7 @@ sub postprocess_bam_file {
     # currently not 1:1 input/output ratio so _verify_bam will fail
     # create bam flagstat
     $self->debug_message('Creating flagstat for bam file');
-    unless( $self->_create_bam_flagstat ) {
+    unless( $self->create_bam_flagstat ) {
         $self->error_message('Failed to create bam flagstat file');
         die $self->error_message;
     }


### PR DESCRIPTION
This should be the last of the fixes for build failures due to per-lane bam removal. Currently, builds may fail if their alignment results have not been 'backfilled' with the .header files.