### PR TITLE
Heartbeat check only if operation_type exists.

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -2679,8 +2679,8 @@ sub _heartbeat {
         }
 
         # only certain operation types would have LSF jobs and everything below is inspecting LSF status
-        my $operation_type = $wf_instance_exec->operation_instance->operation->operation_type;
-        unless ( grep { $operation_type->isa($_) } ('Workflow::OperationType::Command', 'Workflow::OperationType::Event') ) {
+        my $operation_type = $wf_instance_exec->operation_instance->operation_type;
+        unless ( $operation_type and grep { $operation_type->isa($_) } ('Workflow::OperationType::Command', 'Workflow::OperationType::Event') ) {
             next WF;
         }
 

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -2678,7 +2678,7 @@ sub _heartbeat {
             next WF;
         }
 
-        # only certaion operation types would have LSF jobs and everything below is inspecting LSF status
+        # only certain operation types would have LSF jobs and everything below is inspecting LSF status
         my $operation_type = $wf_instance_exec->operation_instance->operation->operation_type;
         unless ( grep { $operation_type->isa($_) } ('Workflow::OperationType::Command', 'Workflow::OperationType::Event') ) {
             next WF;


### PR DESCRIPTION
An instance without a parallel_index for parallel_by jobs doesn't point back to the operation the way the jobs with the parallel_index do.  It doesn't refer to a job that will be scheduled to LSF, so there's no need to investigate it further.