### PR TITLE
Remove Doubled-Up SmallRNA Workflow Links

### DIFF
--- a/lib/perl/Genome/Model/SmallRna.pm.xml
+++ b/lib/perl/Genome/Model/SmallRna.pm.xml
@@ -19,8 +19,6 @@
   <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" toOperation="output connector" toProperty="normalized_filtered_bam" />
   <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" toOperation="SmallRnaWorkflow" toProperty="normalized_bam_file" />
 
-  <link fromOperation="FilterBamFlagstat" fromProperty="result" toOperation="output connector" toProperty="result" />
-
   <operation name="FilterBamFlagstat">
     <operationtype commandClass="Genome::Model::SmallRna::Command::FilterBamFlagstat" typeClass="Workflow::OperationType::Command" />
   </operation>

--- a/lib/perl/Genome/Model/SmallRna.pm.xml
+++ b/lib/perl/Genome/Model/SmallRna.pm.xml
@@ -1,55 +1,54 @@
 <?xml version='1.0' standalone='yes'?>
 
 <workflow name="Parallel Workflow" logDir="/gscmnt/sata142/techd/jhundal/miRNA_logs/" >
-<link fromOperation="input connector" fromProperty="bam_file"    toOperation="SmallRnaWorkflow" toProperty="bam_file" />
-<link fromOperation="input connector" fromProperty="output_base_dir"    toOperation="SmallRnaWorkflow" toProperty="output_base_dir" />
-<link fromOperation="input connector" fromProperty="annotation_files"  toOperation="SmallRnaWorkflow" toProperty="annotation_files" />  
-<link fromOperation="input connector" fromProperty="annotation_name"  	 	toOperation="SmallRnaWorkflow" toProperty="annotation_name" />
-<link fromOperation="input connector" fromProperty="minimum_zenith"    toOperation="SmallRnaWorkflow" toProperty="minimum_zenith" />
-<link fromOperation="input connector" fromProperty="minimum_depth"    toOperation="SmallRnaWorkflow" toProperty="minimum_depth" />
+  <link fromOperation="input connector" fromProperty="bam_file" toOperation="SmallRnaWorkflow" toProperty="bam_file" />
+  <link fromOperation="input connector" fromProperty="output_base_dir" toOperation="SmallRnaWorkflow" toProperty="output_base_dir" />
+  <link fromOperation="input connector" fromProperty="annotation_files" toOperation="SmallRnaWorkflow" toProperty="annotation_files" />
+  <link fromOperation="input connector" fromProperty="annotation_name" toOperation="SmallRnaWorkflow" toProperty="annotation_name" />
+  <link fromOperation="input connector" fromProperty="minimum_zenith" toOperation="SmallRnaWorkflow" toProperty="minimum_zenith" />
+  <link fromOperation="input connector" fromProperty="minimum_depth" toOperation="SmallRnaWorkflow" toProperty="minimum_depth" />
 
-<link fromOperation="input connector" fromProperty="size_bins"    toOperation="SmallRnaWorkflow" toProperty="read_size_bin" />
-<link fromOperation="input connector" fromProperty="subcluster_min_mapzero" toOperation="SmallRnaWorkflow" toProperty="subcluster_min_mapzero" />
-<link fromOperation="input connector" fromProperty="input_cluster_number"  toOperation="SmallRnaWorkflow" toProperty="input_cluster_number" />
+  <link fromOperation="input connector" fromProperty="size_bins" toOperation="SmallRnaWorkflow" toProperty="read_size_bin" />
+  <link fromOperation="input connector" fromProperty="subcluster_min_mapzero" toOperation="SmallRnaWorkflow" toProperty="subcluster_min_mapzero" />
+  <link fromOperation="input connector" fromProperty="input_cluster_number" toOperation="SmallRnaWorkflow" toProperty="input_cluster_number" />
 
