### PR TITLE
minor update to clinseq to handle some edge cases

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/Converge/Base.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/Converge/Base.pm
@@ -36,10 +36,10 @@ class Genome::Model::ClinSeq::Command::Converge::Base {
               doc => 'minimum base quality of bases in reads to be considered',
               default => '20',
         },
-        force => { 
+        allow_multiple_individuals => { 
                is => 'Boolean',
                default_value => 0,
-               doc => 'allow unusual situtations (combining clin-seq builds across multiple individuals)',
+               doc => 'allow the user to combine clin-seq builds across multiple individuals (in cases that do not allow this)',
         },
     ],
     doc => 'converge various data types across clinseq inputs'
@@ -620,7 +620,7 @@ sub get_case_name{
   }
   my $nn = keys %names;
   if ($nn > 1){
-    if ($self->force){
+    if ($self->allow_multiple_individuals){
       $self->warning_message("$nn cases found among these builds, this tool was originally meant to operate on builds from a single individual, combining multiple individuals anyway");
     }else{
       die $self->error_message("$nn cases found among these builds, this tool is meant to operate on builds from a single individual");

--- a/lib/perl/Genome/Model/ClinSeq/Command/Converge/Base.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/Converge/Base.pm
@@ -36,6 +36,11 @@ class Genome::Model::ClinSeq::Command::Converge::Base {
               doc => 'minimum base quality of bases in reads to be considered',
               default => '20',
         },
+        force => { 
+               is => 'Boolean',
+               default_value => 0,
+               doc => 'allow unusual situtations (combining clin-seq builds across multiple individuals)',
+        },
     ],
     doc => 'converge various data types across clinseq inputs'
 };
@@ -615,7 +620,11 @@ sub get_case_name{
   }
   my $nn = keys %names;
   if ($nn > 1){
-    die $self->error_message("$nn cases found among these builds, this tool is meant to operate on builds from a single individual");
+    if ($self->force){
+      $self->warning_message("$nn cases found among these builds, this tool was originally meant to operate on builds from a single individual, combining multiple individuals anyway");
+    }else{
+      die $self->error_message("$nn cases found among these builds, this tool is meant to operate on builds from a single individual");
+    }
   }
 
   my $resolved_name;

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Genome;
 use Time::Piece;
+use List::MoreUtils qw(uniq);
 
 my $default_cancer_annotation_db_id = Genome::Model::ClinSeq->__meta__->property("cancer_annotation_db")->default_value;
 my $default_misc_annotation_db_id = Genome::Model::ClinSeq->__meta__->property("misc_annotation_db")->default_value;
@@ -997,8 +998,14 @@ sub get_genotype_microarray_model_id{
   #If there is no default genotype data defined, return 0
   return $genotype_microarray_model_id unless $default_genotype_data;
 
-  #If there is genotype microarray data, look for GenotypeMicroarray models
-  my @models = $sample->models;
+  #If there is default genotype microarray data, look for GenotypeMicroarray models
+  my @models1 = $sample->models;
+  my $id = Genome::InstrumentData->get(id => $default_genotype_data->id);
+  my @models2 = Genome::Model->get(instrument_data => $id);
+  my @models = @models1;
+  push(@models, @models2);
+  @models = uniq(@models);
+
   my @final_models;
   my @skipped;
   foreach my $model (@models){


### PR DESCRIPTION
Two minor things being committed:

1.) Allow users to run converge tools on a set of clin-seq build that span across multiple individuals (but only if they use the `--force` option because this should only be done carefully)

2.) When searching for existing genotype microarray models, now do this two ways.  First, obtain all genotype microarray models that are using the default_genotype_data for a sample.  Second, obtain all genotype microarray models that are associated with the sample (may or not be using the default_genotype_data).  

This is needed because occasionally the default_genotype_data for a sample is actually generated using *another* sample.  But we can't always use the first method because sometimes we have generated new genotype microarray data (and models) that we want to use, but the default_genotype_data didn't get updated... 