### PR TITLE
Only schedule current dependent reference alignments.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject.pm
+++ b/lib/perl/Genome/Config/AnalysisProject.pm
@@ -5,6 +5,8 @@ use warnings;
 
 use Genome;
 
+use List::MoreUtils qw(any);
+
 class Genome::Config::AnalysisProject {
     is => [
         "Genome::Utility::ObjectWithTimestamps",
@@ -127,6 +129,15 @@ sub _is_updated {
         "$old_val:$new_val",
         $self,
     );
+}
+
+sub is_current {
+    my $self = shift;
+
+    my $status = $self->status;
+    return if any { $_ eq $status } (qw(Completed Archived Template));
+
+    return 1;
 }
 
 1;

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -179,4 +179,10 @@ sub _is_created {
     );
 }
 
+sub is_current {
+    my $self = shift;
+
+    return $self->status eq 'active' and $self->analysis_project->is_current;
+}
+
 1;

--- a/lib/perl/Genome/Model/GenotypeMicroarray-post_success.t
+++ b/lib/perl/Genome/Model/GenotypeMicroarray-post_success.t
@@ -7,6 +7,7 @@ BEGIN {
 
 use above 'Genome';
 use Test::More;
+use Genome::Test::Factory::AnalysisProject;
 use Genome::Test::Factory::InstrumentData::Solexa;
 use Genome::Test::Factory::InstrumentData::Imported;
 use Genome::Test::Factory::Library;
@@ -47,6 +48,9 @@ my $qc_model = Genome::Model::ReferenceAlignment->create(
     subject => $qc_sample,
     instrument_data => [$qc_data],
 );
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+my ($config) = $anp->config_items;
+$anp->add_model_bridge(config_profile_item => $config, model => $qc_model);
 
 #make genotype microarray model
 my $genotype_microarray_model = Genome::Model::GenotypeMicroarray->create(

--- a/lib/perl/Genome/Model/GenotypeMicroarray.pm
+++ b/lib/perl/Genome/Model/GenotypeMicroarray.pm
@@ -185,7 +185,14 @@ sub dependent_cron_ref_align {
         (not $gmm || ($gmm && $gmm->id == $self->id));
     } @compatible_ref_align_models;
 
-    return @dependent_models;
+    # limit to models for which new results might still be useful
+    my @current_models = grep {
+        $_->analysis_project_bridges and
+        $_->analysis_project_bridges->config_profile_item and
+        $_->analysis_project_bridges->config_profile_item->is_current
+    } @dependent_models;
+
+    return @current_models;
 }
 
 sub request_builds_for_dependent_cron_ref_align {

--- a/lib/perl/Genome/Sample-add_default_genotype.t
+++ b/lib/perl/Genome/Sample-add_default_genotype.t
@@ -15,6 +15,8 @@ use_ok('Genome::Model::GenotypeMicroarray::Test') or die;
 use_ok('Genome::Model::ReferenceAlignment') or die;
 use_ok('Genome::InstrumentData::Imported') or die;
 
+use Genome::Test::Factory::AnalysisProject;
+
 # Create test sample
 my $sample = create_test_sample();
 ok($sample, 'Made test sample');
@@ -125,10 +127,13 @@ sub create_ref_seq_build {
 sub create_ref_align_model {
     my ($sample, $ref_seq_build) = @_;
 
+    my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+    my ($config) = $anp->config_items;
+
     my $pp = create_ref_align_pp();
     return unless $pp;
 
-    return Genome::Model::ReferenceAlignment->create(
+    my $model = Genome::Model::ReferenceAlignment->create(
         subject_id => $sample->id,
         subject_class_name => $sample->class,
         name => 'test ref align model',
@@ -136,6 +141,10 @@ sub create_ref_align_model {
         processing_profile_id => $pp->id,
         auto_assign_inst_data => 1,
     );
+
+    $anp->add_model_bridge(config_profile_item => $config, model => $model);
+
+    return $model;
 }
 
 sub make_genotype_pp {


### PR DESCRIPTION
This should eliminate the issue of new microarray data triggering rebuilds of old/outdated models.