-<link fromOperation="input connector" fromProperty="normalization_bin"    toOperation="FilterBamFlagstat" toProperty="read_size_bin" />
-<link fromOperation="input connector" fromProperty="bam_file"   		  toOperation="FilterBamFlagstat" toProperty="bam_file" />
-<link fromOperation="input connector" fromProperty="normalized_filtered_bam"    toOperation="FilterBamFlagstat" toProperty="filtered_bam_file" />
- 
- <link fromOperation="FilterBamFlagstat" 	 fromProperty="filtered_bam_file" toOperation="output connector" toProperty="normalized_filtered_bam" />
- <link fromOperation="FilterBamFlagstat"      fromProperty="filtered_bam_file" toOperation="SmallRnaWorkflow" toProperty="normalized_bam_file" />
- 
- <link fromOperation="FilterBamFlagstat" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
+  <link fromOperation="input connector" fromProperty="normalization_bin" toOperation="FilterBamFlagstat" toProperty="read_size_bin" />
+  <link fromOperation="input connector" fromProperty="bam_file" toOperation="FilterBamFlagstat" toProperty="bam_file" />
+  <link fromOperation="input connector" fromProperty="normalized_filtered_bam" toOperation="FilterBamFlagstat" toProperty="filtered_bam_file" />
 
-<operation name="FilterBamFlagstat">
-	<operationtype commandClass="Genome::Model::SmallRna::Command::FilterBamFlagstat" typeClass="Workflow::OperationType::Command" />
-    </operation>
+  <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" toOperation="output connector" toProperty="normalized_filtered_bam" />
+  <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" toOperation="SmallRnaWorkflow" toProperty="normalized_bam_file" />
 
-<link fromOperation="FilterBamFlagstat" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
- 
-   	<operation name="SmallRnaWorkflow" parallelBy="read_size_bin">
-	<operationtype commandClass="Genome::Model::SmallRna::Command::SmallRnaWorkflow" typeClass="Workflow::OperationType::Command" />
-    </operation>
- 
-  <link fromOperation="SmallRnaWorkflow" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
- 
-    <operationtype typeClass="Workflow::OperationType::Model">
-    
-    <inputproperty>bam_file</inputproperty>   
- 	<inputproperty>size_bins</inputproperty>
-	 <inputproperty>minimum_zenith</inputproperty>
-	  <inputproperty>minimum_depth</inputproperty>
-     <inputproperty>annotation_files</inputproperty>
-     <inputproperty>annotation_name</inputproperty>
-     <inputproperty>output_base_dir</inputproperty>
-      <inputproperty>subcluster_min_mapzero</inputproperty>
-	<inputproperty>input_cluster_number</inputproperty>	
-	<inputproperty>normalization_bin</inputproperty>  
-	<inputproperty>normalized_filtered_bam</inputproperty>  
-    
-     <outputproperty>normalized_filtered_bam</outputproperty>
-	<outputproperty>result</outputproperty>
+  <link fromOperation="FilterBamFlagstat" fromProperty="result" toOperation="output connector" toProperty="result" />
+
+  <operation name="FilterBamFlagstat">
+    <operationtype commandClass="Genome::Model::SmallRna::Command::FilterBamFlagstat" typeClass="Workflow::OperationType::Command" />
+  </operation>
+
+  <link fromOperation="FilterBamFlagstat" fromProperty="result" toOperation="output connector" toProperty="result" />
+
+  <operation name="SmallRnaWorkflow" parallelBy="read_size_bin">
+    <operationtype commandClass="Genome::Model::SmallRna::Command::SmallRnaWorkflow" typeClass="Workflow::OperationType::Command" />
+  </operation>
+
+  <link fromOperation="SmallRnaWorkflow" fromProperty="result" toOperation="output connector" toProperty="result" />
+
+  <operationtype typeClass="Workflow::OperationType::Model">
+    <inputproperty>bam_file</inputproperty>
+    <inputproperty>size_bins</inputproperty>
+    <inputproperty>minimum_zenith</inputproperty>
+    <inputproperty>minimum_depth</inputproperty>
+    <inputproperty>annotation_files</inputproperty>
+    <inputproperty>annotation_name</inputproperty>
+    <inputproperty>output_base_dir</inputproperty>
+    <inputproperty>subcluster_min_mapzero</inputproperty>
+    <inputproperty>input_cluster_number</inputproperty>
+    <inputproperty>normalization_bin</inputproperty>
+    <inputproperty>normalized_filtered_bam</inputproperty>
+
+    <outputproperty>normalized_filtered_bam</outputproperty>
+    <outputproperty>result</outputproperty>
   </operationtype>
