### PR TITLE
Genotype Microarray Dependent Cron RefAlign

### DIFF
--- a/lib/perl/Genome/Model/GenotypeMicroarray.pm
+++ b/lib/perl/Genome/Model/GenotypeMicroarray.pm
@@ -169,7 +169,6 @@ sub dependent_cron_ref_align {
 
     my @ref_align_models = Genome::Model::ReferenceAlignment->get(
         subject_id => [map { $_->id } @subjects],
-        reference_sequence_build => $self->reference_sequence_build,
     );
 
     # limit to models with a compatible reference sequence build


### PR DESCRIPTION
Allow getting of dependent cron ref align models w/o reference first, then
filter by if the reference is compatible.