### PR TITLE
Get bam size from get_bam_file  instead of from alignment_bam_file_paths

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1070,7 +1070,7 @@ sub _compute_alignment_metrics {
         $self->singleton_read_count         ($res->{singleton});
         $self->singleton_base_count         ($res->{singleton_bp});
 
-        $self->bam_size(stat($bam)->size); #store this for per lane bam recreation
+        $self->set_bam_size($bam); #store this for per lane bam recreation
         Genome::Utility::Instrumentation::inc('alignment_result.read_count', $self->total_read_count);
     }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1150,8 +1150,8 @@ sub set_bam_size {
     my ($self, $bam_file) = @_;
     return 1 if $self->bam_size;
 
-    unless (defined $bam_file || -s $bam_file) {
-        $bam_file = $self->get_bam_file unless defined $bam_file;
+    unless (defined $bam_file && -s $bam_file) {
+        $bam_file = $self->get_bam_file;
         unless (-s $bam_file) {
             die $self->error_message('BAM file (%s) does not exist or is empty', $bam_file);
         }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1148,9 +1148,15 @@ sub create_bam_header {
 
 sub set_bam_size {
     my ($self, $bam_file) = @_;
-    $bam_file = $self->get_bam_file unless defined $bam_file;
-
     return 1 if $self->bam_size;
+
+    unless (defined $bam_file || -s $bam_file) {
+        $bam_file = $self->get_bam_file unless defined $bam_file;
+        unless (-s $bam_file) {
+            die $self->error_message('BAM file (%s) does not exist or is empty', $bam_file);
+        }
+    }
+
     $self->bam_size(stat($bam_file)->size);
 
     return 1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1146,6 +1146,15 @@ sub create_bam_header {
     return 1;
 }
 
+sub set_bam_size {
+    my ($self, $bam_file) = @_;
+    $bam_file = $self->get_bam_path unless defined $bam_file;
+
+    return 1 if $self->bam_size;
+    $self->bam_size(stat($bam_file)->size);
+
+    return 1;
+}
 
 sub _verify_bam {
     my $self = shift;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1156,6 +1156,7 @@ sub set_bam_size {
             die $self->error_message('BAM file (%s) does not exist or is empty', $bam_file);
         }
     }
+    return 1 if $self->bam_size;
 
     $self->bam_size(stat($bam_file)->size);
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1148,7 +1148,7 @@ sub create_bam_header {
 
 sub set_bam_size {
     my ($self, $bam_file) = @_;
-    $bam_file = $self->get_bam_path unless defined $bam_file;
+    $bam_file = $self->get_bam_file unless defined $bam_file;
 
     return 1 if $self->bam_size;
     $self->bam_size(stat($bam_file)->size);

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1156,7 +1156,11 @@ sub set_bam_size {
             die $self->error_message('BAM file (%s) does not exist or is empty', $bam_file);
         }
     }
-    return 1 if $self->bam_size;
+    my $previous_value = UR::Context->query_underlying_context;
+    UR::Context->query_underlying_context(1);
+    my $bam_size = $self->bam_size;
+    UR::Context->query_underlying_context($previous_value);
+    return 1 if $bam_size;
 
     $self->bam_size(stat($bam_file)->size);
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -421,7 +421,7 @@ sub estimated_kb_usage {
         unless (defined $bam_size) {
             my $aln_bam = $alignment->get_bam_file;
             unless (-s $aln_bam) {
-                die $self->error_message('BAM file (%s) for alignment (%s) does not exist or is empty', $bam_file, $alignment);
+                die $self->error_message('BAM file (%s) for alignment (%s) does not exist or is empty', $aln_bam, $alignment->id);
             }
             $alignment->set_bam_size($aln_bam);
             my $size = $alignment->bam_size;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -419,15 +419,14 @@ sub estimated_kb_usage {
         my $bam_size = $alignment->bam_size;
 
         unless (defined $bam_size) {
-            my @aln_bams = $alignment->alignment_bam_file_paths;
-            unless (@aln_bams) {
+            my $aln_bam = $alignment->get_bam_file;
+            unless ($aln_bam) {
                 die $self->error_message("alignment $alignment has no bams at " . $alignment->output_dir);
             }
-            for (@aln_bams) {
-                my $size = stat($_)->size;
-                $self->debug_message("BAM has size: " . $size);
-                $bam_size += $size;
-            }
+            $alignment->set_bam_size($aln_bam);
+            my $size = $alignment->bam_size;
+            $self->debug_message("BAM has size: " . $size);
+            $bam_size = $size;
         }
         $total_size += $bam_size;
     }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -420,8 +420,8 @@ sub estimated_kb_usage {
 
         unless (defined $bam_size) {
             my $aln_bam = $alignment->get_bam_file;
-            unless ($aln_bam) {
-                die $self->error_message("alignment $alignment has no bams at " . $alignment->output_dir);
+            unless (-s $aln_bam) {
+                die $self->error_message('BAM file (%s) for alignment (%s) does not exist or is empty', $bam_file, $alignment);
             }
             $alignment->set_bam_size($aln_bam);
             my $size = $alignment->bam_size;


### PR DESCRIPTION
This should fix issues where we will try to estimate the bam size during merging and the `bam_size` hasn't been set on a deleted per-lane bam.