-  
+
 </workflow>
-  
+

--- a/lib/perl/Genome/Model/SmallRna.pm.xml
+++ b/lib/perl/Genome/Model/SmallRna.pm.xml
@@ -23,13 +23,13 @@
     <operationtype commandClass="Genome::Model::SmallRna::Command::FilterBamFlagstat" typeClass="Workflow::OperationType::Command" />
   </operation>
 
-  <link fromOperation="FilterBamFlagstat" fromProperty="result" toOperation="output connector" toProperty="result" />
+  <link fromOperation="FilterBamFlagstat" fromProperty="result" toOperation="output connector" toProperty="filter_bam_flagstat_result" />
 
   <operation name="SmallRnaWorkflow" parallelBy="read_size_bin">
     <operationtype commandClass="Genome::Model::SmallRna::Command::SmallRnaWorkflow" typeClass="Workflow::OperationType::Command" />
   </operation>
 
-  <link fromOperation="SmallRnaWorkflow" fromProperty="result" toOperation="output connector" toProperty="result" />
+  <link fromOperation="SmallRnaWorkflow" fromProperty="result" toOperation="output connector" toProperty="small_rna_result" />
 
   <operationtype typeClass="Workflow::OperationType::Model">
     <inputproperty>bam_file</inputproperty>
@@ -45,7 +45,8 @@
     <inputproperty>normalized_filtered_bam</inputproperty>
 
     <outputproperty>normalized_filtered_bam</outputproperty>
-    <outputproperty>result</outputproperty>
+    <outputproperty>small_rna_result</outputproperty>
+    <outputproperty>filter_bam_flagstat_result</outputproperty>
   </operationtype>
 
 </workflow>

--- a/lib/perl/Genome/Model/SmallRna.pm.xml
+++ b/lib/perl/Genome/Model/SmallRna.pm.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' standalone='yes'?>
 
-<workflow name="Parallel Workflow" logDir="/gscmnt/sata142/techd/jhundal/miRNA_logs/" >
+<workflow name="Parallel Workflow">
   <link fromOperation="input connector" fromProperty="bam_file" toOperation="SmallRnaWorkflow" toProperty="bam_file" />
   <link fromOperation="input connector" fromProperty="output_base_dir" toOperation="SmallRnaWorkflow" toProperty="output_base_dir" />
   <link fromOperation="input connector" fromProperty="annotation_files" toOperation="SmallRnaWorkflow" toProperty="annotation_files" />

--- a/lib/perl/Genome/Model/SmallRna/Command/SmallRnaWorkflow.xml
+++ b/lib/perl/Genome/Model/SmallRna/Command/SmallRnaWorkflow.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' standalone='yes'?>
 
-<workflow name="SmallRna Workflow" logDir="/gscmnt/sata142/techd/jhundal/miRNA_logs/" >
+<workflow name="SmallRna Workflow">
   <link fromOperation="input connector" fromProperty="input_bam_file" toOperation="FilterBamFlagstat" toProperty="bam_file" />
   <link fromOperation="input connector" fromProperty="filtered_bam_file" toOperation="FilterBamFlagstat" toProperty="filtered_bam_file" />
   <link fromOperation="input connector" fromProperty="read_size_bin" toOperation="FilterBamFlagstat" toProperty="read_size_bin" />

