### PR TITLE
Don't report idle parents of running children in heartbeat check.

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -2747,6 +2747,11 @@ sub _heartbeat {
             }
         }
 
+        my @parents = grep { $_->status eq 'running' } grep { defined($_->parent_execution_id) and $_->parent_execution_id eq $wf_instance_exec_id } @wf_instances;
+        if (@parents > 0) {
+            next WF; #this is a parent, so we wouldn't expect its output to be updated while its children are running.  Let them determine the heartbeat status.
+        }
+
         my $output_file = $wf_instance_exec->stdout;
         my $output_stat = stat($output_file);
         my $elapsed_mtime_output_file = time - $output_stat->mtime;
@@ -2765,6 +2770,7 @@ sub _heartbeat {
 
             last WF;
         }
+
         $heartbeat{message} = 'OK. Seems to be running!';
         $heartbeat{is_ok} = 1;
     }

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -2770,7 +2770,9 @@ sub _heartbeat {
 
             last WF;
         }
+    }
 
+    unless ($heartbeat{message}) {
         $heartbeat{message} = 'OK. Seems to be running!';
         $heartbeat{is_ok} = 1;
     }


### PR DESCRIPTION
DV2 dispatchers and other jobs that spawn workers and wait on them will spuriously report no log updates in 48 hours under `Flow`.  Skip these steps instead and report on their children's status.