### PR TITLE
AlignAndMerge only creates per-lane alignment objects without revivification

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -461,10 +461,7 @@ sub _generate_result {
     $self->_prepare_working_and_staging_directories;
 
     # STEP 5: PREPARE REFERENCE SEQUENCES
-    unless($self->_prepare_reference_sequences) {
-        $self->error_message("Reference sequences are invalid.  We can't proceed:  " . $self->error_message);
-        die $self->error_message();
-    }
+    $self->_prepare_reference_sequences;
 
     eval {
 
@@ -477,10 +474,7 @@ sub _generate_result {
 
         # STEP 7: PREPARE THE ALIGNMENT FILE (groups file, sequence dictionary)
         # this also prepares the bam output pipe and crams the alignment headers through it.
-        unless ($self->prepare_scratch_sam_file) {
-            $self->error_message("Failed to prepare the scratch sam file with groups and sequence dictionary");
-            die $self->error_message;
-        }
+        $self->prepare_scratch_sam_file;
 
         # STEP 7: RUN THE ALIGNER
         unless ($self->run_aligner(@inputs)) {
@@ -492,10 +486,7 @@ sub _generate_result {
         if ($self->supports_streaming_to_bam) {
             $self->close_out_streamed_bam_file;
         } else {
-            unless( $self->create_BAM_in_staging_directory()) {
-                $self->error_message("Call to create_BAM_in_staging_directory failed.\n");
-                die $self->error_message;
-            }
+            $self->create_BAM_in_staging_directory;
         }
     };
 
@@ -515,10 +506,7 @@ sub _generate_result {
     }
 
     # STEP 9-10, validate BAM file (if necessary)
-    unless ($self->postprocess_bam_file()) {
-        $self->error_message("Postprocess BAM file failed");
-        die $self->error_message;
-    }
+    $self->postprocess_bam_file;
 
     # STEP 11: COMPUTE ALIGNMENT METRICS
     $self->_compute_alignment_metrics();
@@ -531,11 +519,7 @@ sub _generate_result {
 
     # STEP 13: PROMOTE THE DATA INTO ALIGNMENT DIRECTORY
     $self->debug_message("Moving results to network disk...");
-    my $product_path;
-    unless($product_path= $self->_promote_data) {
-        $self->error_message("Failed to de-stage data into alignment directory " . $self->error_message);
-        die $self->error_message;
-    }
+    $self->_promote_data;
 
     # STEP 14: RESIZE THE DISK
     $self->_reallocate_disk_allocation;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1112,7 +1112,7 @@ sub create_bam_flagstat {
         die $self->error_message('BAM file (%s) does not exist or is empty', $bam_file);
     }
 
-    my $guard  = $self->get_bam_lock->unlock_guard();
+    my $guard  = $self->get_bam_lock(__PACKAGE__)->unlock_guard();
     return 1 if -e $output_file;
 
     my $cmd = Genome::Model::Tools::Sam::Flagstat->create(
@@ -1133,7 +1133,7 @@ sub create_bam_header {
     my $self = shift;
     return $self->bam_header_path if -s $self->bam_header_path;
 
-    my $guard  = $self->get_bam_lock->unlock_guard();
+    my $guard  = $self->get_bam_lock(__PACKAGE__)->unlock_guard();
     return $self->bam_header_path if -s $self->bam_header_path;
 
     my $sam_path = Genome::Model::Tools::Sam->path_for_samtools_version($self->samtools_version);
@@ -1723,7 +1723,7 @@ sub get_bam_file {
         return $self->revivified_alignment_bam_file_path;
     }
     else {
-        my $guard = $self->get_bam_lock->unlock_guard();
+        my $guard = $self->get_bam_lock(__PACKAGE__)->unlock_guard();
 
         if ($self->get_merged_alignment_results) {
             return $self->revivified_alignment_bam_file_path;
@@ -1766,8 +1766,9 @@ sub get_bam_file {
 
 sub get_bam_lock {
     my $self = shift;
+    my $package = shift;
 
-    my $resource = File::Spec->join('genome', __PACKAGE__, 'lock-per-lane-alignment-'.$self->id);
+    my $resource = File::Spec->join('genome', $package, 'lock-per-lane-alignment-'.$self->id);
     my $lock = Genome::Sys::LockProxy->new(
         resource => $resource,
         scope => 'site',
@@ -1784,7 +1785,7 @@ sub remove_bam {
     my $self = shift;
 
     my $bam_path = $self->bam_path;
-    my $guard = $self->get_bam_lock->unlock_guard();
+    my $guard = $self->get_bam_lock(__PACKAGE__)->unlock_guard();
 
     for my $type ('', '.bai', '.md5') {
         my $file = $bam_path . $type;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1035,7 +1035,7 @@ sub postprocess_bam_file {
 
     $self->debug_message("Indexing BAM file ...");
     unless($self->_create_bam_index) {
-        $self->error_message('Fail to create bam md5');
+        $self->error_message('Fail to create bam index');
         die $self->error_message;
     }
     return 1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -433,6 +433,19 @@ sub create {
     my $self = $class->SUPER::create(@_);
     return unless $self;
 
+    $self->post_create;
+
+    return $self;
+}
+
+sub post_create {
+    my $self = shift;
+    $self->_generate_result;
+}
+
+sub _generate_result {
+    my $self = shift;
+
     if (my $output_dir = $self->output_dir) {
         if (-d $output_dir) {
             $self->debug_message("BACKFILL DIRECTORY: $output_dir!");
@@ -551,7 +564,6 @@ sub create {
     $self->_reallocate_disk_allocation;
 
     $self->status_message("Alignment complete.");
-    return $self;
 }
 
 sub delete {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -104,6 +104,14 @@ sub _check_read_count {
     return $self->SUPER::_check_read_count($filtered_bam_rd_ct);
 }
 
+sub _create_bam_md5 {
+    return 1;
+}
+
+sub _create_bam_index {
+    return 1;
+}
+
 sub _promote_data {
     my $self = shift;
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -55,15 +55,17 @@ sub _inititalize_revivified_bam {
     $self->_create_disk_allocation;
 
     $self->_prepare_working_and_staging_directories;
-    $self->_prepare_output_directory;
-    my $bam_file = $self->SUPER::get_bam_file;
-    $self->postprocess_bam_file;
-    $self->_compute_alignment_metrics();
 
     $self->debug_message("Preparing the output directory...");
     $self->debug_message("Staging disk usage is " . $self->_staging_disk_usage . " KB");
     my $output_dir = $self->output_dir || $self->_prepare_output_directory;
     $self->debug_message("Alignment output path is $output_dir");
+
+    my $bam_file = $self->SUPER::get_bam_file;
+
+    $self->postprocess_bam_file;
+
+    $self->_compute_alignment_metrics;
 
     $self->debug_message("Moving results to network disk...");
     $self->_promote_data;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -13,12 +13,7 @@ class Genome::InstrumentData::AlignmentResult::Speedseq {
     ],
 };
 
-sub _run_aligner {
-    my $self = shift;
-
-    #Run get_bam_file to fake revivify the per-lane bams
-    $self->_prepare_output_directory;
-    $self->get_bam_file;
+sub post_create {
     return 1;
 }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -57,10 +57,7 @@ sub _inititalize_revivified_bam {
     $self->_prepare_working_and_staging_directories;
     $self->_prepare_output_directory;
     my $bam_file = $self->SUPER::get_bam_file;
-    unless ($self->postprocess_bam_file()) {
-        $self->error_message("Postprocess BAM file failed");
-        die $self->error_message;
-    }
+    $self->postprocess_bam_file;
     $self->_compute_alignment_metrics();
 
     $self->debug_message("Preparing the output directory...");
@@ -69,11 +66,7 @@ sub _inititalize_revivified_bam {
     $self->debug_message("Alignment output path is $output_dir");
 
     $self->debug_message("Moving results to network disk...");
-    my $product_path;
-    unless($product_path= $self->_promote_data) {
-        $self->error_message("Failed to de-stage data into alignment directory " . $self->error_message);
-        die $self->error_message;
-    }
+    $self->_promote_data;
 
     $self->_reallocate_disk_allocation;
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -24,29 +24,13 @@ sub get_bam_file {
     # delayed until the first time that the bam file is revivified.
     # If we don't have an allocation then this is the first revivification and
     # we will need to do post-processing.
-    my $guard = $self->get_speedseq_bam_lock->unlock_guard();
+    my $guard = $self->get_bam_lock(__PACKAGE__)->unlock_guard();
     unless ($self->disk_allocations) {
         return $self->_inititalize_revivified_bam;
     }
     else {
         return $self->SUPER::get_bam_file;
     }
-}
-
-sub get_speedseq_bam_lock {
-    my $self = shift;
-
-    my $resource = File::Spec->join('genome', __PACKAGE__, 'lock-per-lane-alignment-'.$self->id);
-    my $lock = Genome::Sys::LockProxy->new(
-        resource => $resource,
-        scope => 'site',
-    )->lock(
-        max_try => 288, # Try for 48 hours every 10 minutes
-        block_sleep => 600,
-    );
-
-    die $self->error_message("Unable to acquire the lock for per lane alignment result id (%s) !", $self->id) unless $lock;
-    return $lock;
 }
 
 sub _inititalize_revivified_bam {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -54,22 +54,13 @@ sub _inititalize_revivified_bam {
 
     $self->_create_disk_allocation;
 
-    $self->debug_message("Prepare working directories...");
     $self->_prepare_working_and_staging_directories;
-    $self->debug_message("Staging path is " . $self->temp_staging_directory);
-    $self->debug_message("Working path is " . $self->temp_scratch_directory);
-
     $self->_prepare_output_directory;
-
     my $bam_file = $self->SUPER::get_bam_file;
-
-    $self->debug_message("Postprocessing & Sanity Checking BAM file (if necessary)...");
     unless ($self->postprocess_bam_file()) {
         $self->error_message("Postprocess BAM file failed");
         die $self->error_message;
     }
-
-    $self->debug_message("Computing alignment metrics...");
     $self->_compute_alignment_metrics();
 
     $self->debug_message("Preparing the output directory...");

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.t
@@ -86,16 +86,23 @@ isa_ok($alignment_result, $pkg, 'Alignment result is a speedseq alignment');
 is(-e File::Spec->join($alignment_result->temp_staging_directory, 'all_sequences.bam'), undef, "Per-lane bam file doesn't exist in temp_staging_directory");
 is(-e File::Spec->join($alignment_result->output_dir, 'all_sequences.bam'), undef, "Per-lane bam file doesn't exist in output_dir");
 
-ok(-e $alignment_result->bam_flagstat_path, "Flagstat file exists");
-ok(-e $alignment_result->bam_header_path, "Header file exists");
+ok(!(-e $alignment_result->bam_flagstat_path), "Flagstat file doesn't exist after initial object creation");
+ok(!(-e $alignment_result->bam_header_path), "Header file doesn't exist after initial object creation");
+ok(!($alignment_result->_revivified_bam_file_path), "Bam file hasn't been revivified-created during initial object creation");
+
+my $bam_file = $alignment_result->get_bam_file;
+ok($bam_file, 'Bam file got created');
 
 my $cmp = Genome::Model::Tools::Sam::Compare->execute(
-    file1 => $alignment_result->get_bam_file,
+    file1 => $bam_file,
     file2 => File::Spec->join($test_data_dir, 'alignment_result.bam'),
 );
 ok($cmp->result, 'Per-lane bam as expected');
 
+ok(-e $alignment_result->bam_flagstat_path, 'Flagstat file exists');
+ok(-e $alignment_result->bam_header_path, 'Header file exists');
+
 $alignment_result->_revivified_bam_file_path(undef);
-ok($alignment_result->get_bam_file, "Subsequent revivifications work correctly");
+ok($alignment_result->get_bam_file, 'Subsequent revivifications work correctly');
 
 done_testing;


### PR DESCRIPTION
Previously the AlignAndMerge step would create a merged alignment object (e.g. run Speedseq) and then use it to create the per-lane alignment objects. We would use revivification to create the per-lane bam so that we could create a .header and .flagstat file (and do some other per-lane alignment processing). As a result of having to revivifiy each per-lane bam for all the instrument data (in serial), the AlignAndMerge step would run extremely long.

This PR makes it so that the AlignAndMerge step will still run the aligner to create the merged alignment object but this step will only create the per-lane alignment objects without any further processing. .header and .flagstat file creation are postponed until the first call to get_bam_file. Calling this subroutine will run revivification anyway and we then do all the necessary post-processing at this point.