--- a/lib/perl/Genome/Model/SmallRna/Command/SmallRnaWorkflow.xml
+++ b/lib/perl/Genome/Model/SmallRna/Command/SmallRnaWorkflow.xml
@@ -44,17 +44,9 @@
 
   <link fromOperation="AnnotateCluster" fromProperty="output_tsv_file" toOperation="output connector" toProperty="output_tsv_file" />
 
-  <link fromOperation="FilterBamFlagstat" fromProperty="result" toOperation="output connector" toProperty="result" />
-  <link fromOperation="ClusterCoverage" fromProperty="result" toOperation="output connector" toProperty="result" />
-
-  <link fromOperation="StatsGenerator" fromProperty="result" toOperation="output connector" toProperty="result" />
-  <link fromOperation="AnnotateCluster" fromProperty="result" toOperation="output connector" toProperty="result" />
-  <link fromOperation="Spreadsheet" fromProperty="result" toOperation="output connector" toProperty="result" />
-
   <link fromOperation="StatsGenerator" fromProperty="output_stats_file" toOperation="Spreadsheet"  toProperty="input_stats_file" />
   <link fromOperation="AnnotateCluster" fromProperty="output_tsv_file" toOperation="Spreadsheet" toProperty="input_intersect_file" />
   <link fromOperation="Spreadsheet" fromProperty="output_spreadsheet" toOperation="output connector" toProperty="output_spreadsheet" />
-  <link fromOperation="Spreadsheet" fromProperty="result" toOperation="output connector" toProperty="result" />
 
 
   <operation name="FilterBamFlagstat">
@@ -108,7 +100,6 @@
     <outputproperty>output_tsv_file</outputproperty>
     <outputproperty>output_subclusters_file</outputproperty>
     <outputproperty>output_spreadsheet</outputproperty>
-    <outputproperty>result</outputproperty>
   </operationtype>
 
 </workflow>

--- a/lib/perl/Genome/Model/SmallRna/Command/SmallRnaWorkflow.xml
+++ b/lib/perl/Genome/Model/SmallRna/Command/SmallRnaWorkflow.xml
@@ -29,7 +29,6 @@
   <link fromOperation="input connector" fromProperty="output_spreadsheet" toOperation="Spreadsheet" toProperty="output_spreadsheet" />
   <link fromOperation="input connector" fromProperty="input_cluster_number" toOperation="Spreadsheet" toProperty="input_cluster_number" />
 
-  ######
   <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" toOperation="ClusterCoverage" toProperty="bam_file" />
   <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" toOperation="StatsGenerator" toProperty="bam_file" />
 

--- a/lib/perl/Genome/Model/SmallRna/Command/SmallRnaWorkflow.xml
+++ b/lib/perl/Genome/Model/SmallRna/Command/SmallRnaWorkflow.xml
@@ -1,119 +1,115 @@
 <?xml version='1.0' standalone='yes'?>
 
 <workflow name="SmallRna Workflow" logDir="/gscmnt/sata142/techd/jhundal/miRNA_logs/" >
-<link fromOperation="input connector" fromProperty="input_bam_file"    toOperation="FilterBamFlagstat" toProperty="bam_file" />
-<link fromOperation="input connector" fromProperty="filtered_bam_file"    toOperation="FilterBamFlagstat" toProperty="filtered_bam_file" />
-<link fromOperation="input connector" fromProperty="read_size_bin"    toOperation="FilterBamFlagstat" toProperty="read_size_bin" />
+  <link fromOperation="input connector" fromProperty="input_bam_file" toOperation="FilterBamFlagstat" toProperty="bam_file" />
+  <link fromOperation="input connector" fromProperty="filtered_bam_file" toOperation="FilterBamFlagstat" toProperty="filtered_bam_file" />
+  <link fromOperation="input connector" fromProperty="read_size_bin" toOperation="FilterBamFlagstat" toProperty="read_size_bin" />
 
