### PR TITLE
add valid_signals

### DIFF
--- a/lib/perl/Genome/DataSource/CommonRDBMS.pm
+++ b/lib/perl/Genome/DataSource/CommonRDBMS.pm
@@ -9,6 +9,7 @@ use UR::DataSource::Pg;
 
 class Genome::DataSource::CommonRDBMS {
     doc => 'Mixin class to implement pausing access to the database',
+    valid_signals => [qw( precommit precreate_handle query sequence_nextval )]
 };
 
 my $query_pause = _make_db_pause_function('query_pause_sentry_file_path');

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1836,7 +1836,7 @@ sub _get_temp_allocation {
         owner_id            => Genome::Sys->username,
     );
     UR::Context->process->add_observer(
-        aspect   => 'pre-commit',
+        aspect   => 'precommit',
         once     => 1,
         callback => sub { $temp_allocation->delete; },
     );


### PR DESCRIPTION
An upcoming change to UR fixes a bug in the signal validation code that 
exposes cases where a class did not define `valid_signals` nor a
`validate_subscription` method.  This is one such example.