### PR TITLE
Update speedseq to not pass number threads along as an aligner_param

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
@@ -84,6 +84,7 @@ sub create {
         temp_directory => $temp_directory,
     );
     my %aligner_params = eval($self->aligner_params);
+    $aligner_params{threads} = $self->_available_cpu_count;
     my $command = Genome::Model::Tools::Speedseq::Realign->create(%params, %aligner_params);
     unless ($command->execute) {
         die $self->error_message('Failed to execute Speedseq realign for instrument data: ' . join(', ', map {$_->id} $self->instrument_data));

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow.t
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow.t
@@ -197,7 +197,7 @@ subtest 'simple align_and_merge strategy' => sub {
             force_fragment => 0,
             result_users => $result_users,
         },
-        strategy => 'instrument_data both aligned to reference_sequence_build and merged using speedseq test [threads => 8, sort_memory => 8] api v1',
+        strategy => 'instrument_data both aligned to reference_sequence_build and merged using speedseq test [sort_memory => 8] api v1',
     );
     isa_ok(
         $ad,
@@ -251,7 +251,7 @@ subtest 'simple align_and_merge strategy with qc decoration' => sub {
             force_fragment => 0,
             result_users => $result_users,
         },
-        strategy => sprintf('instrument_data both aligned to reference_sequence_build and merged using speedseq test [threads => 8, sort_memory => 8] @align-and-merge-qc [%s] api v1', $config_name),
+        strategy => sprintf('instrument_data both aligned to reference_sequence_build and merged using speedseq test [sort_memory => 8] @align-and-merge-qc [%s] api v1', $config_name),
     );
     isa_ok(
         $ad,
@@ -689,7 +689,7 @@ sub construct_speedseq_result {
         reference_build => $reference,
         aligner_name => 'speedseq',
         aligner_version => 'test',
-        aligner_params => 'threads => 8, sort_memory => 8',
+        aligner_params => 'sort_memory => 8',
     );
     for my $i (0..$#instrument_data) {
         $speedseq_result->add_input(
@@ -713,7 +713,7 @@ sub construct_speedseq_result {
             reference_build => $reference,
             aligner_name => 'speedseq',
             aligner_version => 'test',
-            aligner_params => 'threads => 8, sort_memory => 8',
+            aligner_params => 'sort_memory => 8',
             samtools_version => 'r599',
             picard_version => '1.29',
         );


### PR DESCRIPTION
Previously, we would specify `threads => 8` in the aligner params portion of the alignment strategy for speedseq. This would get passed into the speedseq wrapper and would set the `-t 8` parameter which would allow speedseq to run with 8 threads (or whatever number was specified in the alignment strategy). 

This PR makes it so that the number of threads are not being defined in the alignment strategy anymore. Instead the `-t` parameter is being set by calling `_available_cpu_count` which under the hood examines the LSF resources of the current job. 

This ensures that the `-t` parameter of speedseq is the same value as the number of cpus requested in LSF and it also makes it so that the number of threads aren't part of the lookup hash of the software result anymore. Speedseq software results will now shortcut no matter the number of threads the data was processed with.

We will need to set test names on existing speedseq software results that have threads specified in the aligner_params. We will also need to change the name of any processing profiles that use threads in the aligner params to deprecate them.