### PR TITLE
Make Genome::Sys->create_symlink() idempotent

### DIFF
--- a/lib/perl/Genome/Site/TGI/Extension/Sys.t
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys.t
@@ -289,9 +289,6 @@ $worked = eval { Genome::Sys->create_symlink($target) };
 ok(!$worked, "create_symlink with no 'link' fails as expected");
 like($@, qr/Can't create_symlink: no 'link' given/, 'exception message is correct');
 
-$worked = eval { Genome::Sys->create_symlink($target, $new_link) };
-ok(!$worked, 'Failed as expected - create_symlink when link already exists');
-like($@, qr/Link \($new_link\) for target \($target\) already exists/, 'exception message is correct');
 unlink $new_link; # remove to not influence target failures below
 
 # Target Failures

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -899,7 +899,8 @@ sub create_symlink {
 
     unless (symlink($target, $link)) {
         if ($! == Errno::EEXIST) {
-            if (readlink($link) ne $target) {
+            my $current_target = readlink($link);
+            if (defined($current_target) and $current_target ne $target) {
                 Carp::croak("Link ($link) for target ($target) already exists.");
             }
         } else {

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -901,7 +901,7 @@ sub create_symlink {
         my $symlink_error = $!;
         if ($symlink_error == Errno::EEXIST) {
             my $current_target = readlink($link);
-            if (defined($current_target) and $current_target ne $target) {
+            if (! defined($current_target) or $current_target ne $target) {
                 Carp::croak("Link ($link) for target ($target) already exists.");
             }
         } else {

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -898,13 +898,14 @@ sub create_symlink {
     }
 
     unless (symlink($target, $link)) {
-        if ($! == Errno::EEXIST) {
+        my $symlink_error = $!;
+        if ($symlink_error == Errno::EEXIST) {
             my $current_target = readlink($link);
             if (defined($current_target) and $current_target ne $target) {
                 Carp::croak("Link ($link) for target ($target) already exists.");
             }
         } else {
-            Carp::croak("Can't create link ($link) to $target\: $!");
+            Carp::croak("Can't create link ($link) to $target\: $symlink_error");
         }
     }
     return 1;

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -897,18 +897,13 @@ sub create_symlink {
         Carp::croak("Can't create_symlink: no 'link' given");
     }
 
-    if ( -e $link ) { # the link exists and points to something
-        Carp::croak("Link ($link) for target ($target) already exists.");
+    unless (symlink($target, $link)) {
+        if ($! == Errno::EEXIST) {
+            Carp::croak("Link ($link) for target ($target) already exists.");
+        } else {
+            Carp::croak("Can't create link ($link) to $target\: $!");
+        }
     }
-
-    if ( -l $link ) { # the link exists, but does not point to something
-        Carp::croak("Link ($link) for target ($target) is already a link.");
-    }
-
-    unless ( symlink($target, $link) ) {
-        Carp::croak("Can't create link ($link) to $target\: $!");
-    }
-
     return 1;
 }
 

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -899,7 +899,9 @@ sub create_symlink {
 
     unless (symlink($target, $link)) {
         if ($! == Errno::EEXIST) {
-            Carp::croak("Link ($link) for target ($target) already exists.");
+            if (readlink($link) ne $target) {
+                Carp::croak("Link ($link) for target ($target) already exists.");
+            }
         } else {
             Carp::croak("Can't create link ($link) to $target\: $!");
         }

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -889,11 +889,11 @@ sub gidgrnam {
 sub create_symlink {
     my ($class, $target, $link) = @_;
 
-    unless ( defined $target ) {
+    unless ( defined($target) && length($target) ) {
         Carp::croak("Can't create_symlink: no target given");
     }
 
-    unless ( defined $link ) {
+    unless ( defined($link) && length($link) ) {
         Carp::croak("Can't create_symlink: no 'link' given");
     }
 

--- a/lib/perl/Genome/Sys.t
+++ b/lib/perl/Genome/Sys.t
@@ -257,7 +257,7 @@ subtest create_symlink => sub {
     };
 
     subtest 'link exists' => sub {
-        plan tests => 5;
+        plan tests => 6;
 
         my $target = '/dev/null';
         my $link = File::Temp::tempnam($dir, 'exists');
@@ -273,6 +273,13 @@ subtest create_symlink => sub {
         throws_ok { Genome::Sys->create_symlink('/dev/zero', $link) }
             qr($expected_error),
             'Creating a link with already existing name throws exception';
+
+        my $not_a_link = File::Temp->new(DIR => $dir);
+        $not_a_link->close();
+        $expected_error = quotemeta( qq(Link \($not_a_link\) for target \(/dev/zero\) already exists));
+        throws_ok { Genome::Sys->create_symlink('/dev/zero', $not_a_link) }
+            qr($expected_error),
+            'Creating a link when a file already exists with that name throws exception';
     };
 
     subtest 'symlink() fails' => sub {

--- a/lib/perl/Genome/Sys.t
+++ b/lib/perl/Genome/Sys.t
@@ -257,12 +257,17 @@ subtest create_symlink => sub {
     };
 
     subtest 'link exists' => sub {
-        plan tests => 2;
+        plan tests => 5;
 
         my $target = '/dev/null';
         my $link = File::Temp::tempnam($dir, 'exists');
         ok( Genome::Sys->create_symlink($target, $link),
             'create_symlink');
+        is(readlink($link), $target, 'symlink is ok');
+
+        ok( Genome::Sys->create_symlink($target, $link),
+            'create_symlink() with the same target and link');
+        is(readlink($link), $target, 'symlink is still ok');
 
         my $expected_error = quotemeta( qq(Link ($link) for target (/dev/zero) already exists) );
         throws_ok { Genome::Sys->create_symlink('/dev/zero', $link) }


### PR DESCRIPTION
There have been several builds in rt 104974 crashing because a call to create_symlink() fails due to the link already existing, but the existing link already has the same target as is being requested, and I can't figure out where the link is being created from.

It seems safe to allow this condition to succeed.