### PR TITLE
Builds use processes

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1392,46 +1392,17 @@ sub _launch {
         return $rv;
     }
     else {
-        my $lsf_project = "build" . $self->id;
-        $ENV{'WF_LSF_PROJECT'} = $lsf_project;
-
-        my $genome_bin = $Command::entry_point_bin || 'genome';
-
-        my @bsub_args = (
-            email    => Genome::Utility::Email::construct_address(),
-            err_file => $build_event->error_log_file,
-            hold_job => 1,
-            log_file => $build_event->output_log_file,
-            project  => $lsf_project,
-            queue    => $server_dispatch,
-            send_job_report => 1,
-            never_rerunnable => 1,
-        );
-        unless ($ENV{WF_EXCLUDE_JOB_GROUP}) {
-            push @bsub_args, job_group => $job_group;
+        my %inputs = $self->model->map_workflow_inputs($self);
+        my $workflow = $self->_initialize_workflow($params{job_dispatch} || Genome::Config::get('lsf_queue_build_worker_alt'));
+        unless ($workflow) {
+            Carp::croak "Build " . $self->__display_name__ . " could not initialize workflow!";
         }
-
-        my @genome_cmd = (
-            'annotate-log', $genome_bin, qw(model services build run),
+        my $workflow_xml = $workflow->save_to_xml();
+        my $process = Genome::Model::Build::Process->create(build => $self);
+        $process->run(
+            workflow_xml => $workflow_xml,
+            workflow_inputs => \%inputs,
         );
-
-        my @genome_args;
-        # args have to be --key=value for Genome::Model->sudo_wrapper()
-        push @genome_args, '--model-id=' . $model->id;
-        push @genome_args, '--build-id=' . $self->id;
-        if ($job_dispatch eq 'inline') {
-            push @genome_args, '--inline';
-        }
-
-        my $job_id = $self->_execute_bsub_command(
-            'bsub',
-            @bsub_args,
-            cmd => [ @genome_cmd, @genome_args ],
-        );
-        return unless $job_id;
-
-        $build_event->lsf_job_id($job_id);
-
         return 1;
     }
 }
@@ -1516,51 +1487,6 @@ sub _initialize_workflow {
     $workflow->save_to_xml(OutputFile => $self->data_directory . '/build.xml');
 
     return $workflow;
-}
-
-sub _execute_bsub_command { # here to overload in testing
-    my ($self, @cmd) = @_;
-
-    local $ENV{UR_DUMP_DEBUG_MESSAGES} = 1;
-    local $ENV{UR_COMMAND_DUMP_DEBUG_MESSAGES} = 1;
-    local $ENV{UR_DUMP_STATUS_MESSAGES} = 1;
-    local $ENV{UR_COMMAND_DUMP_STATUS_MESSAGES} = 1;
-
-    if ($ENV{UR_DBI_NO_COMMIT}) {
-        $self->warning_message("Skipping bsub when NO_COMMIT is turned on (job will fail)\n");
-        return 1;
-    }
-
-    my $job_id = eval { Genome::Sys::LSF::bsub::run(@cmd) };
-    if ($@) {
-        $self->error_message("Failed to launch bsub:\n$@\n");
-        return;
-    }
-
-    # create a change record so that if it is "undone" it will kill the job
-    my $bsub_undo = sub {
-        $self->status_message("Killing LSF job ($job_id) for build " . $self->__display_name__ . ".");
-        system("bkill $job_id");
-    };
-    my $lsf_change = UR::Context::Transaction->log_change($self, 'UR::Value', $job_id, 'external_change', $bsub_undo);
-    unless ($lsf_change) {
-        die $self->error_message("Failed to record LSF job submission ($job_id).");
-    }
-
-    # create a commit observer to resume the job when build is committed to database
-    my $process = UR::Context->process;
-    my $commit_observer = $process->add_observer(
-        aspect => 'commit',
-        callback => sub {
-            my $bresume_output = `bresume $job_id`; chomp $bresume_output;
-            $self->status_message($bresume_output) unless ( $bresume_output =~ /^Job <$job_id> is being resumed$/ );
-        },
-    );
-    unless ($commit_observer) {
-        $self->error_message("Failed to add commit observer to resume LSF job ($job_id).");
-    }
-
-    return "$job_id";
 }
 
 sub initialize {

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1392,6 +1392,11 @@ sub _launch {
         return $rv;
     }
     else {
+        if ($ENV{UR_DBI_NO_COMMIT}) {
+            $self->warning_message("Skipping launching process when NO_COMMIT is turned on (job will fail)\n");
+            return;
+        }
+
         my %inputs = $self->model->map_workflow_inputs($self);
         my $workflow = $self->_initialize_workflow($params{job_dispatch} || Genome::Config::get('lsf_queue_build_worker_alt'));
         unless ($workflow) {

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1311,6 +1311,12 @@ sub _get_running_master_lsf_job {
     my $self = shift;
 
     my $job_id = $self->the_master_event->lsf_job_id;
+    if (not defined($job_id)) {
+        my $process = Genome::Model::Build::Process->get(build => $self);
+        if ($process) {
+            $job_id = $process->lsf_job_id;
+        }
+    }
     return if not defined $job_id;
 
     my $job = $self->_get_job($job_id);

--- a/lib/perl/Genome/Model/Build/Command/Start.pm
+++ b/lib/perl/Genome/Model/Build/Command/Start.pm
@@ -160,7 +160,7 @@ sub create_and_start_build {
 
     my $start_transaction = UR::Context::Transaction->begin();
     my $build_started = try {
-        $build->start(%{$self->_start_params});
+        $build->start(%{$self->_start_params}) || die "Couldn't start build";
         $start_transaction->commit();
         return 1;
     }

--- a/lib/perl/Genome/Model/Build/Command/Start.pm
+++ b/lib/perl/Genome/Model/Build/Command/Start.pm
@@ -161,7 +161,7 @@ sub create_and_start_build {
     my $start_transaction = UR::Context::Transaction->begin();
     my $build_started = try {
         my $rv = $build->start(%{$self->_start_params});
-        $start_transaction->commit();
+        $start_transaction->commit() or die "Cannot commit 'build start' transaction";
         return $rv;
     }
     catch {

--- a/lib/perl/Genome/Model/Build/Command/Start.pm
+++ b/lib/perl/Genome/Model/Build/Command/Start.pm
@@ -160,9 +160,9 @@ sub create_and_start_build {
 
     my $start_transaction = UR::Context::Transaction->begin();
     my $build_started = try {
-        $build->start(%{$self->_start_params}) || die "Couldn't start build";
+        my $rv = $build->start(%{$self->_start_params});
         $start_transaction->commit();
-        return 1;
+        return $rv;
     }
     catch {
         $start_transaction->rollback();

--- a/lib/perl/Genome/Model/Build/Process.pm
+++ b/lib/perl/Genome/Model/Build/Process.pm
@@ -1,0 +1,142 @@
+package Genome::Model::Build::Process;
+
+use strict;
+use warnings FATAL => 'all';
+use Genome;
+use Try::Tiny qw(try catch);
+
+class Genome::Model::Build::Process {
+    is => [
+        "Genome::Process",
+    ],
+    has_input => [
+        build => {
+            is => 'Genome::Model::Build',
+        },
+    ],
+
+};
+
+sub workflow_name {
+    my $self = shift;
+    return $self->build->workflow_name;
+}
+
+sub lsf_project_name {
+    my $self = shift;
+    return "build" . $self->build->id;
+}
+
+sub log_directory {
+    my $self = shift;
+    return $self->build->log_directory;
+}
+
+sub update_status {
+    my $self = shift;
+    my ($new_status) = @_;
+
+    my $accessor = sprintf("_before_%s", lc($new_status));
+    if ($self->can($accessor)) {
+        $self->$accessor;
+    }
+
+    return $self->SUPER::update_status(@_);
+}
+
+sub _before_running {
+    my $self = shift;
+
+    try {
+        $self->build->initialize;
+    } catch {
+        $self->_post_build_failure($_);
+        die "Couldn't initialize build";
+    };
+
+    if ($ENV{WF_USE_FLOW}) {
+        $self->build->add_note(
+            header_text => 'run using flow',
+            body_text => '',
+        );
+    }
+}
+
+sub _before_succeeded {
+    my $self = shift;
+
+    unless ( $self->build->success ) {
+        my $msg = sprintf(
+            'Failed to set build to success: %s',
+            $self->build->error_text || 'no error given',
+        );
+        return $self->_post_build_failure($msg);
+    }
+
+    UR::Context->commit();
+
+    require UR::Object::View::Default::Xsl;
+
+    my $cachetrigger = Genome::Config::get('sys_services_web_view_url');
+    $cachetrigger =~ s/view$/cachetrigger/;
+
+    my $url = $cachetrigger . '/' . UR::Object::View::Default::Xsl::type_to_url     (ref($self->build)) . '/status.html?id=' . $self->build->id;
+
+    system("curl -k $url >/dev/null 2>/dev/null &");
+}
+
+sub _before_crashed {
+    my $self = shift;
+
+    my $error = try {
+        my $determine_error_command = Genome::Model::Build::Command::DetermineError->create(
+            build => $self->build,
+            assume_build_status => 'Failed',
+            display_results => 0,
+            color => 0,
+        );
+        $determine_error_command->execute();
+        return $determine_error_command->formatted_results;
+    } catch {
+        return "Error could not be determined: $_";
+    };
+    $self->_post_build_failure($error);
+}
+
+sub _post_build_failure {
+    my ($self, $msg) = @_;
+
+    $self->error_message($msg);
+
+    my $build_event = $self->build->build_event;
+    my $error = Genome::Model::Build::Error->create(
+        build_event_id => $build_event->id,
+        stage_event_id => $build_event->id,
+        stage => 'all stages',
+        step_event_id => $build_event->id,
+        step => 'main',
+        error => $msg,
+    );
+
+    unless ( $self->build->fail($error) ) {
+        return $self->_failed_build_fail($error);
+    }
+
+    return 1;
+}
+
+sub _failed_build_fail {
+    my ($self, @errors) = @_;
+
+    my $msg = sprintf(
+        "Failed to fail build because: %s\nOriginal errors:\n%s",
+        ( $self->build->error_text || 'No error given' ),
+        join("\n", map { $_->error } @errors),
+    );
+
+    $self->error_message($msg);
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/Command/Define/ImportedAnnotation.t
+++ b/lib/perl/Genome/Model/Command/Define/ImportedAnnotation.t
@@ -12,8 +12,16 @@ BEGIN {
 use Test::More tests => 12;
 
 use above 'Genome';
+use Sub::Install;
 
 use_ok('Genome::Model::Command::Define::ImportedAnnotation');
+
+use Genome::Model::Build;
+Sub::Install::reinstall_sub({
+    into => 'Genome::Model::Build',
+    as => 'start',
+    code => sub {return 1},
+});
 
 my $reference_sequence_build;
 my $version;

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
@@ -138,7 +138,7 @@ sub execute {
     my $tier_file_location = $annotation_build->tiering_bed_files_by_version(3);
     $self->tier_files($tier_file_location);
 
-    my $new_ref_cmd = Genome::Model::Command::Define::ImportedReferenceSequence->create(
+    my %import_params = (
         species_name => 'human',
         use_default_sequence_uri => '1',
         derived_from => $ref_seq_build,
@@ -148,8 +148,12 @@ sub execute {
         prefix => $sample_id,
         server_dispatch => 'inline',
         is_rederivable => 1,
-        analysis_project => $self->build->model->analysis_project,
     );
+    if ($self->build->model->analysis_project) {
+        $import_params{analysis_project} = $self->build->model->analysis_project;
+    }
+
+    my $new_ref_cmd = Genome::Model::Command::Define::ImportedReferenceSequence->create(%import_params);
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');
         return;

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -446,7 +446,7 @@ sub _disk_allocation_cleanup_closure {
         }
     };
     $self->debug_message("Created closure to delete disk allocation (%s) " .
-        "assocatied with process (%s)", $allocation_id, $process_id);
+        "associated with process (%s)", $allocation_id, $process_id);
     return $remove_allocation;
 }
 

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -330,6 +330,11 @@ sub workflow_name {
     return sprintf('Genome::Process(%s)', $self->id);
 }
 
+sub lsf_project_name {
+    my $self = shift;
+    return $self->workflow_name;
+}
+
 sub newest_workflow_instance {
     my $self = shift;
     my @sorted = sort {$b->id <=> $a->id} $self->_workflow_instances;

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -324,6 +324,16 @@ sub update_status {
     return $self->status;
 }
 
+sub lsf_job_id {
+    my $self = shift;
+
+    my $id_note = $self->notes(header_text => 'workflow lsf job_id');
+    if ($id_note) {
+        return $id_note->body_text;
+    } else {
+        return;
+    }
+}
 
 sub workflow_name {
     my $self = shift;

--- a/lib/perl/Genome/Process/Command/Run.pm
+++ b/lib/perl/Genome/Process/Command/Run.pm
@@ -147,7 +147,7 @@ sub _bsub_in_pend_state {
         err_file => $self->workflow_process_error_log,
         log_file => $self->workflow_process_out_log,
         hold_job => 1,
-        project => $self->process->workflow_name,
+        project => $self->process->lsf_project_name,
         queue => Genome::Config::get('lsf_queue_build_workflow'),
         send_job_report => 1,
         never_rerunnable => 1,

--- a/lib/perl/Genome/Process/Command/Run.pm
+++ b/lib/perl/Genome/Process/Command/Run.pm
@@ -159,6 +159,11 @@ sub _bsub_in_pend_state {
         die "Failed to launch bsub:\n$_\n";
     };
     $self->process->update_status('Scheduled');
+
+    $self->process->add_note(
+        header_text => 'workflow lsf job_id',
+        body_text => $job_id,
+    );
     return $job_id;
 }
 


### PR DESCRIPTION
This makes it so that when server_dispatch != inline, the `Build` uses a `Genome::Process` to execute the workflow.  There should be no changes for server_dispatch == inline.  This is a necessary step towards full PTero integration, and should make it possible to run builds with PTero in the same way that you can run processes with Ptero.

Model tests that I ran by hand diffed clean (rnaseq, somatic-validation and somatic-variation).

One side-effect of this change is that every build will use Flow unless you explicitly set WF_USE_FLOW=0.  This is because the `Genome::Process` framework defaults to using Flow unless it is already set.