### PR TITLE
Call renamed accessor in search index command.

### DIFF
--- a/lib/perl/Genome/Sys/Command/Search/Index.pm
+++ b/lib/perl/Genome/Sys/Command/Search/Index.pm
@@ -43,7 +43,7 @@ sub execute {
     my $self = shift;
 
     # Manually init logger so it ties STDERR.
-    $self->log_dispatch();
+    $self->delegate_logger();
 
     if ($self->subject_text ne 'list') {
         my $confirmed = $self->prompt_for_confirmation() if $self->confirm;


### PR DESCRIPTION
The property name was changed in 9a7b89d0ce79eb135d72df0586a9faf41d654dac.