### PR TITLE
make lsf_resource configurable

### DIFF
--- a/etc/genome/spec/dv2.breakdancer.lsf_resource.yaml
+++ b/etc/genome/spec/dv2.breakdancer.lsf_resource.yaml
@@ -1,0 +1,3 @@
+---
+default_value: "-M 25000000 -R 'select[mem>25000] rusage[mem=25000]'"
+env: XGENOME_DV2_BREAKDANCER_LSF_RESOURCE

--- a/lib/perl/Genome/Config.pm
+++ b/lib/perl/Genome/Config.pm
@@ -9,6 +9,7 @@ use Genome::ConfigSpec qw();
 use Path::Class qw();
 use YAML::Syck qw();
 
+require Genome::Logger;
 require Scope::Guard;
 
 =item get()
@@ -60,6 +61,7 @@ sub get {
         $ENV{$spec->env} = $value;
     }
 
+    Genome::Logger->debugf(qq(got config value for '%s': %s\n), $key, $value);
     return $value;
 }
 

--- a/lib/perl/Genome/Logger.pm
+++ b/lib/perl/Genome/Logger.pm
@@ -10,6 +10,8 @@ use Module::Runtime qw(module_notional_filename use_package_optimistically);
 
 use UR;
 
+require Scalar::Util;
+
 class Genome::Logger {
     has => {
         delegate_logger => {
@@ -22,11 +24,13 @@ class Genome::Logger {
 my $logger;
 sub logger {
     my $class = shift;
-    if ($logger) {
+    if (Scalar::Util::blessed $logger
+        && $logger->isa($class)
+    ) {
         return $logger;
     }
 
-    $logger = Genome::Logger->create(
+    $logger = $class->create(
         delegate_logger => Log::Dispatch->new(@_),
     );
     $logger->delegate_logger->add(screen_to_add());

--- a/lib/perl/Genome/Model/Build/Command/ViewNotes.t
+++ b/lib/perl/Genome/Model/Build/Command/ViewNotes.t
@@ -61,14 +61,15 @@ is($c,1, 'returned expected number of notes');
 
 sub run_command {
     my $cmd = shift;
-    my ($fh, $file) = Genome::Sys->create_temp_file();
+    my $path = Genome::Sys->create_temp_file_path();
     my $rv;
     {
-        local *STDOUT = $fh;
+        local *STDOUT;
+        open(STDOUT, '>', $path) or die $!;
         $rv = $cmd->execute;
-        close *STDOUT;
+        close STDOUT;
     }
 
     ok($rv, "executed command");
-    return $file;
+    return $path;
 }

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Breakdancer.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Breakdancer.pm
@@ -10,7 +10,7 @@ use Genome::Utility::Text;
 my @FULL_CHR_LIST = (1..22, 'X', 'Y', 'MT');
 
 class Genome::Model::Tools::DetectVariants2::Breakdancer{
-    is => 'Genome::Model::Tools::DetectVariants2::Detector',
+    is => [qw(Genome::Model::Tools::DetectVariants2::Detector Genome::Configurable)],
     has => [
         _config_base_name => {
             is => 'Text',
@@ -73,7 +73,8 @@ class Genome::Model::Tools::DetectVariants2::Breakdancer{
     ],
     has_param => [
         lsf_resource => {
-            default_value => "-M 25000000 -R 'select[mem>25000] rusage[mem=25000]'",
+            is_classwide => 1,
+            config => 'dv2.breakdancer.lsf_resource',
         },
     ],
 };


### PR DESCRIPTION
The goal of this is to demonstrate how we can make `lsf_resource`, etc. configurable so that we no longer need to make custom snapshots just to boost the memory request.