### PR TITLE
remove `local $@`

### DIFF
--- a/lib/perl/Genome/ProcessingProfile/Command/Create.t
+++ b/lib/perl/Genome/ProcessingProfile/Command/Create.t
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 
 use above "Genome";
+use Try::Tiny qw(try catch);
 
 use Test::More tests => 38;
 
@@ -187,8 +188,7 @@ sub test_processing_profile_class {
 sub test_based_on_param_value_overrides_default_value {
     my $transaction = UR::Context::Transaction->begin;
 
-    local $@ = '';
-    eval {
+    try {
         my $meta = UR::Object::Type->get('Genome::ProcessingProfile::Tester');
         ok($meta, 'got "Genome::ProcessingProfile::Tester" class object');
 
@@ -227,8 +227,11 @@ sub test_based_on_param_value_overrides_default_value {
         # make sure it got alternate_pp's dna_source not the default value for dna_source
         isnt($alternate_pp->dna_source, $default_dna_source, "alternate_pp's dna_source should not match the default value");
         is($alternate_pp->dna_source, $source_pp->dna_source, "alternate_pp's dna_source matches source_pp");
+    }
+    catch {
+        print "ERROR: $_\n";
+        return;
     };
-    print "ERROR: $@\n" if ($@);
 
     $transaction->rollback;
 }

--- a/lib/perl/Genome/SoftwareResult.pm
+++ b/lib/perl/Genome/SoftwareResult.pm
@@ -351,9 +351,9 @@ sub create {
             eval {
                 Genome::Sys->create_directory($output_dir)
             };
-            if ($@) {
+            if (my $error = $@) {
                 $self->delete;
-                die $@;
+                die $error;
             }
         }
     }

--- a/lib/perl/Genome/SoftwareResult.pm
+++ b/lib/perl/Genome/SoftwareResult.pm
@@ -434,7 +434,6 @@ my $recalculate_lookup_hash_callback = sub {
     my ($object, $aspect) = @_;
     return unless $object;
     return unless $object->software_result;
-    local $@;
     $object->software_result->recalculate_lookup_hash();
 };
 for my $name (qw(Param Input)) {

--- a/lib/perl/Genome/Utility/Test.t/compare_ok.t
+++ b/lib/perl/Genome/Utility/Test.t/compare_ok.t
@@ -5,6 +5,7 @@ use above "Genome";
 use Test::Builder::Tester;
 use Genome::Utility::Test qw(capture_ok);
 use Test::More;
+use Test::Fatal qw(exception);
 
 BEGIN {
     use_ok 'Genome::Utility::Test', qw(compare_ok);
@@ -47,9 +48,9 @@ subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_C) => sub {
 
 my @args_D = ('file_1', 'file_2', 'args_D', name => 'args_D');
 subtest '_compare_ok_parse_args did fail to parse: ' . join(', ', @args_D) => sub {
-    local $@ = '';
-    my ($f1, $f2, %o) = eval { $_compare_ok_parse_args->(@args_D) };
-    like($@,
+    plan tests => 1;
+    my $exception = exception { $_compare_ok_parse_args->(@args_D) };
+    like($exception,
         qr(^duplicate name argument not expected),
         'Got exception specifying the test name twice');
 };

--- a/lib/perl/Genome/Utility/Test.t/compare_ok.t
+++ b/lib/perl/Genome/Utility/Test.t/compare_ok.t
@@ -18,17 +18,15 @@ my $_compare_ok_parse_args = \&Genome::Utility::Test::_compare_ok_parse_args;
 
 my @args_A = ('file_1', 'file_2', 'args_A');
 subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_A) => sub {
-    local $@ = '';
-    my ($f1, $f2, %o) = eval { $_compare_ok_parse_args->(@args_A) };
-    ok(!$@, 'did not die');
+    plan tests => 1;
+    my ($f1, $f2, %o) = $_compare_ok_parse_args->(@args_A);
     is($o{name}, $args_A[2], 'name matched expected value');
 };
 
 my @args_B = ('file_1', 'file_2', 'args_B', filters => [qr(/foo/)]);
 subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_B) => sub {
-    local $@ = '';
-    my ($f1, $f2, %o) = eval { $_compare_ok_parse_args->(@args_B) };
-    ok(!$@, 'did not die');
+    plan tests => 3;
+    my ($f1, $f2, %o) = $_compare_ok_parse_args->(@args_B);
     is($o{name}, $args_B[2], 'name matched expected value');
     is(scalar(@{$o{xform}}), 1, 'Created one transform');
 
@@ -38,9 +36,8 @@ subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_B) => sub {
 
 my @args_C = ('file_1', 'file_2', filters => [qr(/foo/)], name => 'args_C');
 subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_C) => sub {
-    local $@ = '';
-    my ($f1, $f2, %o) = eval { $_compare_ok_parse_args->(@args_C) };
-    ok(!$@, 'did not die');
+    plan tests => 3;
+    my ($f1, $f2, %o) = $_compare_ok_parse_args->(@args_C);
     is($o{name}, $args_C[5], 'name matched expected value');
     is(scalar(@{$o{xform}}), 1, 'Created one transform');
 
@@ -59,9 +56,8 @@ subtest '_compare_ok_parse_args did fail to parse: ' . join(', ', @args_D) => su
 
 my @args_E = ('file_1', 'file_2', 'args_E', filters => qr(/foo/));
 subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_E) => sub {
-    local $@ = '';
-    my ($f1, $f2, %o) = eval { $_compare_ok_parse_args->(@args_E) };
-    ok(!$@, 'did not die');
+    plan tests => 3;
+    my ($f1, $f2, %o) = $_compare_ok_parse_args->(@args_E);
     is($o{name}, $args_E[2], 'name matched expected value');
     is(scalar(@{$o{xform}}), 1, 'Created one transform');
 
@@ -71,9 +67,8 @@ subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_E) => sub {
 
 my @args_F = ('file1', 'file2', 'args_F', replace => [[qr(/foo/) => 'bar'], ['abc' => 'xyz']]);
 subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_F) => sub {
-    local $@ = '';
-    my ($f1, $f2, %o) = eval { $_compare_ok_parse_args->(@args_F) };
-    ok(!$@, 'did not die');
+    plan tests => 5;
+    my ($f1, $f2, %o) = $_compare_ok_parse_args->(@args_F);
     is($o{name}, $args_F[2], 'name matched expected value');
     is(scalar(@{$o{xform}}), 2, 'Created two transforms');
 
@@ -86,9 +81,8 @@ subtest '_compare_ok_parse_args parsed: ' . join(', ', @args_F) => sub {
 };
 
 subtest '_compare_ok_parse_args parsed with multiple occurrences: ' . join(', ', @args_F) => sub {
-    local $@ = '';
-    my ($f1, $f2, %o) = eval { $_compare_ok_parse_args->(@args_F) };
-    ok(!$@, 'did not die');
+    plan tests => 3;
+    my ($f1, $f2, %o) = $_compare_ok_parse_args->(@args_F);
     is($o{name}, $args_F[2], 'name matched expected value');
     is(scalar(@{$o{xform}}), 2, 'Created two transforms');
 
@@ -97,6 +91,8 @@ subtest '_compare_ok_parse_args parsed with multiple occurrences: ' . join(', ',
 };
 
 subtest 'compare_ok matches diff command' => sub {
+    plan tests => 8;
+
     my $expected_fh = File::Temp->new(TMPDIR => 1);
     my $expected_fn = $expected_fh->filename;
     $expected_fh->print("a\n");
@@ -132,6 +128,8 @@ subtest 'compare_ok matches diff command' => sub {
 };
 
 subtest 'compare_ok replace' => sub {
+    plan tests => 8;
+
     my $expected_fh = File::Temp->new(TMPDIR => 1);
     my $expected_fn = $expected_fh->filename;
     $expected_fh->print("a\n");


### PR DESCRIPTION
I misunderstood one of the issues with `$@` so am trying to cleanup a bit.  I
looked for all `local $@` because `$@` has to be scoped very narrowly to avoid
causing problems when using `local $@`.  See [Localizing silently masks errors][1].

[1]: https://metacpan.org/pod/Try::Tiny#Localizing-silently-masks-errors