-<link fromOperation="input connector" fromProperty="zenith_depth"    toOperation="ClusterCoverage" toProperty="zenith_depth" />
-<link fromOperation="input connector" fromProperty="minimum_depth"    toOperation="ClusterCoverage" toProperty="minimum_depth" />
-<link fromOperation="input connector" fromProperty="stats_file"    toOperation="ClusterCoverage" toProperty="stats_file" />
-<link fromOperation="input connector" fromProperty="bed_file"    toOperation="ClusterCoverage" toProperty="bed_file" />
+  <link fromOperation="input connector" fromProperty="zenith_depth" toOperation="ClusterCoverage" toProperty="zenith_depth" />
+  <link fromOperation="input connector" fromProperty="minimum_depth" toOperation="ClusterCoverage" toProperty="minimum_depth" />
+  <link fromOperation="input connector" fromProperty="stats_file" toOperation="ClusterCoverage" toProperty="stats_file" />
+  <link fromOperation="input connector" fromProperty="bed_file" toOperation="ClusterCoverage" toProperty="bed_file" />
 
-<link fromOperation="input connector" fromProperty="stats_file" 	toOperation="StatsGenerator" toProperty="coverage_stats_file" />
-<link fromOperation="input connector" fromProperty="output_stats_file"  toOperation="StatsGenerator" toProperty="output_stats_file" />
+  <link fromOperation="input connector" fromProperty="stats_file" toOperation="StatsGenerator" toProperty="coverage_stats_file" />
+  <link fromOperation="input connector" fromProperty="output_stats_file" toOperation="StatsGenerator" toProperty="output_stats_file" />
 
-<link fromOperation="input connector" fromProperty="output_clusters_file"  toOperation="StatsGenerator" toProperty="output_clusters_file" />
-<link fromOperation="input connector" fromProperty="flagstat_17_70_file"  toOperation="StatsGenerator" toProperty="flagstat_17_70_file" />
-<link fromOperation="input connector" fromProperty="output_subclusters_file"  toOperation="StatsGenerator" toProperty="output_subclusters_file" />
-<link fromOperation="input connector" fromProperty="output_subcluster_intersect_file"  toOperation="StatsGenerator" toProperty="output_subcluster_intersect_file" />
-<link fromOperation="input connector" fromProperty="subcluster_min_mapzero" toOperation="StatsGenerator" toProperty="subcluster_min_mapzero" />
+  <link fromOperation="input connector" fromProperty="output_clusters_file" toOperation="StatsGenerator" toProperty="output_clusters_file" />
+  <link fromOperation="input connector" fromProperty="flagstat_17_70_file" toOperation="StatsGenerator" toProperty="flagstat_17_70_file" />
+  <link fromOperation="input connector" fromProperty="output_subclusters_file" toOperation="StatsGenerator" toProperty="output_subclusters_file" />
+  <link fromOperation="input connector" fromProperty="output_subcluster_intersect_file" toOperation="StatsGenerator" toProperty="output_subcluster_intersect_file" />
+  <link fromOperation="input connector" fromProperty="subcluster_min_mapzero" toOperation="StatsGenerator" toProperty="subcluster_min_mapzero" />
 
