### PR TITLE
fix `register_callback` call because subject is not valid for that API

### DIFF
--- a/lib/perl/Genome/Site/TGI/Extension/Sys/Lock.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys/Lock.pm
@@ -42,7 +42,8 @@ if ($nessy_server) {
     Genome::Sys::Lock->add_backend('site', $nessy_site_backend);
 
     UR::Observer->register_callback(
-        subject => UR::Context->process,
+        subject_class_name => UR::Context->process->class,
+        subject_id => UR::Context->process->id,
         aspect => 'sync_databases',
         callback => sub {
             my ($ctx, $aspect, $sync_db_result) = @_;


### PR DESCRIPTION
This was not caught by testing on the PR because `GENOME_NESSY_SERVER` isn't
set on PR tests (yet).