### PR TITLE
Unload LIMS entities outside of the transaction.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/SyncLimsAndGenome.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/SyncLimsAndGenome.pm
@@ -248,9 +248,6 @@ sub _create_genome_objects_for_lims_objects {
     $self->status_message('Attempted: '.$ids_to_create->size);
     $self->status_message('Created:   '.@ids_created);
 
-    $self->status_message("Unloading $lims_class objects...");
-    my $unloaded = $lims_class->unload;
-
     $self->_report($report);
 
     $self->status_message("Commit $entity_name...");
@@ -260,6 +257,9 @@ sub _create_genome_objects_for_lims_objects {
         $transaction->rollback;
         Carp::confess( $self->error_message("Failed to commit $genome_class!") );
     }
+
+    $self->status_message("Unloading $lims_class objects...");
+    my $unloaded = $lims_class->unload;
 
     $self->status_message("Create $entity_name objects in Genome...done");
     return 1;


### PR DESCRIPTION
We don't need to bother registering 100s of thousands of "unload" records as changes inside the transaction.  Since transactions only verify changed objects, this will save tons of unnecessary work.