### PR TITLE
Update speedseq test version to our frozen version

### DIFF
--- a/lib/perl/Genome/Model/Tools/Speedseq/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Speedseq/Base.pm
@@ -59,7 +59,7 @@ sub help_detail {
 }
 
 my %TOOL_VERSIONS = (
-    'test'     => '/gscmnt/gc2719/halllab/users/cchiang/bin/speedseq',
+    'test'     => '/gscmnt/sata849/info/speedseq_freeze/v1/speedseq/bin/speedseq',
 );
 
 sub available_versions {

--- a/lib/perl/Genome/Model/Tools/Speedseq/Base.t
+++ b/lib/perl/Genome/Model/Tools/Speedseq/Base.t
@@ -10,7 +10,7 @@ my $pkg = 'Genome::Model::Tools::Speedseq::Base';
 use_ok ($pkg);
 
 my $version = 'test';
-my $expected_path = '/gscmnt/gc2719/halllab/users/cchiang/bin/speedseq';
+my $expected_path = '/gscmnt/sata849/info/speedseq_freeze/v1/speedseq/bin/speedseq';
 
 
 my $path = $pkg->path_for_version($version);


### PR DESCRIPTION
I made a local install of the gms branch of speedseq at `/gscmnt/sata849/info/speedseq_freeze/v1/speedseq/bin/speedseq`. This is a precursor to ultimately packaging speedseq. Right now we just wanted to stop pointing to the Hall lab version of speedseq and have a local version installed so that we aren't affected by changes in the Hall lab install. 

Right now /gscmnt/sata849/info/speedseq_freeze/v1/speedseq/bin/speedseq.config points to `PYTHON=/gscmnt/gc2719/halllab/bin/gemini_python` because `/usr/bin/python2.7 doesn't have pysam installed. This is being addressed by systems in https://jira.gsc.wustl.edu/browse/INFOSYS-16236. Once python has been updated I will update  the config file to point to our /usr/bin version, thus removing the last dependency on any local Hall lab installs.