### PR TITLE
New command: failed-model-ticket-status

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTicketBase.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTicketBase.pm
@@ -1,0 +1,101 @@
+package Genome::Model::Command::Admin::FailedModelTicketBase;
+
+use strict;
+use warnings;
+
+use Error qw(:try);
+require RT::Client::REST;
+require RT::Client::REST::Ticket;
+require WWW::Mechanize;
+
+class Genome::Model::Command::Admin::FailedModelTicketBase {
+    is => 'Genome::Command::WithColor',
+    is_abstract => 1,
+    doc => 'Base class for admin commands working with RT',
+};
+
+sub _find_open_tickets {
+    my ($self, $rt) = @_;
+
+    # The call to $rt->search() below messed up the login credentials stored in the
+    # $rt session, making the loop at the bottom that retrieves tickets fail.
+    # Save a copy of the login credentials here so we can re-set them when it's
+    # time to get the ticket details
+    my $login_cookies = $rt->_cookie();
+
+    # Retrieve tickets -
+    $self->status_message('Looking for tickets...');
+    my @ticket_ids;
+    try {
+        @ticket_ids = $rt->search(
+            type => 'ticket',
+            query => "Queue = 'apipe-support' AND ( Status = 'new' OR Status = 'open' )",
+
+        );
+    }
+    catch Exception::Class::Base with {
+        my $msg = shift;
+        if ( $msg eq 'Internal Server Error' ) {
+            die 'Incorrect username or password';
+        }
+        else {
+            die $msg->message;
+        }
+    };
+    $self->status_message($self->_color('Tickets (new or open): ', 'bold').scalar(@ticket_ids));
+
+    # re-set the login cookies that we saved away eariler
+    $rt->_ua->cookie_jar($login_cookies);
+
+    return @ticket_ids;
+}
+
+sub _ticket_for_id {
+    my ($self, $rt, $ticket_id) = @_;
+
+    my $ticket = eval {
+        RT::Client::REST::Ticket->new(
+            rt => $rt,
+            id => $ticket_id,
+        )->retrieve;
+    };
+    unless ($ticket) {
+        $self->error_message("Problem retrieving data for ticket $ticket_id: $@");
+    }
+
+    return $ticket;
+}
+
+sub _server {
+    return 'https://rt.gsc.wustl.edu/';
+}
+
+sub _login_sso {
+    my $self = shift;
+
+    my $mech = WWW::Mechanize->new(
+        after =>  1,
+        timeout => 10,
+        agent =>  'WWW-Mechanize',
+    );
+    $mech->get( $self->_server() );
+
+    my $uri = $mech->uri;
+    my $host = $uri->host;
+    if ($host ne 'sso.gsc.wustl.edu') {
+        return;
+    }
+
+    $mech->submit_form (
+        form_number =>  1,
+        fields =>  {
+            j_username => 'limsrt',
+            j_password => 'Koh3gaed',
+        },
+    );
+    $mech->submit();
+
+    return RT::Client::REST->new(server => _server(), _cookie =>  $mech->{cookie_jar});
+}
+
+1;

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTicketStatus.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTicketStatus.pm
@@ -29,6 +29,11 @@ class Genome::Model::Command::Admin::FailedModelTicketStatus {
             doc => 'Only print status summary for each ticket',
             default => 0,
         },
+        include_subjects => {
+            is => 'Boolean',
+            doc => 'Include the subject of each ticket in the output',
+            default => 0,
+        },
     ],
 };
 
@@ -82,6 +87,13 @@ sub execute {
             $self->_color($self->_color('Ticket %s', 'bold'), 'white') .' (' . $self->_color('%s',$color) . '):',
             $ticket_id, $ticket->owner
         );
