### PR TITLE
add support for getting multiple configuration keys

### DIFF
--- a/lib/perl/Genome/Configurable.t
+++ b/lib/perl/Genome/Configurable.t
@@ -6,7 +6,7 @@ use warnings;
 use Genome qw();
 use Genome::Test::Config qw(setup_config);
 
-use Test::More tests => 3;
+use Test::More tests => 5;
 
 use_ok('Genome::Configurable');
 
@@ -17,6 +17,9 @@ local $ENV{XGENOME_CONFIG_DIRS} = $new_temp_dir->();
 setup_config(
     spec => {
         'foo.name' => {},
+        'bar.name' => {
+            env => 'XGENOME_BAR',
+        },
     },
     home => {
         'foo.name' => 'foo_value',
@@ -33,8 +36,29 @@ UR::Object::Type->define(
     ],
 );
 
+UR::Object::Type->define(
+    class_name => 'Genome::Bar',
+    is => ['Genome::Configurable'],
+    has => [
+        name => {
+            config => [qw(bar.name foo.name)],
+        },
+    ],
+);
+
 my $foo1 = Genome::Foo->create();
 is($foo1->name, 'foo_value');
 
 my $foo2 = Genome::Foo->create(name => 'Joe');
 is($foo2->name, 'Joe');
+
+{
+    my $bar = Genome::Bar->create();
+    is($bar->name, 'foo_value', q(got 'foo_value' when 'bar.name' is not set));
+}
+
+{
+    my $guard = Genome::Config::set_env('bar.name', 'bar_value');
+    my $bar = Genome::Bar->create();
+    is($bar->name, 'bar_value', q(got 'bar_value' when 'bar.name' was set));
+}

--- a/lib/perl/Genome/Configurable.t
+++ b/lib/perl/Genome/Configurable.t
@@ -16,9 +16,7 @@ local $ENV{XGENOME_CONFIG_HOME} = $new_temp_dir->();
 local $ENV{XGENOME_CONFIG_DIRS} = $new_temp_dir->();
 setup_config(
     spec => {
-        'foo.name' => {
-            type => 'Str',
-        },
+        'foo.name' => {},
     },
     home => {
         'foo.name' => 'bar',

--- a/lib/perl/Genome/Configurable.t
+++ b/lib/perl/Genome/Configurable.t
@@ -19,7 +19,7 @@ setup_config(
         'foo.name' => {},
     },
     home => {
-        'foo.name' => 'bar',
+        'foo.name' => 'foo_value',
     },
 );
 
@@ -34,7 +34,7 @@ UR::Object::Type->define(
 );
 
 my $foo1 = Genome::Foo->create();
-is($foo1->name, 'bar');
+is($foo1->name, 'foo_value');
 
 my $foo2 = Genome::Foo->create(name => 'Joe');
 is($foo2->name, 'Joe');


### PR DESCRIPTION
I am not sure if this is useful or not yet.  As documented for
`Genome::Config::get_first()` the two use cases I am anticipating are:

- `Genome::Config::get_first($my_key, $parent_key, $grandparent_key)`
- `Genome::Config::get_first($new_key, $old_key)`