### PR TITLE
Set a default tmp space request for SomaticVariation's CreateReport step

### DIFF
--- a/lib/perl/Genome/Model/SomaticVariation/Command/CreateReport.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/CreateReport.pm
@@ -85,6 +85,11 @@ class Genome::Model::SomaticVariation::Command::CreateReport {
             is => 'Genome::Disk::Allocation',
         },
     ],
+    has_param => [
+        lsf_resource => {
+            default => "-R 'select[tmp>2000] rusage[tmp=2000]'",
+        },
+    ],
 };
 
 


### PR DESCRIPTION
A recent build failed because `/tmp` was full.  Since this step uses `/tmp`, request some!