### PR TITLE
Use String::QuoteShell to do quoting for shell.

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -47,16 +47,12 @@ sub concatenate_files {
 }
 
 sub quote_for_shell {
+    require String::ShellQuote;
+
     # this is needed until shellcmd supports an array form,
     # which is difficult because we go to a bash sub-shell by default
     my $class = shift;
-    my @quoted = @_;
-    for my $value (@quoted) {
-        $value =~ s|\\|\\\\|g;
-        $value =~ s/\"/\\\"/g;
-        $value = "\"${value}\"";
-        print STDERR $value,"\n";
-    }
+    my @quoted = map String::ShellQuote::shell_quote($_), @_;
     if (wantarray) {
         return @quoted
     }


### PR DESCRIPTION
The require is included inside the subroutine because we don't have the module installed for Perl 5.8.  (I generally believe that it is safe to stop supporting Perl 5.8, but there's no reason to force the issue here.)