### PR TITLE
Add options to clinseq update-analysis to use validation data as exome data

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -871,11 +871,12 @@ sub get_trsn{
   foreach my $instrument_data (@instrument_data){
     my $trsn = $instrument_data->target_region_set_name;
     if ($trsn){
+      #Force exome trsn when validation-as-exome-my-trsn option is used with validation-as-exome option
       if ($self->validation_as_exome && $self->validation_as_exome_my_trsn) {
         my $fl = Genome::FeatureList->get(name => $trsn);
         if ($fl->content_type eq 'exome') {
           $trsns{$trsn}=1;
-          $trsn_ref = 'SeqCap EZ Human Exome v2.0';
+          $trsn_ref = $trsn;
         }else{
           $trsns{$trsn}=1;
         }

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -684,23 +684,18 @@ sub get_dna_instrument_data{
 
   foreach my $instrument_data (@sample_instrument_data){
     my $trsn = $instrument_data->target_region_set_name;
-    if ($self->validation_as_exome) {
-      if ($trsn){
-        my $fl = Genome::FeatureList->get(name => $trsn);
+    if ($trsn){
+      my $fl = Genome::FeatureList->get(name => $trsn);
+      if ($self->validation_as_exome) {
         if (not $fl or not $fl->content_type) {
           push @unknown, $instrument_data;
         }elsif ($fl->content_type eq 'exome' || $fl->content_type eq 'validation') {
           push @exome, $instrument_data;
           $trsns{$trsn}=1;
-        }else {
+        }else{
           push @other, $instrument_data;
         }
       }else{
-        push @wgs, $instrument_data;
-      }
-    }else{
-      if ($trsn){
-        my $fl = Genome::FeatureList->get(name => $trsn);
         if (not $fl or not $fl->content_type) {
           push @unknown, $instrument_data;
         }elsif ($fl->content_type eq 'exome') {
@@ -709,9 +704,9 @@ sub get_dna_instrument_data{
         }else {
           push @other, $instrument_data;
         }
-      }else{
-        push @wgs, $instrument_data;
       }
+    }else{
+      push @wgs, $instrument_data;
     }
   }
 

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -842,7 +842,7 @@ sub get_trsn{
   my $trsn_ref;
   
   #When using validation-as-exome and my-trsn options, use user-defined target region set name (exome or validation)
-  if ($self->validation_as_exome && $self->my_trsn) {
+  if ($self->my_trsn) {
     my $user_trsn = $self->my_trsn;
     $self->warning_message("Using '$user_trsn' target region specified by my-trsn.");
     
@@ -857,7 +857,12 @@ sub get_trsn{
         }
       }
     }
-  
+    
+    #Checks that $trsn_ref has been initialized
+    if(!defined $trsn_ref) {
+      die $self->error_message("Cannot provide --my-trsn specified target region set name. Feature list of the target region set name does not have expected 'exome' or 'validation' content type.");
+    }
+
   #Default behavior for choosing target-region-set-name   
   }else{
     foreach my $instrument_data (@instrument_data){

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -255,6 +255,14 @@ sub execute {
     $self->status_message("\nExiting...  --display-defaults mode is used for summarizing purposes only\n\n");
     return 1;
   }
+  
+  #If the user selected the --validation-as-exome-my-trsn option, make sure --validation-as-exome option is used
+  if ($self->validation_as_exome_my_trsn) {
+    unless ($self->validation_as_exome) {
+      $self->error_message("Exiting... validation_as_exome_my_trsn requires validation_as_exome option");
+      exit 1;
+    }
+  }
 
   #Make sure an individual is defined
   unless ($self->individual){

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -697,24 +697,17 @@ sub get_dna_instrument_data{
     my $trsn = $instrument_data->target_region_set_name;
     if ($trsn){
       my $fl = Genome::FeatureList->get(name => $trsn);
+      my @valid_types = "exome";
       if ($self->validation_as_exome) {
-        if (not $fl or not $fl->content_type) {
-          push @unknown, $instrument_data;
-        }elsif ($fl->content_type eq 'exome' || $fl->content_type eq 'validation') {
-          push @exome, $instrument_data;
-          $trsns{$trsn}=1;
-        }else{
-          push @other, $instrument_data;
-        }
+        push(@valid_types, "validation");
+      }
+      if (not $fl or not $fl->content_type) {
+        push @unknown, $instrument_data;
+      }elsif (grep {$fl->content_type eq $_} @valid_types) {
+        push @exome, $instrument_data;
+        $trsns{$trsn}=1;
       }else{
-        if (not $fl or not $fl->content_type) {
-          push @unknown, $instrument_data;
-        }elsif ($fl->content_type eq 'exome') {
-          push @exome, $instrument_data;
-          $trsns{$trsn}=1;
-        }else {
-          push @other, $instrument_data;
-        }
+        push @other, $instrument_data;
       }
     }else{
       push @wgs, $instrument_data;

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -198,6 +198,10 @@ class Genome::Model::ClinSeq::Command::UpdateAnalysis {
               is => 'Boolean',
               doc => 'Treat validation data as exome data. Includes instrument data from validation capture in exome reference alignment model.',
         },
+        validation_as_exome_my_trsn => {
+              is => 'Boolean',
+              doc => 'If using validation-as-exome option, force target set region name to be derived from exome, not validation instrument data.', 
+        },
    ],
     doc => 'evaluate models/builds for an individual and help create/update a clinseq model that meets requested criteria',
 };
@@ -791,6 +795,26 @@ sub check_model_trsn_and_roi{
       $trsn_ref = $trsn;
     }
   }
+
+#  my $trsn_ref;
+#  foreach my $instrument_data (@model_instrument_data){
+#    my $trsn = $instrument_data->target_region_set_name;
+#    if ($trsn){
+#      if ($self->validation_as_exome && $self->validation_as_exome_my_trsn) {
+#        my $fl = Genome::FeatureList->get(name => $trsn);
+#        if ($fl->content_type eq 'exome') {
+#          $trsns{$trsn}=1;
+#          $trsn_ref = 'SeqCap EZ Human Exome v2.0';
+#        }else{
+#          $trsns{$trsn}=1;
+#        }
+#      }else{
+#        $trsns{$trsn}=1;
+#        $trsn_ref = $trsn;
+#      }
+#    }
+#  }
+
   
   #Watch out for cases where multiple TRSNs have been combined...
   my $trsn_count = keys %trsns;
@@ -836,13 +860,32 @@ sub get_trsn{
   my %trsns;
   my $trsn_ref;
 
+#  foreach my $instrument_data (@instrument_data){
+#    my $trsn = $instrument_data->target_region_set_name;
+#    if ($trsn){
+#      $trsns{$trsn}=1;
+#      $trsn_ref = $trsn;
+#    }
+#  }
+
   foreach my $instrument_data (@instrument_data){
     my $trsn = $instrument_data->target_region_set_name;
     if ($trsn){
-      $trsns{$trsn}=1;
-      $trsn_ref = $trsn;
+      if ($self->validation_as_exome && $self->validation_as_exome_my_trsn) {
+        my $fl = Genome::FeatureList->get(name => $trsn);
+        if ($fl->content_type eq 'exome') {
+          $trsns{$trsn}=1;
+          $trsn_ref = 'SeqCap EZ Human Exome v2.0';
+        }else{
+          $trsns{$trsn}=1;
+        }
+      }else{
+        $trsns{$trsn}=1;
+        $trsn_ref = $trsn;
+      }
     }
   }
+
   
   #Watch out for cases where multiple TRSNs have been combined...
   my $trsn_count = keys %trsns;

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -259,8 +259,7 @@ sub execute {
   #If the user selected the --validation-as-exome-my-trsn option, make sure --validation-as-exome option is used
   if ($self->validation_as_exome_my_trsn) {
     unless ($self->validation_as_exome) {
-      $self->error_message("Exiting... validation_as_exome_my_trsn requires validation_as_exome option");
-      exit 1;
+      die $self->error_message("Exiting... validation_as_exome_my_trsn requires validation_as_exome option");
     }
   }
 
@@ -860,23 +859,22 @@ sub get_trsn{
       $user_trsn = 'validation';
       $self->warning_message("Using '$user_trsn' target region specified by validation-as-exome-my-trsn.");
     }else{
-      $self->error_message("Not a valid argument for validation_as_exome_my_trsn. 1='exome' or 2='validation'");
-      exit 1;
+      die $self->error_message("Not a valid argument for validation_as_exome_my_trsn. 1='exome' or 2='validation'");
     }
     
+    #Assigns the target-region-set-name to the value defined by the user
     foreach my $instrument_data (@instrument_data){
       my $trsn = $instrument_data->target_region_set_name;
       if ($trsn){
         my $fl = Genome::FeatureList->get(name => $trsn);
+        $trsns{$trsn}=1;
         if ($fl->content_type eq $user_trsn) {
-          $trsns{$trsn}=1;
           $trsn_ref = $trsn;
-        }else{
-          $trsns{$trsn}=1;
         }
       }
     }
-     
+  
+  #Default behavior for choosing target-region-set-name   
   }else{
     foreach my $instrument_data (@instrument_data){
       my $trsn = $instrument_data->target_region_set_name;

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -684,7 +684,7 @@ sub get_dna_instrument_data{
       my $fl = Genome::FeatureList->get(name => $trsn);
       if (not $fl or not $fl->content_type) {
         push @unknown, $instrument_data;
-      }elsif ($fl->content_type eq 'exome') {
+      }elsif ($fl->content_type eq 'exome' || $fl->content_type eq 'validation') {
         push @exome, $instrument_data;
         $trsns{$trsn}=1;
       }else {

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -199,8 +199,9 @@ class Genome::Model::ClinSeq::Command::UpdateAnalysis {
               doc => 'Treat validation data as exome data. Includes instrument data from validation capture in exome reference alignment model.',
         },
         my_trsn => {
-              is => 'Number',
-              doc => 'If using validation-as-exome option, option to specify what instrument data to derive the target-set-region-name and region-of-interest from. 1=exome or 2=validation', 
+              is => 'Text',
+              doc => 'If using validation-as-exome option, option to specify what instrument data to derive the target-set-region-name and region-of-interest from. valid options: exome or validation', 
+              valid_values => ['exome','validation']
         },
    ],
     doc => 'evaluate models/builds for an individual and help create/update a clinseq model that meets requested criteria',
@@ -840,20 +841,10 @@ sub get_trsn{
   my %trsns;
   my $trsn_ref;
   
-  #When using validation-as-exome and my-trsn options, use user-defined target region set name (1=exome or 2=validation)
+  #When using validation-as-exome and my-trsn options, use user-defined target region set name (exome or validation)
   if ($self->validation_as_exome && $self->my_trsn) {
     my $user_trsn = $self->my_trsn;
-    
-    #Check if a valid option for my-trsn and use or warn user and exit
-    if ($user_trsn == 1){
-      $user_trsn = 'exome';
-      $self->warning_message("Using '$user_trsn' target region specified by my-trsn.");
-    }elsif($user_trsn == 2){
-      $user_trsn = 'validation';
-      $self->warning_message("Using '$user_trsn' target region specified by my-trsn.");
-    }else{
-      die $self->error_message("Not a valid argument for my_trsn. 1='exome' or 2='validation'");
-    }
+    $self->warning_message("Using '$user_trsn' target region specified by my-trsn.");
     
     #Assigns the target-region-set-name to the value defined by the user
     foreach my $instrument_data (@instrument_data){

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -1175,7 +1175,7 @@ sub check_ref_align_models{
     next unless ($self->determine_model_data_type('-model'=>$model) eq $data_type);
 
     #If the desired $data_type is exome.  Check that the TRSN and ROI have been set correctly, exclude models that are not
-#    next unless ($self->check_model_trsn_and_roi('-model'=>$model, '-data_type'=>$data_type));
+    next unless ($self->check_model_trsn_and_roi('-model'=>$model, '-data_type'=>$data_type));
     #$self->status_message("\t\tName: " . $model->name . " (" . $model->id . ")");
 
     push (@final_models, $model);

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -198,7 +198,7 @@ class Genome::Model::ClinSeq::Command::UpdateAnalysis {
               is => 'Boolean',
               doc => 'Treat validation data as exome data. Includes instrument data from validation capture in exome reference alignment model.',
         },
-        validation_as_exome_my_trsn => {
+        my_trsn => {
               is => 'Number',
               doc => 'If using validation-as-exome option, option to specify what instrument data to derive the target-set-region-name and region-of-interest from. 1=exome or 2=validation', 
         },
@@ -256,10 +256,10 @@ sub execute {
     return 1;
   }
   
-  #If the user selected the --validation-as-exome-my-trsn option, make sure --validation-as-exome option is used
-  if ($self->validation_as_exome_my_trsn) {
+  #If the user selected the --my-trsn option, make sure --validation-as-exome option is used
+  if ($self->my_trsn) {
     unless ($self->validation_as_exome) {
-      die $self->error_message("Exiting... validation_as_exome_my_trsn requires validation_as_exome option");
+      die $self->error_message("Exiting... my-trsn requires validation-as-exome option");
     }
   }
 
@@ -840,19 +840,19 @@ sub get_trsn{
   my %trsns;
   my $trsn_ref;
   
-  #When using validation-as-exome and validation-as-exome-my-trsn options, use user-defined target region set name (1=exome or 2=validation)
-  if ($self->validation_as_exome && $self->validation_as_exome_my_trsn) {
-    my $user_trsn = $self->validation_as_exome_my_trsn;
+  #When using validation-as-exome and my-trsn options, use user-defined target region set name (1=exome or 2=validation)
+  if ($self->validation_as_exome && $self->my_trsn) {
+    my $user_trsn = $self->my_trsn;
     
-    #Check if a valid option for validation-as-exome-my-trsn and use or warn user and exit
+    #Check if a valid option for my-trsn and use or warn user and exit
     if ($user_trsn == 1){
       $user_trsn = 'exome';
-      $self->warning_message("Using '$user_trsn' target region specified by validation-as-exome-my-trsn.");
+      $self->warning_message("Using '$user_trsn' target region specified by my-trsn.");
     }elsif($user_trsn == 2){
       $user_trsn = 'validation';
-      $self->warning_message("Using '$user_trsn' target region specified by validation-as-exome-my-trsn.");
+      $self->warning_message("Using '$user_trsn' target region specified by my-trsn.");
     }else{
-      die $self->error_message("Not a valid argument for validation_as_exome_my_trsn. 1='exome' or 2='validation'");
+      die $self->error_message("Not a valid argument for my_trsn. 1='exome' or 2='validation'");
     }
     
     #Assigns the target-region-set-name to the value defined by the user

--- a/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/UpdateAnalysis.pm
@@ -796,26 +796,6 @@ sub check_model_trsn_and_roi{
     }
   }
 
-#  my $trsn_ref;
-#  foreach my $instrument_data (@model_instrument_data){
-#    my $trsn = $instrument_data->target_region_set_name;
-#    if ($trsn){
-#      if ($self->validation_as_exome && $self->validation_as_exome_my_trsn) {
-#        my $fl = Genome::FeatureList->get(name => $trsn);
-#        if ($fl->content_type eq 'exome') {
-#          $trsns{$trsn}=1;
-#          $trsn_ref = 'SeqCap EZ Human Exome v2.0';
-#        }else{
-#          $trsns{$trsn}=1;
-#        }
-#      }else{
-#        $trsns{$trsn}=1;
-#        $trsn_ref = $trsn;
-#      }
-#    }
-#  }
-
-  
   #Watch out for cases where multiple TRSNs have been combined...
   my $trsn_count = keys %trsns;
   if ($trsn_count >= 2){
@@ -859,14 +839,6 @@ sub get_trsn{
 
   my %trsns;
   my $trsn_ref;
-
-#  foreach my $instrument_data (@instrument_data){
-#    my $trsn = $instrument_data->target_region_set_name;
-#    if ($trsn){
-#      $trsns{$trsn}=1;
-#      $trsn_ref = $trsn;
-#    }
-#  }
 
   foreach my $instrument_data (@instrument_data){
     my $trsn = $instrument_data->target_region_set_name;


### PR DESCRIPTION
This pull request added 2 options to clin-seq update-analysis. 1) --validation-as-exome allows users to combine exome and validation instrument data when setting up reference alignments. 2) --my-trsn allows the user to specify which instrument data (validation or exome) to use for the target-set-region-name and region-of-interest options when using --validation-as-exome.