### PR TITLE
Model Summary: Allow specification of max fail count

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -43,7 +43,7 @@ class Genome::Model::Command::Admin::ModelSummary {
         max_fail_count => {
             is => 'Number',
             default => 5,
-            doc => 'Rebuild will not be recommended for models that have failed this many times or more.',
+            doc => 'Rebuild will not be recommended for models that have failed this many times or more. (If undefined, any fail count will be allowed.)',
         },
     ],
 };
@@ -249,6 +249,7 @@ sub model_has_failed_too_many_times {
     my $model = shift;
 
     my $max_fails = $self->max_fail_count;
+    return unless defined $max_fails;
 
     my @builds = reverse $model->builds;
     return unless @builds;

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -251,7 +251,7 @@ sub model_has_failed_too_many_times {
     my $max_fails = $self->max_fail_count;
     return unless defined $max_fails;
 
-    my @builds = reverse $model->builds;
+    my @builds = $model->builds;
     return unless @builds;
 
     my @failed_builds = grep { $_->status eq 'Failed' } @builds;

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -243,11 +243,8 @@ sub model_has_failed_too_many_times {
     my @builds = reverse $model->builds;
     return unless @builds;
 
-    my $n = (@builds >= $max_fails ? ($max_fails - 1) : $#builds);
-    my @last_n_builds = @builds[0..$n];
-
-    my @failed_builds = grep { $_->status eq 'Failed' } @last_n_builds;
-    return (@failed_builds == $max_fails );
+    my @failed_builds = grep { $_->status eq 'Failed' } @builds;
+    return (@failed_builds >= $max_fails);
 }
 
 

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -219,7 +219,7 @@ sub should_review_model {
     return if @builds == 1;
 
     # If it has failed >3 times in a row then submit for review.
-    return 1 if model_has_failed_to_many_times($model);
+    return 1 if model_has_failed_too_many_times($model);
 
     # If it hasn't made progress since last time then submit for review.
     return 1 unless model_has_progressed($model);
@@ -237,7 +237,7 @@ sub latest_build_succeeded {
 
 
 my $max_fails = 5;
-sub model_has_failed_to_many_times {
+sub model_has_failed_too_many_times {
     my $model = shift;
 
     my @builds = reverse $model->builds;


### PR DESCRIPTION
* Count all builds when deciding if there are too many failures.  (We regularly abandon failures preceding previous successes, so these would usually all be "newer" than the last success.)
* Allow the maximum fail count to be specified.  (I currently believe 5 might be on the high side, but that could be mitigated by improving the `model_has_progressed` check.)