### PR TITLE
Reallocate temp allocation for revivified bam or in-place bam copy

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1859,6 +1859,7 @@ sub _reallocate_temp_allocation {
     }
     catch {
         $self->warning_message('Failed to reallocate temp allocation '.$temp_allocation->id. " Error: $_");
+        return;
     }
 }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1736,6 +1736,7 @@ sub get_bam_file {
                     Genome::Sys->copy_file($file, $dest_file);
                 }
             }
+            eval{$temp_allocation->reallocate};
             return File::Spec->join($temp_allocation->absolute_path, basename($bams[0]));
         }
     }
@@ -1817,6 +1818,8 @@ sub revivified_alignment_bam_file_path {
     unless ($cmd->execute) {
         die $self->error_message('Failed to execute RecreatePerLaneBam for '.$self->id);
     }
+
+    eval{$temp_allocation->reallocate};
 
     if (-s $revivified_bam) {
         # Cache the path of this revivified bam for future access


### PR DESCRIPTION
Reallocation is needed since revivified bam or in-place bam copy will exist for a while during merge and the temp allocation could be over-allocated if bam_size is not set.