### PR TITLE
Only print an extra newline if output was not redirected.

### DIFF
--- a/lib/perl/Genome/Sys-shellcmd.t
+++ b/lib/perl/Genome/Sys-shellcmd.t
@@ -73,8 +73,7 @@ sub test_redirect_stdout_stderr {
         ok($result, 'Run echo with stdout redirected');
         ok(! (-s $parentout), 'Found no output in stdout of parent')
             or diag $read_file->($parentout);
-        # two newlines, as the shellcmd will emit an extra newline
-        is( $read_file->($childout), "test\n\n", 'redirected child stdout to a file');
+        is( $read_file->($childout), "test\n", 'redirected child stdout to a file');
         unlink($parentout, $childout);
     }
 
@@ -104,8 +103,7 @@ sub test_redirect_stdout_stderr {
         ok($result, 'Run echo with stdout redirected not through a shell');
         ok(! (-s $parentout), 'Found no output in stdout of parent')
             or diag $read_file->($parentout);
-        # two newlines, as the shellcmd will emit an extra newline
-        is( $read_file->($childout), "another test\n\n", 'redirected child stdout to a file');
+        is( $read_file->($childout), "another test\n", 'redirected child stdout to a file');
         unlink($parentout, $childout);
     }
 

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1508,15 +1508,7 @@ sub shellcmd {
                 # parent
                 waitpid($pid, 0);
                 $system_retval = $?;
-                # add a new line so that bad programs don't break TAP, etc
-                # Adding a newline to the redirected stdout file isn't strictly
-                # necessary, but is included for compatibility with previous versions
-                # of this code that always printed an extra newline to STDOUT, whether
-                # it was redirected or not.
-                my $extra_newline = $redirect_stdout
-                                    ? IO::File->new($redirect_stdout, O_WRONLY|O_APPEND)
-                                    : *STDOUT;
-                print $extra_newline "\n";
+                print STDOUT "\n" unless $redirect_stdout; # add a new line so that bad programs don't break TAP, etc.
 
             } else {
                 # child


### PR DESCRIPTION
Only three modules are currently using `redirect_stdout`, two of which send it to `/dev/null`, and `Genome::InstrumentData::Command::Import::WorkFlow::SraToBam` which is using it while writing a BAM file.  Seems like an extra newline isn't desirable there.

This reverts commit ba557795fe0e72ca1d4a691230206d9e39e7e80e.  (Is there a reason to keep the extra newline that I'm missing?)