### PR TITLE
try to improve consistency of unarchiving

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -291,14 +291,18 @@ sub is_archived {
     return $self->status eq 'archived';
 }
 
-sub tar_path {
+sub archive_path {
     my $self = shift;
     return File::Spec->join(
         $self->volume->archive_mount_path,
         $self->group_subdirectory,
         $self->allocation_path,
-        'archive.tar',
     );
+}
+
+sub tar_path {
+    my $self = shift;
+    return File::Spec->join($self->archive_path, 'archive.tar');
 }
 
 sub archivable {

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -15,6 +15,8 @@ use File::Find::Rule;
 use Cwd;
 use DateTime;
 
+require File::Spec;
+
 our $TESTING_DISK_ALLOCATION = 0;
 
 use constant SECONDS_IN_ONE_YEAR => 365*24*60*60;
@@ -291,7 +293,12 @@ sub is_archived {
 
 sub tar_path {
     my $self = shift;
-    return join('/', $self->absolute_path, 'archive.tar');
+    return File::Spec->join(
+        $self->volume->archive_mount_path,
+        $self->group_subdirectory,
+        $self->allocation_path,
+        'archive.tar',
+    );
 }
 
 sub archivable {

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -293,8 +293,11 @@ sub is_archived {
 
 sub archive_path {
     my $self = shift;
+    my $mount_path = $self->volume->is_archive
+                   ? $self->volume->mount_path
+                   : $self->volume->archive_mount_path;
     return File::Spec->join(
-        $self->volume->archive_mount_path,
+        $mount_path,
         $self->group_subdirectory,
         $self->allocation_path,
     );

--- a/lib/perl/Genome/Disk/Command/Allocation/Unarchive.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Unarchive.t
@@ -88,7 +88,7 @@ ok($archive_assignment, 'added archive volume to test group successfully');
 Genome::Sys->create_directory(join('/', $archive_volume->mount_path, $group->subdirectory));
 
 # Override these methods so archive/active volume linking works for our test volumes
-no warnings 'redefine';
+no warnings qw(redefine once);
 *Genome::Disk::Volume::archive_volume_prefix = sub { return $archive_volume->mount_path };
 *Genome::Disk::Volume::active_volume_prefix = sub { return $volume->mount_path };
 use warnings;

--- a/lib/perl/Genome/Disk/Detail/Allocation/Archiver.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Archiver.pm
@@ -7,6 +7,8 @@ use Genome;
 
 use Carp qw(confess);
 
+require File::Spec;
+
 class Genome::Disk::Detail::Allocation::Archiver {
     is => 'Genome::Disk::Detail::StrictObject',
 
@@ -27,11 +29,8 @@ sub archive {
         Genome::Disk::Allocation->get_with_lock($id);
 
     my $current_allocation_path = $allocation_object->absolute_path;
-    my $archive_allocation_path = join('/',
-        $allocation_object->volume->archive_mount_path,
-        $allocation_object->group_subdirectory,
-        $allocation_object->allocation_path);
-    my $tar_path = join('/', $archive_allocation_path, 'archive.tar');
+    my $tar_path = $allocation_object->tar_path();
+    my $archive_allocation_path = (File::Spec->splitpath($tar_path))[1];
 
     # This gets set to true immediately before tarball creation is started.
     # This allows for conditional clean up of the archive directory in case of

--- a/lib/perl/Genome/Disk/Detail/Allocation/Archiver.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Archiver.pm
@@ -7,8 +7,6 @@ use Genome;
 
 use Carp qw(confess);
 
-require File::Spec;
-
 class Genome::Disk::Detail::Allocation::Archiver {
     is => 'Genome::Disk::Detail::StrictObject',
 
@@ -30,7 +28,7 @@ sub archive {
 
     my $current_allocation_path = $allocation_object->absolute_path;
     my $tar_path = $allocation_object->tar_path();
-    my $archive_allocation_path = (File::Spec->splitpath($tar_path))[1];
+    my $archive_allocation_path = $allocation_object->archive_path();
 
     # This gets set to true immediately before tarball creation is started.
     # This allows for conditional clean up of the archive directory in case of

--- a/lib/perl/Genome/Disk/Detail/Allocation/Purger.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Purger.pm
@@ -73,8 +73,7 @@ sub _purge_archived {
     my $allocation_object = shift;
 
     unless ($ENV{UR_DBI_NO_COMMIT}) {
-        $allocation_object->_cleanup_archive_directory(
-            $allocation_object->absolute_path);
+        $allocation_object->_cleanup_archive_directory($allocation_object->archive_path);
     }
 
     $self->_finalize_purge($allocation_object);

--- a/lib/perl/Genome/Disk/Detail/Allocation/Unarchiver.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Unarchiver.pm
@@ -116,6 +116,13 @@ sub unarchive {
                 $old_absolute_path, $allocation_object->absolute_path);
         }
 
+        $allocation_object->add_note(
+            header_text => 'unarchived',
+            body_text => $self->reason,
+        );
+        Genome::Timeline::Event::Allocation->unarchived($self->reason, $allocation_object);
+        $allocation_object->status('active');
+
         unless ($tx->commit() && $allocation_object->_commit_unless_testing) {
             die 'failed to commit';
         }
@@ -131,14 +138,6 @@ sub unarchive {
         $allocation_lock->unlock() if $allocation_lock;
         $shadow_allocation->delete();
     };
-
-    $allocation_object->add_note(
-        header_text => 'unarchived',
-        body_text => $self->reason,
-    );
-    Genome::Timeline::Event::Allocation->unarchived($self->reason,
-        $allocation_object);
-    $allocation_object->status('active');
 
     $allocation_object->_cleanup_archive_directory($archive_path);
     return 1;

--- a/lib/perl/Genome/Disk/Detail/Allocation/Unarchiver.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Unarchiver.pm
@@ -150,7 +150,10 @@ sub _swap_shadow_allocation {
     try {
         $allocation_object->mount_path($shadow_allocation->volume->mount_path);
         Genome::Sys->create_directory($allocation_object->absolute_path);
-        Genome::Sys->rename($shadow_allocation->absolute_path, $allocation_object->absolute_path);
+        my $rename_ok = Genome::Sys->rename($shadow_allocation->absolute_path, $allocation_object->absolute_path);
+        unless ($rename_ok) {
+            die 'rename failed';
+        };
         $tx->commit();
     }
     catch {


### PR DESCRIPTION
I found 391 allocations that had their `status` still set to 'archived' but
their `mount_path` was not a `/gscarchive` path.  These changes are possible
fixes for what may be causing that inconsistency.