### PR TITLE
Bump FastQC's JVM memory request to 512 MB.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Fastqc.pm
+++ b/lib/perl/Genome/Model/Tools/Fastqc.pm
@@ -7,7 +7,7 @@ use Genome;
 use File::Basename;
 
 my $FASTQC_DEFAULT = '0.10.0';
-my $DEFAULT_MEMORY = 250;
+my $DEFAULT_MEMORY = 512;
 
 class Genome::Model::Tools::Fastqc {
     is  => 'Command',


### PR DESCRIPTION
* This is still well inside the LSF memory request.
* 51a4d27df3d515bf5697032aad5a0584d229ac91 claims this value should scale with threads.  (I don't know that we're currently scaling our request, however.  The failure case I'm addressing was run with one thread.)