### PR TITLE
Stop picking up single jar versions of Picard.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -262,12 +262,11 @@ sub path_for_picard_version {
 }
 
 sub installed_picard_versions {
-    my @files = glob('/usr/share/java/picard-*.jar');
+    my @files = glob('/usr/share/java/picard-tools*');
 
     my @versions;
     for my $f (@files) {
-        if($f =~ /picard-([\d\.]+).jar$/) {
-            next if $1 eq '1.124';
+        if($f =~ /picard-tools([\d\.]+)\/?$/) {
             push @versions, $1;
         }
     }


### PR DESCRIPTION
Prior to version 1.124, Picard was made up as a set of jars, one for
each tool, installed under `/usr/share/java/picard-toolsV.VVV/`.
Additionally, a support jar would be installed as
`/usr/share/java/picard-V.VVV.jar`.

Picard versions 1.124 and later use a single jar, installed as
`/usr/share/java/picard-V.VVV.jar`, to provide all tools.

The Picard GMT was picking up both single- and multi-jar versions of
Picard, even though it could only handle the older multi-jar versions.
This commit should prevent the Picard GMT from picking up the single-jar
versions of Picard (1.124 and later) until single-jar support can be
added.