### PR TITLE
Ensure the exception message shows up in the error message.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -229,8 +229,9 @@ sub create {
         $self->debug_message('Merge done');
     }
     catch {
+        my $err = $_;
         $tx->rollback();
-        die $class->error_message('Merge failed due to error: ' . $_);
+        die $class->error_message('Merge failed due to error: ' . $err);
     };
 
     $self->_reallocate_disk_allocation;


### PR DESCRIPTION
Looks like rollback() was blanking $_, making the error message not
helpful.