### PR TITLE
Use the labelled merged result in SomaticValidation's Identify DNP

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/IdentifyDnp.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/IdentifyDnp.pm
@@ -53,11 +53,7 @@ sub params_for_result {
     }
 
     my $build = $self->build;
-    my @result_users = Genome::SoftwareResult::User->get(user => $build);
-    my @results = map($_->software_result, @result_users);
-    my @merged_results = grep { $_->isa('Genome::InstrumentData::AlignedBamResult::Merged') } @results;
-    my ($tumor_alignment_result) = grep( ($_->instrument_data)[0]->sample eq $build->tumor_sample, @merged_results);
-
+    my $tumor_alignment_result = $build->merged_alignment_result;
     my $tumor_aligment_result_id = $tumor_alignment_result->id;
 
     my $snv_result_user = Genome::SoftwareResult::User->get(label => 'snv_result', user => $build);


### PR DESCRIPTION
The "refinements" each produce separate merged BAMs, so picking the first one we run across is not guaranteed to get the final BAM.  Thankfully we already have an accessor for choosing the proper one.