### PR TITLE
avoid side effects if an allocation is rolled back

### DIFF
--- a/lib/perl/Genome/Disk/Allocation-rollback.t
+++ b/lib/perl/Genome/Disk/Allocation-rollback.t
@@ -22,6 +22,6 @@ subtest 'regression test for RT 105743' => sub {
     my $a_iter = Genome::Disk::Allocation->create_iterator();
     my $a = $a_iter->next;
     ok($a, 'got an allocation');
-    ok(UR::Context->rollback, 'rolled back again to induce arhivable side-effects');
+    ok(UR::Context->rollback, 'rolled back again to induce archivable side-effects');
     ok(UR::Context->commit, 'commit to demonstrate invalid data for save');
 };

--- a/lib/perl/Genome/Disk/Allocation-rollback.t
+++ b/lib/perl/Genome/Disk/Allocation-rollback.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env genome-perl
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Genome;
+
+subtest 'regression test for RT 105743' => sub {
+    # This is a regression test.  Previously some necessary observers were
+    # destroyed during UR::Context->rollback().  "Random" hash ordering would
+    # sometimes cause the destruction of observers before other, dependent
+    # rollback actions ran.  In this test we rollback twice to not depend on
+    # the hash ordering.
+    plan tests => 4;
+    ok(UR::Context->rollback, 'rolled back to induce destruction of necessary observers');
+    my $a_iter = Genome::Disk::Allocation->create_iterator();
+    my $a = $a_iter->next;
+    ok($a, 'got an allocation');
+    ok(UR::Context->rollback, 'rolled back again to induce arhivable side-effects');
+    ok(UR::Context->commit, 'commit to demonstrate invalid data for save');
+};

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -547,6 +547,23 @@ sub __display_name__ {
     return $self->absolute_path;
 }
 
+sub __rollback_property__ {
+    my ($self, $property_name) = @_;
+
+    # We do not want to create new Genome::Timeline::Events during rollback so
+    # have to bypass the overridden methods and directly use the accessors.
+    if ($property_name eq 'archivable') {
+        my $saved_value = UR::Context->current->value_for_object_property_in_underlying_context($self, $property_name);
+        return $self->__archivable($saved_value);
+    }
+    if ($property_name eq 'archive_after_time') {
+        my $saved_value = UR::Context->current->value_for_object_property_in_underlying_context($self, $property_name);
+        return $self->__archive_after_time($saved_value);
+    }
+
+    return $self->SUPER::__rollback_property__($property_name);
+}
+
 # Using a system call when not in dev mode is a hack to get around the fact that we don't
 # have software transactions. Allocation need to be able to make its changes and commit
 # immediately so locks can be released in a timely manner. Without software transactions,


### PR DESCRIPTION
When an allocation is rolled back UR would, for example, run
`$a->archivable(0)` which since `archivable` is an overriden property would
have unintended side-effects.