### PR TITLE
Search base references for CopyCat annotation data

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/CopyCatSomaticWithBamWindow.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/CopyCatSomaticWithBamWindow.pm
@@ -185,6 +185,14 @@ sub _find_annotation_data {
         $annotation_reference = $annotation_reference->derived_from;
     }
 
+    if($annotation_sr->reference_sequence ne $reference_build) {
+        $self->status_message(
+            'No annotation data for reference %s.  Using data for reference %s from which it was derived.',
+            $reference_build->id,
+            $annotation_sr->reference_sequence->id,
+        );
+    }
+
     return $annotation_sr;
 }
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/CopyCatSomaticWithBamWindow.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/CopyCatSomaticWithBamWindow.t
@@ -138,7 +138,7 @@ sub _create_test_annotation_data{
     );
     ok($cmd, "Annotation data creation command exists");
     ok($cmd->execute, 'Successfully created annotation data set');
-    return $version;
+    return $cmd->version;
 }
 
 1;


### PR DESCRIPTION
If there is no annotation data specific to our reference, try looking at references from which ours is derived.