### PR TITLE
don't need to use Genome here

### DIFF
--- a/lib/perl/Genome/Role/Logger.pm
+++ b/lib/perl/Genome/Role/Logger.pm
@@ -3,10 +3,12 @@ package Genome::Role::Logger;
 use strict;
 use warnings;
 
-use Genome;
+use UR;
 use Log::Dispatch;
 use Log::Dispatch::Screen;
 use Log::Dispatch::FileRotate;
+
+require Genome::Logger;
 
 my @log_levels = keys %Log::Dispatch::LEVELS;
 

--- a/lib/perl/Genome/Role/Logger.t
+++ b/lib/perl/Genome/Role/Logger.t
@@ -6,8 +6,6 @@ use warnings;
 use Test::More;
 use File::Temp;
 
-use above "Genome";
-
 use_ok('Genome::Role::Logger');
 
 test_stderr_tie();


### PR DESCRIPTION
I'm trying to avoid just blindly using Genome which can trigger accidental
circular dependencies if packages such as this are used by any of the packages
that are loading during `use Genome`.