### PR TITLE
Reduce Build Loading in ModelSummary

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -295,6 +295,8 @@ sub determine_error_for_build {
 sub find_first_nondone_step {
     my $build = shift;
 
+    return if grep { $_ eq $build->status } ('Succeeded', 'Scheduled', 'Unstartable', 'New');
+
     # The following is wrapped in a transaction and try to protect against
     # "corrupt" Workflow::Models.
     my $tx = UR::Context::Transaction->begin();

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -55,8 +55,6 @@ sub execute {
     my @models = $self->models;
     my @hide_statuses = $self->hide_statuses;
 
-    my $synchronous = ($self->auto and $self->auto_batch_size);  # whether we should start builds as we go or wait until the end
-
     # Header for the report produced at the end of the loop
     $self->print_message(join("\t", qw(model_id action latest_build_status first_nondone_step latest_build_rev model_name pp_name fail_count)));
     $self->print_message(join("\t", qw(-------- ------ ------------------- ------------------ ---------------- ---------- ------- ----------)));


### PR DESCRIPTION
As promised, here's the next phase of ModelSummary revisions.  We now use sets and iterators to avoid loading most builds.

Some of the functionality has changed. Many places are more selective about which builds are considered.  (`Abandoned` builds are more consistently ignored; deciding whether a model "has progressed" now considers the previous failure (whether `Failed` or `Unstartable`)).

I'm not sure this works properly for builds with `Unknown` status...