### PR TITLE
Allow specifying the command as a list in Genome::Sys->shellcmd

### DIFF
--- a/lib/perl/Genome/Sys-shellcmd.t
+++ b/lib/perl/Genome/Sys-shellcmd.t
@@ -93,6 +93,22 @@ sub test_redirect_stdout_stderr {
         unlink($parenterr, $childerr);
     }
 
+    {
+        my $parentout = File::Temp::tmpnam();
+        my $childout = File::Temp::tmpnam();
+        my $result = $test_redirect->(
+            cmd => [qw(echo another test)],
+            parentout => $parentout,
+            redirect_stdout => $childout,
+        );
+        ok($result, 'Run echo with stdout redirected not through a shell');
+        ok(! (-s $parentout), 'Found no output in stdout of parent')
+            or diag $read_file->($parentout);
+        # two newlines, as the shellcmd will emit an extra newline
+        is( $read_file->($childout), "another test\n\n", 'redirected child stdout to a file');
+        unlink($parentout, $childout);
+    }
+
     Genome::Sys->dump_status_messages($do_dump_status_messages);
 }
 

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1533,7 +1533,7 @@ sub shellcmd {
                         @cmdline = ('bash', '-c', "$shellopts_part $cmd");
                     }
 
-                    exec(@cmdline)
+                    exec { $cmdline[0] } (@cmdline)
                         or do {
                             print STDERR "Can't exec: $!\nCommand line was: ",join(' ', @cmdline),"\n";
                             exit(127);

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1405,6 +1405,12 @@ sub shellcmd {
 
     my ($t1,$t2,$elapsed);
 
+    my @cmdline;
+    if (ref($cmd) and ref($cmd) eq 'ARRAY') {
+        @cmdline = @$cmd;
+        $cmd = join(' ', map $self->quote_for_shell($_), @cmdline);
+    }
+
     # Go ahead and print the status message if the cmd is shortcutting
     if ($output_files and @$output_files) {
         my @found_outputs = grep { -e $_ } grep { not -p $_ } @$output_files;
@@ -1518,7 +1524,11 @@ sub shellcmd {
                 {   # POE sets a handler to ignore SIG{PIPE}, that makes the
                     # pipefail option useless.
                     local $SIG{PIPE} = 'DEFAULT';
-                    my @cmdline = ('bash', '-c', "$shellopts_part $cmd");
+
+                    unless (@cmdline) {
+                        @cmdline = ('bash', '-c', "$shellopts_part $cmd");
+                    }
+
                     exec(@cmdline)
                         or do {
                             print STDERR "Can't exec: $!\nCommand line was: ",join(' ', @cmdline),"\n";

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1395,6 +1395,16 @@ sub shellcmd {
     my $print_status_to_stderr       = delete $params{print_status_to_stderr};
     my $keep_dbh_connection_open     = delete $params{keep_dbh_connection_open};
 
+    my @cmdline;
+    if (ref($cmd) and ref($cmd) eq 'ARRAY') {
+        if (defined $set_pipefail) {
+            Carp::confess "Cannot use set_pipefail with ARRAY form of cmd!";
+        }
+
+        @cmdline = @$cmd;
+        $cmd = join(' ', map $self->quote_for_shell($_), @cmdline);
+    }
+
     $set_pipefail = 1 if not defined $set_pipefail;
     $print_status_to_stderr = 1 if not defined $print_status_to_stderr;
     $skip_if_output_is_present = 1 if not defined $skip_if_output_is_present;
@@ -1404,12 +1414,6 @@ sub shellcmd {
     }
 
     my ($t1,$t2,$elapsed);
-
-    my @cmdline;
-    if (ref($cmd) and ref($cmd) eq 'ARRAY') {
-        @cmdline = @$cmd;
-        $cmd = join(' ', map $self->quote_for_shell($_), @cmdline);
-    }
 
     # Go ahead and print the status message if the cmd is shortcutting
     if ($output_files and @$output_files) {


### PR DESCRIPTION
This skips the `bash -c` and eliminates the need to worry about properly quoting arguments!  (The old way is still available for using commands that involve pipes and the like.)

* Should whether or not to use `bash -c` when supplying an array be a separate option?