### PR TITLE
Encode/Decode workflow inputs and outputs when using PTero

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/DAG.pm
+++ b/lib/perl/Genome/WorkflowBuilder/DAG.pm
@@ -8,6 +8,7 @@ use Params::Validate qw(:types);
 use Set::Scalar qw();
 use JSON;
 use List::MoreUtils qw();
+use Genome::Utility::Inputs qw(encode decode);
 
 
 class Genome::WorkflowBuilder::DAG {
@@ -116,7 +117,7 @@ sub _execute_with_ptero {
 
     my $wf_builder = $self->get_ptero_builder($self->name);
 
-    my $wf_proxy = $wf_builder->submit( inputs => $inputs );
+    my $wf_proxy = $wf_builder->submit( inputs => encode($inputs) );
     $self->status_message("Waiting on PTero workflow (%s) to complete",
         $wf_proxy->url);
     $wf_proxy->wait(polling_interval => $polling_interval);
@@ -125,7 +126,7 @@ sub _execute_with_ptero {
         if (!defined($wf_proxy->outputs)) {
             die $self->error_message('PTero workflow (%s) returned no results', $wf_proxy->url);
         } else {
-            return $wf_proxy->outputs;
+            return decode($wf_proxy->outputs);
         }
     }
     else {


### PR DESCRIPTION
We were already doing this for steps within a workflow, but some
workflows take objects as inputs and return objects as outputs.  This
allows that to work.