### PR TITLE
Spelling/grammar changes to Heartbeat Check

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -2657,7 +2657,7 @@ sub _heartbeat {
     );
     if (grep { $heartbeat{status} eq $_ } ('Succeeded', 'Preserved')) {
         $heartbeat{is_ok} = 1;
-        $heartbeat{message} = 'Build is succeeded. Stauts is '.$heartbeat{status}.'.';
+        $heartbeat{message} = 'Build is succeeded. Status is '.$heartbeat{status}.'.';
         return %heartbeat;
     }
 

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -2657,7 +2657,7 @@ sub _heartbeat {
     );
     if (grep { $heartbeat{status} eq $_ } ('Succeeded', 'Preserved')) {
         $heartbeat{is_ok} = 1;
-        $heartbeat{message} = 'Build is succeeded. Status is '.$heartbeat{status}.'.';
+        $heartbeat{message} = 'Build has succeeded. Status is '.$heartbeat{status}.'.';
         return %heartbeat;
     }
 


### PR DESCRIPTION
* Spelling: `Stauts` => `Status`
* Change `is` to `has`, since the build might have a different literal status.