### PR TITLE
GMT Integration of VCF Evaluation (part 3)

### DIFF
--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -472,8 +472,11 @@ sub stat_sensitivity_exact {
     my $results = $self->get_rawstats();
 
     my $total_true = $self->stat_total_true_positive_exact;
-    if ($total_true == 0) {
-        return 0;
+    {
+        no warnings;
+        if ($total_true == 0) {
+            return "NaN";
+        }
     }
 
     my $stat = $results->{true_positive_exact} / $total_true;
@@ -500,8 +503,11 @@ sub stat_sensitivity_partial {
     my $results = $self->get_rawstats();
 
     my $total_true = $self->stat_total_true_positive_partial;
-    if ($total_true == 0) {
-        return 0;
+    {
+        no warnings;
+        if ($total_true == 0) {
+            return "NaN";
+        }
     }
 
     my $stat = $results->{true_positive_partial} / $total_true;
@@ -537,8 +543,11 @@ sub stat_exact_specificity {
     # may be significantly smaller than the target space ROI
     
     my $tn = $self->stat_true_negatives();
-    if ($tn == 0) {
-        return 0;
+    {
+        no warnings;
+        if ($tn == 0) {
+            return "NaN";
+        }
     }
 
     my $stat =
@@ -551,8 +560,11 @@ sub stat_partial_specificity {
     my $results = $self->get_rawstats();
 
     my $tn = $self->stat_true_negatives();
-    if ($tn == 0) {
-        return 0;
+    {
+        no warnings;
+        if ($tn == 0) {
+            return "NaN";
+        }
     }
 
     my $stat =
@@ -567,8 +579,11 @@ sub stat_exact_ppv {
     my $tp_exact = $self->stat_true_positive_found_exact();
 
     my $denominator = $fp_exact + $tp_exact;
-    if ($denominator == 0) {
-        return 0;
+    {
+        no warnings;
+        if ($denominator == 0) {
+            return "NaN";
+        }
     }
 
     my $stat = $tp_exact / $denominator;
@@ -582,8 +597,11 @@ sub stat_partial_ppv {
     my $tp_partial = $self->stat_true_positive_found_partial();
 
     my $denominator = $fp_partial + $tp_partial;
-    if ($denominator == 0) {
-        return 0;
+    {
+        no warnings;
+        if ($denominator == 0) {
+            return "NaN";
+        }
     }
 
     my $stat = $tp_partial / $denominator;
@@ -605,8 +623,11 @@ sub stat_lines_specificity_in_tn_only {
     # doesn't take partial into account
 
     my $tn = $self->stat_true_negatives();
-    if ($tn == 0) {
-        return 0;
+    {
+        no warnings;
+        if ($tn == 0) {
+            return "NaN";
+        }
     }
 
     my $stat = ($tn - $results->{false_positives_in_roi}) / $tn;

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcfs.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcfs.pm
@@ -82,7 +82,7 @@ class Genome::Model::Tools::Vcf::EvaluateVcfs {
         },
     ],
 
-    has_output => [
+    has_transient_optional_output => [
         rawdata => {
             is => "HASH",
             doc => "The organized stats & metadata generated during "

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcfs.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcfs.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Cwd;
 use Path::Class;
-use JSON::XS;
+use JSON;
 
 class Genome::Model::Tools::Vcf::EvaluateVcfs {
     is => "Command::V2",
@@ -125,7 +125,7 @@ sub dump_stats_to_json {
     }
 
     # JSON-ify
-    my $coder = JSON::XS->new()->pretty(1)->canonical(1)->allow_nonref;
+    my $coder = JSON->new()->pretty(1)->canonical(1)->allow_nonref;
     my $json_txt = $coder->encode(\%summary);
 
     # dump to file

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcfs.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcfs.t
@@ -26,10 +26,11 @@ my $basedir = Path::Class::Dir->new(
 );
 
 SKIP: {
-    skip "this is a long-running test & must be run within TGI", 75;
+    skip "this is a long-running test & must be run within TGI", 77;
 
     my $cmd = run_evaluate_vcfs();
     check_stats($cmd);
+    check_json_file($cmd);
 }
 
 done_testing();
@@ -71,6 +72,15 @@ sub check_stats {
             delta_ok($calculated, $expected, "stat: '$stat' matches up");
         }
     }
+}
+
+sub check_json_file {
+    my $cmd = shift;
+    my $json_file = $cmd->json_file;
+
+    ok(-e $json_file, "Found $json_file in the output dir!");
+    my $size = -s $json_file;
+    ok($size, "JSON file contains data ($size bytes)!");
 }
 
 sub setup_evaluation_params {


### PR DESCRIPTION
This is part 3 of a roll out to integrate the [VCF Evaluation scripts][1] within the genome codebase. The aim of this pull request is to address minor differences with recent changes to [evaluate_vcf.pl][2] and minor annoyances with the final summary report.

* use `NaN` instead of `0` for divde by zero cases
* use `has_transient_optional_output` instead of `has_output` for the transient output hash storing the statistical results
* store the statistical results to a JSON file

See internal jira issue [BIO-1387][3] for details.

[1]: https://github.com/genome/vcf-evaluation
[2]: https://github.com/genome/vcf-evaluation/blob/master/evaluate_vcf.pl
[3]: https://jira.gsc.wustl.edu/browse/BIO-1387