### PR TITLE
Also test for directory existence before trying to create it.

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -841,13 +841,13 @@ sub create_directory {
 sub make_path {
     my ($path) = validate_pos(@_, {type => SCALAR});
 
+    return 1 if -d $path; #This also triggers the automounter so mkdir() gets EEXIST instead of EACCES.
+
     my $gid = gidgrnam(Genome::Config::get('sys_group'));
 
     my @dirs = File::Spec->splitdir($path);
     for (my $i = 0; $i < @dirs; $i++) {
         my $subpath = File::Spec->catdir(@dirs[0..$i]);
-
-        next if -d $subpath;
 
         my $rv = mkdir $subpath;
         my $mkdir_errno = $!;

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -847,6 +847,8 @@ sub make_path {
     for (my $i = 0; $i < @dirs; $i++) {
         my $subpath = File::Spec->catdir(@dirs[0..$i]);
 
+        next if -d $subpath;
+
         my $rv = mkdir $subpath;
         my $mkdir_errno = $!;
         if ($rv) {


### PR DESCRIPTION
Unmounted volumes will not return EEXIST from mkdir().  Checking for
directory existence triggers the automounter to ensure the volume is
mounted before trying to create it.