### PR TITLE
Remove tigra-sv version 20110321

### DIFF
--- a/lib/perl/Genome/Model/Tools/TigraSv.pm
+++ b/lib/perl/Genome/Model/Tools/TigraSv.pm
@@ -16,7 +16,7 @@ class Genome::Model::Tools::TigraSv {
     has => [
         use_version => {
             is  => 'Version',
-            doc => "tigra_sv version to be used, default is $DEFAULT. ",
+            doc => "tigra_sv version to be used.",
             is_optional   => 1,
             default_value => $DEFAULT,
         },

--- a/lib/perl/Genome/Model/Tools/TigraSv.pm
+++ b/lib/perl/Genome/Model/Tools/TigraSv.pm
@@ -9,7 +9,7 @@ use POSIX;
 use DateTime;
 use IO::File;
 
-my $DEFAULT = '20110321';
+my $DEFAULT = '0.1';
 
 class Genome::Model::Tools::TigraSv {
     is  => 'Command',
@@ -43,7 +43,6 @@ EOS
 
 
 my %TIGRASV_VERSIONS = (
-    20110321 => '/gscuser/tabbott/bin/tigra-sv',
     '0.1'    => '/usr/bin/tigra-sv0.1',
 );
 

--- a/lib/perl/Genome/Model/Tools/TigraSv.pm
+++ b/lib/perl/Genome/Model/Tools/TigraSv.pm
@@ -3,7 +3,7 @@ package Genome::Model::Tools::TigraSv;
 use strict;
 use warnings;
 
-use Genome; 
+use Genome;
 use File::Basename;
 use POSIX;
 use DateTime;
@@ -14,11 +14,11 @@ my $DEFAULT = '0.1';
 class Genome::Model::Tools::TigraSv {
     is  => 'Command',
     has => [
-        use_version => { 
-            is  => 'Version', 
-            doc => "tigra_sv version to be used, default is $DEFAULT. ", 
-            is_optional   => 1, 
-            default_value => $DEFAULT,   
+        use_version => {
+            is  => 'Version',
+            doc => "tigra_sv version to be used, default is $DEFAULT. ",
+            is_optional   => 1,
+            default_value => $DEFAULT,
         },
     ],
 };
@@ -32,12 +32,12 @@ sub help_brief {
 sub help_synopsis {
     my $self = shift;
     return <<"EOS"
-gmt tigra-sv ...    
+gmt tigra-sv ...
 EOS
 }
 
-sub help_detail {                           
-    return <<EOS 
+sub help_detail {
+    return <<EOS
 EOS
 }
 
@@ -61,8 +61,8 @@ sub path_for_tigrasv_version {
 sub default_tigrasv_version {
     die "default tigra_sv version: $DEFAULT is not valid" unless $TIGRASV_VERSIONS{$DEFAULT};
     return $DEFAULT;
-}    
-    
+}
+
 sub tigrasv_path {
     my $self = shift;
     return $self->path_for_tigrasv_version($self->use_version);


### PR DESCRIPTION
This version only lived in a home directory, which has been removed.

Version 0.1 is the "default" specified [in `Genome::Model::Tools::DetectVariants2::Filter::TigraValidation`](https://github.com/genome/genome/blob/d50a74cd0998c9a1618c789609ff62502119b2b1/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/TigraValidation.pm#L77).