+        if($self->include_subjects) {
+            $self->status_message(
+                'Subject: ' . $self->_color('%s', 'magenta'),
+                $ticket->subject,
+            );
+        }
+
         if (@ids) {
             my @models = Genome::Model->get(\@ids);
             if (@models) {

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTicketStatus.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTicketStatus.pm
@@ -5,17 +5,12 @@ use warnings;
 
 use Genome;
 
-use Error qw(:try);
-require RT::Client::REST;
-require RT::Client::REST::Ticket;
-require WWW::Mechanize;
-
 BEGIN {
     $ENV{UR_DBI_NO_COMMIT} = 1;
 }
 
 class Genome::Model::Command::Admin::FailedModelTicketStatus {
-    is => 'Genome::Command::WithColor',
+    is => 'Genome::Model::Command::Admin::FailedModelTicketBase',
     doc => 'report status of models in tickets',
     has_optional_input => [
         tickets => {
@@ -48,15 +43,15 @@ sub execute {
     my $self = shift;
 
     # Connect
-    my $rt = Genome::Model::Command::Admin::FailedModelTickets->_login_sso();
+    my $rt = $self->_login_sso();
 
     my @ticket_ids = $self->tickets;
     unless(@ticket_ids) {
-        @ticket_ids = Genome::Model::Command::Admin::FailedModelTickets::_find_open_tickets($self, $rt);
+        @ticket_ids = $self->_find_open_tickets($rt);
     }
 
     for my $ticket_id ( @ticket_ids ) {
-        my $ticket = Genome::Model::Command::Admin::FailedModelTickets::_ticket_for_id($self, $rt, $ticket_id);
+        my $ticket = $self->_ticket_for_id($rt, $ticket_id);
         next unless $ticket;
 
         if(defined $self->owner and $ticket->owner ne $self->owner) {

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTicketStatus.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTicketStatus.pm
@@ -22,6 +22,7 @@ class Genome::Model::Command::Admin::FailedModelTicketStatus {
         owner => {
             is => 'Text',
             doc => 'Limit any tickets to those owned by this user',
+            example_values => ['Nobody'],
         },
         summary_only => {
             is => 'Boolean',

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTicketStatus.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTicketStatus.pm
@@ -56,16 +56,8 @@ sub execute {
     }
 
     for my $ticket_id ( @ticket_ids ) {
-        my $ticket = eval {
-            RT::Client::REST::Ticket->new(
-                rt => $rt,
-                id => $ticket_id,
-            )->retrieve;
-        };
-        unless ($ticket) {
-            $self->error_message("Problem retrieving data for ticket $ticket_id: $@");
-            next;
-        }
+        my $ticket = Genome::Model::Command::Admin::FailedModelTickets::_ticket_for_id($self, $rt, $ticket_id);
+        next unless $ticket;
 
         if(defined $self->owner and $ticket->owner ne $self->owner) {
             next;

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
@@ -5,11 +5,7 @@ use warnings;
 
 use Genome;
 
-use Data::Dumper 'Dumper';
 use Error qw(:try);
-use File::Find 'find';
-use File::Grep 'fgrep';
-require IO::Prompt;
 require RT::Client::REST;
 require RT::Client::REST::Ticket;
 require WWW::Mechanize;

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
@@ -38,7 +38,7 @@ class Genome::Model::Command::Admin::FailedModelTickets {
 
 sub help_detail {
     return <<HELP;
-This command collects cron models by failed or unstartable build events and scours tickets for them. If they are not found, the models are summaraized first by the error entry log and then by grepping the error log files. The summary is the printed to STDOUT.
+This command collects cron models with failed or unstartable builds and scours tickets for their IDs. If they are not found in the existing tickets, the models are summarized and grouped by the `genome model build determine-error` output.
 HELP
 }
 

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
@@ -110,7 +110,7 @@ sub get_builds {
         }
 
         # only keep the most recently scheduled build
-        next if $builds{ $model->id } and $builds{ $model->id }->date_scheduled gt $build->date_scheduled;
+        next if $builds{ $model->id } and $builds{ $model->id }->created_at gt $build->created_at;
         $builds{ $model->id } = $build;
     }
     $self->status_message('Found '.keys(%builds).' models');


### PR DESCRIPTION
Conveniently examine existing tickets from the command-line.  Assuming that the ticket body was created with the model ID at the start of each line (as in the output format of `failed-model-tickets`) and that any additions are replies and not comments, this command will list the current status of the listed models.

(This is how I've been going through and closing tickets when rebuilds from `model-summary` were successful.)