### PR TITLE
Remove alert from `genome disk group available-space` report

### DIFF
--- a/lib/perl/Genome/Disk/Command/Group/AvailableSpace.pm
+++ b/lib/perl/Genome/Disk/Command/Group/AvailableSpace.pm
@@ -78,7 +78,7 @@ sub execute {
 
     $self->status_message(join("\n", @reports));
 
-    return 1;
+    return !$group_is_low;
 }
 
 sub kb_to_gb {

--- a/lib/perl/Genome/Disk/Command/Group/AvailableSpace.pm
+++ b/lib/perl/Genome/Disk/Command/Group/AvailableSpace.pm
@@ -12,16 +12,6 @@ class Genome::Disk::Command::Group::AvailableSpace {
             is => 'Text',
             doc => 'comma delimited list of disk groups to be checked',
         },
-        send_alert => {
-            is => 'Boolean',
-            default => 0,
-            doc => 'If set, an alert will be sent out if a disk group is does not have the minimum amount of free space',
-        },
-        alert_recipients => {
-            is => 'Text',
-            default => 'jeldred,apipebulk',
-            doc => 'If an alert is sent, these are the recipients',
-        },
     ],
 };
 
@@ -87,17 +77,6 @@ sub execute {
     }
 
     $self->status_message(join("\n", @reports));
-
-    if ($group_is_low and $self->send_alert) {
-        my @to = map { Genome::Utility::Email::construct_address($_) } split(',', $self->alert_recipients);
-        Genome::Utility::Email::send(
-            from    => Genome::Sys::User->get_current->email,
-            to      => \@to,
-            subject => 'Disk Groups Running Low on Space!',
-            body    => join("\n", @reports),
-        );
-        $self->warning_message("Sent alert to " . $self->alert_recipients);
-    }
 
     return 1;
 }

--- a/lib/perl/Genome/Disk/Command/Group/AvailableSpace.pm
+++ b/lib/perl/Genome/Disk/Command/Group/AvailableSpace.pm
@@ -46,7 +46,7 @@ sub help_detail {
 
 sub execute {
     my $self = shift;
-    
+
     my @disk_groups;
     if ($self->disk_group_names) {
         @disk_groups = split(',', $self->disk_group_names);

--- a/lib/perl/Genome/Disk/Command/Group/AvailableSpace.t
+++ b/lib/perl/Genome/Disk/Command/Group/AvailableSpace.t
@@ -15,7 +15,6 @@ use_ok('Genome::Disk::Command::Group::AvailableSpace') or die;
 
 my $cmd = Genome::Disk::Command::Group::AvailableSpace->create(
     disk_group_names => Genome::Config::get('disk_group_dev'),
-    send_alert => 0,
 );
 ok($cmd, 'Successfully created avaiable space command object') or die;
 


### PR DESCRIPTION
I'm migrating this to a Jenkins task, so that will be responsible for alerting if trouble arises.