### PR TITLE
Remove other locking now that SR::User is ObjectWithLockedConstruction.

### DIFF
--- a/lib/perl/Genome/Process.t
+++ b/lib/perl/Genome/Process.t
@@ -75,9 +75,6 @@ $result->add_user(user => $p, label => 'test');
 is_deeply([$p->results], [$result],
     'Found TestResult via SoftwareResult::User relationship');
 
-$result->add_user(user => $p, label => 'test');
-is_deeply([$p->results], [$result, $result],
-    'Found two TestResults via SoftwareResult::User relationship');
 my $code_test_dir = __FILE__ . '.d';
 
 my %tests = (

--- a/lib/perl/Genome/SoftwareResult/User.pm
+++ b/lib/perl/Genome/SoftwareResult/User.pm
@@ -118,25 +118,13 @@ sub _register_users {
         callback => sub {
             for my $params (@param_sets) {
                 next if grep { $params->{$_}->isa('UR::DeletedRef') } qw(user software_result);
-                $class->get_or_create($params);
+                $class->create($params);
             }
         }
     );
     unless($observer) {
         die 'Failed to create observer';
     }
-}
-
-sub get_or_create {
-    my $class = shift;
-    my $params = shift;
-
-    my $self = $class->get(%$params);
-    unless($self) {
-        $self = $class->create(%$params);
-    }
-
-    return 1;
 }
 
 sub _role_for_type {

--- a/lib/perl/Genome/SoftwareResult/User.t
+++ b/lib/perl/Genome/SoftwareResult/User.t
@@ -143,22 +143,6 @@ subtest 'multiple shortcutters result in only one user' => sub {
     }
     UR::Context->commit();
 
-    subtest 'lock not still held after commit is complete' => sub {
-        my $resource = Genome::SoftwareResult::User->_resolve_lock_name({
-                label => 'sponsor',
-                user => $users_hash{users}{sponsor},
-                software_result => $sr,
-        });
-        my $lock = Genome::Sys::LockProxy->new(
-            resource => $resource,
-            scope => 'site',
-        )->lock(
-            max_try => 1,
-        );
-        ok($lock, 'got lock');
-        $lock->unlock();
-    };
-
     my @users = $sr->users;
     is(scalar(@users), 2, 'users only added once across all three calls');
     my @sponsors = grep { $_->label eq 'sponsor' } @users;

--- a/lib/perl/Genome/Utility/ObjectWithLockedConstruction.pm
+++ b/lib/perl/Genome/Utility/ObjectWithLockedConstruction.pm
@@ -13,19 +13,17 @@ class Genome::Utility::ObjectWithLockedConstruction {
 
 sub create {
     my $class = shift;
+
+    my $obj = $class->get(@_);
+    return $obj if $obj;
+
     if ($ENV{UR_DBI_NO_COMMIT}) {
         return $class->SUPER::create(@_);
     } else {
         my $lock_id = $class->lock_id(@_);
-
         my $lock_var = sprintf('%s/%s', $class, $lock_id);
 
-        my $obj = $class->get(@_);
-        if($obj) {
-            return $obj;
-        } else {
-            return $class->create_with_lock($lock_var, @_);
-        }
+        return $class->create_with_lock($lock_var, @_);
     }
 }
 


### PR DESCRIPTION
This should be merged only after no running builds are on a snapshot prior to `genome-3607`.