### PR TITLE
QC bugfix

### DIFF
--- a/lib/perl/Genome/Qc/Config.pm
+++ b/lib/perl/Genome/Qc/Config.pm
@@ -25,13 +25,13 @@ sub get_commands_for_alignment_result {
                 refseq_file => 'reference_sequence',
                 assume_sorted => 1,
                 use_version => 1.123,
-                output_file=> '/dev/null',
+                output_file=> 'output_file',
             },
         },
         picard_mark_duplicates => {
             class => 'Genome::Qc::Tool::Picard::MarkDuplicates',
             params => {
-                output_file => '/dev/null',
+                output_file => 'output_file',
                 input_file => 'bam_file',
                 use_version => 1.123,
             },

--- a/lib/perl/Genome/Qc/Config.pm
+++ b/lib/perl/Genome/Qc/Config.pm
@@ -26,6 +26,7 @@ sub get_commands_for_alignment_result {
                 assume_sorted => 1,
                 use_version => 1.123,
                 output_file=> 'output_file',
+                chart_output => 'chart_output',
             },
         },
         picard_mark_duplicates => {

--- a/lib/perl/Genome/Qc/Result.pm
+++ b/lib/perl/Genome/Qc/Result.pm
@@ -42,7 +42,7 @@ sub _run {
             name => $name,
             args => [$tool->cmd_line],
             in_file_link => $self->_input_file_for_tool($tool, $name),
-            out_file_link => $self->_output_file_for_tool($name),
+            out_file_link => $self->_qc_metrics_file_for_tool($name),
             err_file_link => $self->_error_file_for_tool($name),
         );
         $process_graph->add_process($process_ref{$name});
@@ -90,7 +90,7 @@ sub _error_file_for_tool {
     return undef;
 }
 
-sub _output_file_for_tool {
+sub _qc_metrics_file_for_tool {
     my ($self, $name) = @_;
     my $file_name = $self->qc_config->get_commands_for_alignment_result($self->is_capture)->{$name}->{out_file};
     if (defined $file_name) {
@@ -125,8 +125,8 @@ sub _non_streaming_tools {
 
 sub _tool_from_name_and_params {
     my ($self, $name, $gmt_params) = @_;
-    if (defined $name->output_file_accessor) {
-        my $output_param_name = $name->output_file_accessor;
+    if (defined $name->qc_metrics_file_accessor) {
+        my $output_param_name = $name->qc_metrics_file_accessor;
         $gmt_params->{$output_param_name} = Genome::Sys->create_temp_file_path;
     }
     my $tool = $name->create(gmt_params => $gmt_params, alignment_result => $self->alignment_result);

--- a/lib/perl/Genome/Qc/Tool.pm
+++ b/lib/perl/Genome/Qc/Tool.pm
@@ -28,11 +28,11 @@ sub cmd_line {
     die $self->error_message("Abstract method run must be overriden by subclass");
 }
 
-sub output_file {
+sub qc_metrics_file {
     my $self = shift;
-    my $output_file_accessor = $self->output_file_accessor;
+    my $qc_metrics_file_accessor = $self->qc_metrics_file_accessor;
     my %params = %{$self->gmt_params};
-    return $params{$output_file_accessor};
+    return $params{$qc_metrics_file_accessor};
 }
 
 sub supports_streaming {
@@ -46,7 +46,7 @@ sub get_metrics {
 }
 
 # Overwrite this in subclass to return the gmt tool parameter name for the output file
-sub output_file_accessor {
+sub qc_metrics_file_accessor {
     return undef;
 }
 

--- a/lib/perl/Genome/Qc/Tool/Picard.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard.pm
@@ -18,7 +18,7 @@ sub cmd_line {
 sub get_metrics {
     my $self = shift;
 
-    my $file = $self->output_file;
+    my $file = $self->qc_metrics_file;
     my $gmt_class = $self->gmt_class;
     my %metrics = $self->metrics;
     my $metric_results = $gmt_class->parse_file_into_metrics_hashref($file);

--- a/lib/perl/Genome/Qc/Tool/Picard/CalculateHsMetrics.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard/CalculateHsMetrics.pm
@@ -12,7 +12,7 @@ sub supports_streaming {
     return 1;
 }
 
-sub output_file_accessor {
+sub qc_metrics_file_accessor {
     return 'output_file';
 }
 

--- a/lib/perl/Genome/Qc/Tool/Picard/CollectGcBiasMetrics.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard/CollectGcBiasMetrics.pm
@@ -31,6 +31,10 @@ sub gmt_class {
     return 'Genome::Model::Tools::Picard::CollectGcBiasMetrics';
 }
 
+sub chart_output {
+    return Genome::Sys->create_temp_file_path();
+}
+
 sub output_file {
     return Genome::Sys->create_temp_file_path();
 }

--- a/lib/perl/Genome/Qc/Tool/Picard/CollectGcBiasMetrics.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard/CollectGcBiasMetrics.pm
@@ -31,4 +31,8 @@ sub gmt_class {
     return 'Genome::Model::Tools::Picard::CollectGcBiasMetrics';
 }
 
+sub output_file {
+    return Genome::Sys->create_temp_file_path();
+}
+
 1;

--- a/lib/perl/Genome/Qc/Tool/Picard/CollectGcBiasMetrics.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard/CollectGcBiasMetrics.pm
@@ -12,7 +12,7 @@ sub supports_streaming {
     return 1;
 }
 
-sub output_file_accessor {
+sub qc_metrics_file_accessor {
     return 'summary_output';
 }
 

--- a/lib/perl/Genome/Qc/Tool/Picard/CollectMultipleMetrics.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard/CollectMultipleMetrics.pm
@@ -66,7 +66,7 @@ sub gmt_class_for_file_extension {
     return $file_extension_to_gmt_class{$file_extension};
 }
 
-sub output_file_accessor {
+sub qc_metrics_file_accessor {
     return 'output_basename';
 }
 
@@ -76,7 +76,7 @@ sub get_metrics {
     my %desired_metric_results;
     my %metrics = $self->metrics;
     while (my ($tool, $tool_metrics) = each %metrics) {
-        my $base = $self->output_file;
+        my $base = $self->qc_metrics_file;
         my $file = join('.', $base, $tool);
         my $gmt_class = $self->gmt_class_for_file_extension($tool);
         my %metric_results = %{$gmt_class->parse_file_into_metrics_hashref($file)};

--- a/lib/perl/Genome/Qc/Tool/Picard/CollectWgsMetrics.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard/CollectWgsMetrics.pm
@@ -12,7 +12,7 @@ sub supports_streaming {
     return 1;
 }
 
-sub output_file_accessor {
+sub qc_metrics_file_accessor {
     return 'output_file';
 }
 

--- a/lib/perl/Genome/Qc/Tool/Picard/MarkDuplicates.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard/MarkDuplicates.pm
@@ -34,4 +34,8 @@ sub gmt_class {
     return 'Genome::Model::Tools::Picard::MarkDuplicates';
 }
 
+sub output_file {
+    return Genome::Sys->create_temp_file_path();
+}
+
 1;

--- a/lib/perl/Genome/Qc/Tool/Picard/MarkDuplicates.pm
+++ b/lib/perl/Genome/Qc/Tool/Picard/MarkDuplicates.pm
@@ -12,7 +12,7 @@ sub supports_streaming {
     return 1;
 }
 
-sub output_file_accessor {
+sub qc_metrics_file_accessor {
     return 'metrics_file';
 }
 


### PR DESCRIPTION
This fixes a bug in the Picard CollectGcBiasMetrics qc tool where the chart_output param would default to the cwd. We're not interested in the contents of this file for qc so we just write it to a temp file.

I also did some subroutine renaming for clarity.