### PR TITLE
validate values to hash

### DIFF
--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -191,10 +191,18 @@ sub _role_for_type {
 sub user_hash_for_build {
     my $class = shift;
     my $build = shift;
+    unless ($build) {
+        Carp::croak q(user_hash_for_build requires 'build' as an argument);
+    }
+
+    my $sponsor = $build->model->analysis_projects // Genome::Sys::User->get(username => $build->model->run_as);
+    unless ($sponsor) {
+        die q(unable to determine sponsor for build);
+    }
 
     return {
         requestor => $build,
-        sponsor   => $build->model->analysis_projects // Genome::Sys::User->get(username => $build->model->run_as),
+        sponsor   => $sponsor,
     };
 }
 

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -3,6 +3,7 @@ package Genome::SoftwareResult::User;
 use strict;
 use warnings;
 use Genome;
+use Genome::Carp qw(dief);
 use Genome::Sys::LockProxy qw();
 use List::MoreUtils qw(any);
 use Params::Validate qw(:types);
@@ -197,7 +198,7 @@ sub user_hash_for_build {
 
     my $sponsor = $build->model->analysis_projects // Genome::Sys::User->get(username => $build->model->run_as);
     unless ($sponsor) {
-        die q(unable to determine sponsor for build);
+        dief q(unable to determine sponsor for build: %s), $build->id;
     }
 
     return {


### PR DESCRIPTION
We had a case where no sponsor was found for a build which caused a warning
about odd number of elements in the hash and then failed downstream.