-<link fromOperation="input connector" fromProperty="annotation_bed_file"  toOperation="AnnotateCluster" toProperty="annotation_bed_file" />  
-<link fromOperation="input connector" fromProperty="output_clusters_file"  toOperation="AnnotateCluster" toProperty="cluster_bed_file" />
-<link fromOperation="input connector" fromProperty="annotation_name"  	 	toOperation="AnnotateCluster" toProperty="annotation_name" />
-<link fromOperation="input connector" fromProperty="output_tsv_file"  	 	toOperation="AnnotateCluster" toProperty="output_tsv_file" />
+  <link fromOperation="input connector" fromProperty="annotation_bed_file" toOperation="AnnotateCluster" toProperty="annotation_bed_file" />
+  <link fromOperation="input connector" fromProperty="output_clusters_file" toOperation="AnnotateCluster" toProperty="cluster_bed_file" />
+  <link fromOperation="input connector" fromProperty="annotation_name" toOperation="AnnotateCluster" toProperty="annotation_name" />
+  <link fromOperation="input connector" fromProperty="output_tsv_file" toOperation="AnnotateCluster" toProperty="output_tsv_file" />
 
-<link fromOperation="input connector" fromProperty="output_stats_file"  toOperation="Spreadsheet" toProperty="input_stats_file" />
-<link fromOperation="input connector" fromProperty="output_tsv_file"  toOperation="Spreadsheet" toProperty="input_intersect_file" />
-<link fromOperation="input connector" fromProperty="output_spreadsheet"  toOperation="Spreadsheet" toProperty="output_spreadsheet" />
-<link fromOperation="input connector" fromProperty="input_cluster_number"  toOperation="Spreadsheet" toProperty="input_cluster_number" />
-  
+  <link fromOperation="input connector" fromProperty="output_stats_file" toOperation="Spreadsheet" toProperty="input_stats_file" />
+  <link fromOperation="input connector" fromProperty="output_tsv_file" toOperation="Spreadsheet" toProperty="input_intersect_file" />
+  <link fromOperation="input connector" fromProperty="output_spreadsheet" toOperation="Spreadsheet" toProperty="output_spreadsheet" />
+  <link fromOperation="input connector" fromProperty="input_cluster_number" toOperation="Spreadsheet" toProperty="input_cluster_number" />
+
   ######
   <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" toOperation="ClusterCoverage" toProperty="bam_file" />
-   <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" 	toOperation="StatsGenerator" toProperty="bam_file" />
-  
-  <link fromOperation="ClusterCoverage" fromProperty="stats_file" 	toOperation="StatsGenerator" toProperty="coverage_stats_file" />
-  
-  <link fromOperation="StatsGenerator" fromProperty="output_clusters_file"  toOperation="output connector" toProperty="output_clusters_file" />
-  <link fromOperation="StatsGenerator" fromProperty="output_clusters_file"  toOperation="AnnotateCluster" toProperty="cluster_bed_file" />
-  <link fromOperation="StatsGenerator" fromProperty="output_subcluster_intersect_file"  toOperation="output connector" toProperty="output_subcluster_intersect_file" />
-<link fromOperation="StatsGenerator" fromProperty="output_subclusters_file"  toOperation="output connector" toProperty="output_subclusters_file" />
- <link fromOperation="StatsGenerator" fromProperty="output_stats_file"  toOperation="output connector" toProperty="output_stats_file" />
-   <link fromOperation="StatsGenerator" fromProperty="bam_file"    toOperation="output connector" toProperty="filtered_bam_file" />
- 
- <link fromOperation="AnnotateCluster" 	 fromProperty="output_tsv_file"  toOperation="output connector" toProperty="output_tsv_file" />
+  <link fromOperation="FilterBamFlagstat" fromProperty="filtered_bam_file" toOperation="StatsGenerator" toProperty="bam_file" />
+
+  <link fromOperation="ClusterCoverage" fromProperty="stats_file" toOperation="StatsGenerator" toProperty="coverage_stats_file" />
+
+  <link fromOperation="StatsGenerator" fromProperty="output_clusters_file" toOperation="output connector" toProperty="output_clusters_file" />
+  <link fromOperation="StatsGenerator" fromProperty="output_clusters_file" toOperation="AnnotateCluster" toProperty="cluster_bed_file" />
+  <link fromOperation="StatsGenerator" fromProperty="output_subcluster_intersect_file" toOperation="output connector" toProperty="output_subcluster_intersect_file" />
+  <link fromOperation="StatsGenerator" fromProperty="output_subclusters_file" toOperation="output connector" toProperty="output_subclusters_file" />
+  <link fromOperation="StatsGenerator" fromProperty="output_stats_file" toOperation="output connector" toProperty="output_stats_file" />
+  <link fromOperation="StatsGenerator" fromProperty="bam_file" toOperation="output connector" toProperty="filtered_bam_file" />
+
+  <link fromOperation="AnnotateCluster" fromProperty="output_tsv_file" toOperation="output connector" toProperty="output_tsv_file" />
+
+  <link fromOperation="FilterBamFlagstat" fromProperty="result" toOperation="output connector" toProperty="result" />
+  <link fromOperation="ClusterCoverage" fromProperty="result" toOperation="output connector" toProperty="result" />
+
+  <link fromOperation="StatsGenerator" fromProperty="result" toOperation="output connector" toProperty="result" />
+  <link fromOperation="AnnotateCluster" fromProperty="result" toOperation="output connector" toProperty="result" />
+  <link fromOperation="Spreadsheet" fromProperty="result" toOperation="output connector" toProperty="result" />
+
+  <link fromOperation="StatsGenerator" fromProperty="output_stats_file" toOperation="Spreadsheet"  toProperty="input_stats_file" />
+  <link fromOperation="AnnotateCluster" fromProperty="output_tsv_file" toOperation="Spreadsheet" toProperty="input_intersect_file" />
+  <link fromOperation="Spreadsheet" fromProperty="output_spreadsheet" toOperation="output connector" toProperty="output_spreadsheet" />
+  <link fromOperation="Spreadsheet" fromProperty="result" toOperation="output connector" toProperty="result" />
 
 
+  <operation name="FilterBamFlagstat">
+    <operationtype commandClass="Genome::Model::SmallRna::Command::FilterBamFlagstat" typeClass="Workflow::OperationType::Command" />
+  </operation>
 
