### PR TITLE
Support Converge Operations when using Ptero

### DIFF
--- a/lib/perl/Genome/Ptero/workflow_tests/converge/inputs.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/converge/inputs.json
@@ -1,0 +1,4 @@
+{
+    "a" : ["hello", "goodbye"],
+    "b" : "polly"
+}

--- a/lib/perl/Genome/Ptero/workflow_tests/converge/outputs.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/converge/outputs.json
@@ -1,0 +1,1 @@
+{ "out" : [["hello", "polly"], ["goodbye", "polly"]] }

--- a/lib/perl/Genome/Ptero/workflow_tests/converge/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/converge/ptero_workflow.json
@@ -1,0 +1,40 @@
+{
+   "links" : [
+      {
+         "destination" : "Convergence",
+         "destinationProperty" : "a",
+         "source" : "input connector",
+         "sourceProperty" : "a"
+      },
+      {
+         "destination" : "Convergence",
+         "destinationProperty" : "b",
+         "source" : "input connector",
+         "sourceProperty" : "b"
+      },
+      {
+         "destination" : "output connector",
+         "destinationProperty" : "out",
+         "source" : "Convergence",
+         "sourceProperty" : "out"
+      }
+   ],
+   "tasks" : {
+      "Convergence" : {
+         "methods" : [
+            {
+               "name" : "converge",
+               "parameters" : {
+                  "input_names" : [
+                     "a",
+                     "b"
+                  ],
+                  "output_name" : "out"
+               },
+               "service" : "workflow-converge"
+            }
+         ],
+         "parallelBy" : "a"
+      }
+   }
+}

--- a/lib/perl/Genome/Ptero/workflow_tests/converge/workflow.xml
+++ b/lib/perl/Genome/Ptero/workflow_tests/converge/workflow.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' standalone='yes'?>
+<workflow name="Converge Test"
+    logDir="test_logs/converge">
+    <link fromOperation="input connector" fromProperty="a"
+        toOperation="Convergence" toProperty="a" />
+    <link fromOperation="input connector" fromProperty="b"
+        toOperation="Convergence" toProperty="b" />
+
+    <link fromOperation="Convergence" fromProperty="out"
+        toOperation="output connector" toProperty="out" />
+
+    <operation name="Convergence" parallelBy="a">
+        <operationtype typeClass="Workflow::OperationType::Converge" />
+            <inputproperty>a</inputproperty>
+            <inputproperty>b</inputproperty>
+            <outputproperty>out</outputproperty>
+    </operation>
+
+    <operationtype typeClass="Workflow::OperationType::Model">
+        <inputproperty>a</inputproperty>
+        <inputproperty>b</inputproperty>
+        <outputproperty>out</outputproperty>
+    </operationtype>
+</workflow>

--- a/lib/perl/Genome/WorkflowBuilder/Converge.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Converge.pm
@@ -97,12 +97,12 @@ sub _get_ptero_converge_method {
     require Ptero::Builder::Detail::Workflow::Converge;
 
     my $self = shift;
-    my @output_names = $self->output_properties;
+    my ($output_name) = $self->output_properties;
     return Ptero::Builder::Detail::Workflow::Converge->new(
         name => 'converge',
         parameters => {
             input_names => [$self->input_properties],
-            output_name => shift @output_names,
+            output_name => $output_name,
         },
     );
 }

--- a/lib/perl/Genome/WorkflowBuilder/Converge.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Converge.pm
@@ -32,6 +32,7 @@ sub from_xml_element {
         name => $element->getAttribute('name'),
         input_properties => \@input_properties,
         output_properties => \@output_properties,
+        parallel_by => $element->getAttribute('parallelBy'),
     );
 }
 
@@ -71,6 +72,39 @@ sub notify_output_link {
     }
 
     return;
+}
+
+sub get_ptero_builder_task {
+    require Ptero::Builder::Detail::Workflow::Task;
+
+    my $self = shift;
+
+    $self->validate;
+
+    my %params = (
+        name => $self->name,
+        methods => [
+            $self->_get_ptero_converge_method(),
+        ],
+    );
+    if (defined $self->parallel_by) {
+        $params{parallel_by} = $self->parallel_by;
+    }
+    return Ptero::Builder::Detail::Workflow::Task->new(%params);
+}
+
+sub _get_ptero_converge_method {
+    require Ptero::Builder::Detail::Workflow::Converge;
+
+    my $self = shift;
+    my @output_names = $self->output_properties;
+    return Ptero::Builder::Detail::Workflow::Converge->new(
+        name => 'converge',
+        parameters => {
+            input_names => [$self->input_properties],
+            output_name => shift @output_names,
+        },
+    );
 }
 
 1;

--- a/lib/perl/Genome/WorkflowBuilder/DAG.pm
+++ b/lib/perl/Genome/WorkflowBuilder/DAG.pm
@@ -122,7 +122,11 @@ sub _execute_with_ptero {
     $wf_proxy->wait(polling_interval => $polling_interval);
 
     if ($wf_proxy->has_succeeded) {
-        return $wf_proxy->outputs;
+        if (!defined($wf_proxy->outputs)) {
+            die $self->error_message('PTero workflow (%s) returned no results', $wf_proxy->url);
+        } else {
+            return $wf_proxy->outputs;
+        }
     }
     else {
         die $self->error_message('PTero workflow (%s) did not succeed',


### PR DESCRIPTION
PTero itself now has support for both Block and Converge operations, but I've just implemented support for Converge operations here in Genome.  WorkflowBuilder has no concept of Block operations, and maybe never will, so I didn't try to fix that now.