### PR TITLE
add `default_from` to config

### DIFF
--- a/lib/perl/Genome/Config.pm
+++ b/lib/perl/Genome/Config.pm
@@ -152,6 +152,19 @@ sub global_dirs {
     return map { Path::Class::Dir->new($_) } split(/:/, $dirs);
 }
 
+sub has_default_value {
+    my $spec = _normalize_spec(shift);
+    return $spec->has_default_value;
+}
+
+sub default_value {
+    my $spec = _normalize_spec(shift);
+    if ($spec->has_default_value) {
+        return $spec->default_value;
+    }
+    return;
+}
+
 =item _normalize_spec()
 
 C<_normalize_spec()> takes a key or spec as an input and returns the spec.
@@ -182,8 +195,8 @@ sub _lookup_value {
     @files = _lookup_files($config_subpath, snapshot_dir(), global_dirs());
     $value = _lookup_value_from_files($spec, @files);
 
-    if (!defined($value) && $spec->has_default_value) {
-        $value = $spec->default_value;
+    if (!defined($value) && has_default_value($spec)) {
+        $value = default_value($spec);
     }
 
     return $value;

--- a/lib/perl/Genome/Config.pm
+++ b/lib/perl/Genome/Config.pm
@@ -154,7 +154,7 @@ sub global_dirs {
 
 sub has_default_value {
     my $spec = _normalize_spec(shift);
-    return $spec->has_default_value;
+    return ($spec->has_default_value || $spec->has_default_from);
 }
 
 sub default_value {
@@ -162,6 +162,13 @@ sub default_value {
     if ($spec->has_default_value) {
         return $spec->default_value;
     }
+
+    # This could infinite loop but will reveal itself when someone runs `genome
+    # config validate` after making their change.
+    if ($spec->has_default_from) {
+        return default_value($spec->default_from);
+    }
+
     return;
 }
 

--- a/lib/perl/Genome/Config/Command/Validate.pm
+++ b/lib/perl/Genome/Config/Command/Validate.pm
@@ -51,8 +51,8 @@ sub execute {
             push @{ $env{$spec->env} }, $spec;
         }
 
-        if ($spec->has_default_value) {
-            my $error = $spec->validate($spec->default_value);
+        if (Genome::Config::has_default_value($spec)) {
+            my $error = $spec->validate(Genome::Config::default_value($spec));
             if (defined $error) {
                 printf("%s has an invalid default_value\n", $spec->key);
                 $return = 0;


### PR DESCRIPTION
This add a `default_from` field to the configuration spec allowing the default
value to be found via the specificed key.

This could allow a specific tool to use defaults for a common parent, e.g. all
the `gmt picard` commands could share a default value while allow each specific
command to be overridden in configuration.

It could also be used to help migrate configuration variables names (keys)
while coupling the `default_value`.