- <link fromOperation="FilterBamFlagstat" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
-  <link fromOperation="ClusterCoverage" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
- 
-  <link fromOperation="StatsGenerator" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
-  <link fromOperation="AnnotateCluster" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
-   <link fromOperation="Spreadsheet" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
 
- <link fromOperation="StatsGenerator" 	 fromProperty="output_stats_file" toOperation="Spreadsheet"  toProperty="input_stats_file" />
- <link fromOperation="AnnotateCluster" 	 fromProperty="output_tsv_file"  toOperation="Spreadsheet" toProperty="input_intersect_file" />
- <link fromOperation="Spreadsheet" 	 fromProperty="output_spreadsheet" toOperation="output connector" toProperty="output_spreadsheet" />
- <link fromOperation="Spreadsheet" 	 fromProperty="result" 			 toOperation="output connector" toProperty="result" />
- 
- 
-   	<operation name="FilterBamFlagstat">
-	<operationtype commandClass="Genome::Model::SmallRna::Command::FilterBamFlagstat" typeClass="Workflow::OperationType::Command" />
-    </operation>
- 
- 
-  	<operation name="ClusterCoverage">
-	<operationtype commandClass="Genome::Model::SmallRna::Command::ClusterCoverage" typeClass="Workflow::OperationType::Command" />
-    </operation>
-    
+  <operation name="ClusterCoverage">
+    <operationtype commandClass="Genome::Model::SmallRna::Command::ClusterCoverage" typeClass="Workflow::OperationType::Command" />
+  </operation>
 
-    <operation name="StatsGenerator">
+
+  <operation name="StatsGenerator">
     <operationtype commandClass="Genome::Model::SmallRna::Command::StatsGenerator"   typeClass="Workflow::OperationType::Command" />
