### PR TITLE
ModelSummary uses DetermineError to decide build progress

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DetermineError.pm
+++ b/lib/perl/Genome/Model/Build/Command/DetermineError.pm
@@ -437,3 +437,5 @@ sub set_file_and_line {
         $self->error_source_line($2);
     }
 }
+
+1;

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
@@ -163,9 +163,9 @@ sub get_build_errors {
         my $header = join("\t", qw(Model Build Build-Class Date));
         my $line = join("\t", $build->model_id, $build->id, $build->class, $cmd->error_date);
         if ($cmd->error_type eq 'Unstartable') {
-            $key = $self->get_unstartable_key($cmd);
+            $key = $cmd->get_unstartable_key;
         } elsif ($cmd->error_type eq 'Failed') {
-            $key = $self->get_failed_key($cmd);
+            $key = $cmd->get_failed_key;
 
             # unstartable and unknown errors don't generally have a host.
             $header = join("\t", qw(Model Build Build-Class Host Date));
@@ -185,59 +185,6 @@ sub get_build_errors {
     return \%build_errors;
 }
 
-sub get_failed_key {
-    my ($self, $cmd) = @_;
-
-    if ($cmd->error_text =~ m/gscarchive/) {
-        return "Failed: Archived Data";
-    }
-    if ($cmd->error_source_line ne 'Unknown') {
-        (my $delocalized_file = $cmd->error_source_file) =~ s/^.*\/lib\/perl\///;
-        return sprintf("Failed: %s %s", $delocalized_file, $cmd->error_source_line);
-    } else {
-        return sprintf("Failed: %s", remove_ids_and_paths($cmd->error_text));
-    }
-}
-
-sub remove_ids_and_paths {
-    my $str = shift;
-    my $formatted_str = $str;
-
-    # replace things that look like paths
-    $formatted_str =~ s/[a-zA-Z0-9.\-_]*[\/][a-zA-Z0-9.\-_\/]*/<path>/g;
-
-    # replace things that look like ids
-    $formatted_str =~ s/[0-9a-f]{5,32}/<id>/g;
-
-    return $formatted_str;
-}
-
-
-sub get_unstartable_key {
-    my ($self, $cmd) = @_;
-
-    my $text = remove_ids_and_paths($cmd->error_text);
-    my $information;
-    if ($text =~ m/Transaction error:/) {
-        ($information = $text) =~ s/.*problems on//;
-        if ($information =~ m/(.*?)\:(.*?)\:/) {
-            $information = "$1: $2";
-        }
-    }
-    if ($text =~ m/reason:/) {
-        ($information = $text) =~ s/.*reason://;
-        if ($information =~ m/(.*?)\sat\s/) {
-            $information = $1;
-        }
-    }
-    if ($text =~ m/validated for start!/) {
-        ($information = $text) =~ s/.*validated for start!//;
-        if ($information =~ m/(.*?)\:(.*?)\:/) {
-            $information = "$1: $2";
-        }
-    }
-    return sprintf("Unstartable: %s", $information);
-}
 
 sub remove_builds_in_tickets {
     my ($self, $builds) = @_;

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -370,3 +370,5 @@ sub _find_first_nondone_step_impl {
 
     return $failed_step;
 }
+
+1;

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -273,7 +273,10 @@ sub previous_build {
     my $build = shift;
 
     my $model = $build->model;
-    my @prior_builds = grep { $_->date_scheduled lt $build->date_scheduled } $model->builds;
+    my @prior_builds =
+        grep { $_->status eq $build->status }
+        grep { $_->date_scheduled lt $build->date_scheduled }
+        $model->builds;
 
     my $previous_build = @prior_builds ? $prior_builds[-1] : undef;
     return $previous_build;

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -278,7 +278,7 @@ sub previous_build {
         grep { $_->date_scheduled lt $build->date_scheduled }
         $model->builds;
 
-    my $previous_build = @prior_builds ? $prior_builds[-1] : undef;
+    my $previous_build = @prior_builds ? $prior_builds[0] : undef;
     return $previous_build;
 }
 

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -269,19 +269,6 @@ sub model_has_progressed {
 }
 
 
-sub latest_build_is_succeeded {
-    my $model = shift;
-
-    my $latest_build = $model->latest_build;
-
-    return (
-        $latest_build
-        && $latest_build->status
-        && $latest_build->status eq 'Succeeded'
-    );
-}
-
-
 sub previous_build {
     my $build = shift;
 


### PR DESCRIPTION
* Instead of doing its own workflow inspection, decide if it failed the same way twice by the error found by the `genome model build determine-error` command.
* Fix the `previous_build` finder to not find the first build instead!