### PR TITLE
Set validation references as being rederivable.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Validation/LongIndelsPartOne.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/LongIndelsPartOne.pm
@@ -247,6 +247,7 @@ sub execute {
         fasta_file => $contigs_file,
         prefix => $sample_id,
         model_name => $new_ref_model_name,
+        is_rederivable => 1,
     );
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');

--- a/lib/perl/Genome/Model/Tools/Validation/SvManualReviewContigs.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/SvManualReviewContigs.pm
@@ -236,6 +236,7 @@ sub execute {
         version => $version,
         fasta_file => $contigs_file,
         prefix => $sample_id . "_SV_Contigs",
+        is_rederivable => 1,
     );
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');


### PR DESCRIPTION
This adds the `is_rederivable` flag to the references created in these GMTs, which makes them like the ones created in the SomaticValidation pipeline.  (The practical effect is that such references will not be stored in the location to which `Genome::Config::get('disk_group_references')` points.)