-    </operation>
-   
-   
-    <operation name="AnnotateCluster">
-	<operationtype commandClass="Genome::Model::SmallRna::Command::AnnotateCluster" typeClass="Workflow::OperationType::Command" />
-    </operation>
-    
-    
-    <operation name="Spreadsheet">
-	<operationtype commandClass="Genome::Model::SmallRna::Command::Spreadsheet" typeClass="Workflow::OperationType::Command" />
-    </operation>
-    
-    <operationtype typeClass="Workflow::OperationType::Model">
-    
+  </operation>
+
+
+  <operation name="AnnotateCluster">
+    <operationtype commandClass="Genome::Model::SmallRna::Command::AnnotateCluster" typeClass="Workflow::OperationType::Command" />
+  </operation>
+
+
+  <operation name="Spreadsheet">
+    <operationtype commandClass="Genome::Model::SmallRna::Command::Spreadsheet" typeClass="Workflow::OperationType::Command" />
+  </operation>
+
+  <operationtype typeClass="Workflow::OperationType::Model">
     <inputproperty>input_bam_file</inputproperty>
     <inputproperty>filtered_bam_file</inputproperty>
- 	<inputproperty>read_size_bin</inputproperty>
-	 <inputproperty>zenith_depth</inputproperty>
-<inputproperty>minimum_depth</inputproperty>
-     <inputproperty>bed_file</inputproperty>
-<inputproperty>flagstat_17_70_file</inputproperty>
-     <inputproperty>output_stats_file</inputproperty>
-     <inputproperty>output_clusters_file</inputproperty>
-     <inputproperty>output_subclusters_file</inputproperty>
-     <inputproperty>output_subcluster_intersect_file</inputproperty>
-      <inputproperty>subcluster_min_mapzero</inputproperty>
+    <inputproperty>read_size_bin</inputproperty>
+    <inputproperty>zenith_depth</inputproperty>
+    <inputproperty>minimum_depth</inputproperty>
+    <inputproperty>bed_file</inputproperty>
+    <inputproperty>flagstat_17_70_file</inputproperty>
+    <inputproperty>output_stats_file</inputproperty>
+    <inputproperty>output_clusters_file</inputproperty>
+    <inputproperty>output_subclusters_file</inputproperty>
+    <inputproperty>output_subcluster_intersect_file</inputproperty>
+    <inputproperty>subcluster_min_mapzero</inputproperty>
     <inputproperty>annotation_bed_file</inputproperty>
     <inputproperty>output_tsv_file</inputproperty>
-	<inputproperty>annotation_name</inputproperty>
-	<inputproperty>output_spreadsheet</inputproperty>
-	<inputproperty>input_cluster_number</inputproperty>
-	<inputproperty>stats_file</inputproperty>
-	
-	
-     <outputproperty>filtered_bam_file</outputproperty>
+    <inputproperty>annotation_name</inputproperty>
+    <inputproperty>output_spreadsheet</inputproperty>
+    <inputproperty>input_cluster_number</inputproperty>
+    <inputproperty>stats_file</inputproperty>
+
+    <outputproperty>filtered_bam_file</outputproperty>
     <outputproperty>output_clusters_file</outputproperty>
     <outputproperty>output_stats_file</outputproperty>
-  	 <outputproperty>output_subcluster_intersect_file</outputproperty>
+    <outputproperty>output_subcluster_intersect_file</outputproperty>
     <outputproperty>output_tsv_file</outputproperty>
     <outputproperty>output_subclusters_file</outputproperty>
     <outputproperty>output_spreadsheet</outputproperty>
-	<outputproperty>result</outputproperty>
+    <outputproperty>result</outputproperty>
   </operationtype>
-  
+
 </workflow>
-  
+


### PR DESCRIPTION
WorkflowBuilder was failing to validate these workflows, because they strangely were mapping several things into the final `result`.  This deduplicates the ones in the outer workflow and simply removes them from the inner workflow.

(This is another case where `?w=1` comes in handy viewing the diffs!)