### PR TITLE
Remove length restriction on fail_count.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/InstrumentDataBridge.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/InstrumentDataBridge.pm
@@ -27,7 +27,7 @@ class Genome::Config::AnalysisProject::InstrumentDataBridge {
             default_value => 'new',
             valid_values => [ "new", "failed", "processed", "skipped" ],
         },
-        fail_count => { is => 'Integer', len => 4, default_value => 0 },
+        fail_count => { is => 'Integer', default_value => 0 },
         reason => { is => 'Text', is_optional => 1 },
     ],
     schema_name => 'GMSchema',


### PR DESCRIPTION
The backing column's type is an `integer` itself.

(CQID is currently failing because it's trying to set a fail_count of 10,000.)