### PR TITLE
Dynamic resource requirements for AlignAndMerge (Speedseq)

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -730,5 +730,12 @@ sub scalar_property_from_underlying_alignment_results {
     }
 }
 
+sub estimated_gtmp_for_instrument_data  {
+    my $class = shift;
+    die $class->error_message(
+        "Attempted to call estimated_gtmp_for_instrument_data() on %s which does not implement it!",
+        $class
+    );
+}
 
 1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
@@ -9,6 +9,7 @@ use Genome::InstrumentData::AlignmentResult::Merged::Helpers qw(
     resolve_alignment_subdirectory
     resolve_allocation_disk_group_name
 );
+use File::stat;
 
 class Genome::InstrumentData::AlignmentResult::Merged::Speedseq {
     is => ['Genome::InstrumentData::AlignedBamResult::Merged', 'Genome::SoftwareResult::WithNestedResults'],
@@ -114,6 +115,19 @@ sub create {
 sub aligner_name_for_aligner_index {
     my $self = shift;
     return $self->aligner_name;
+}
+
+sub estimated_gtmp_for_instrument_data {
+    my $class = shift;
+    my $instrument_data = shift;
+    my $bam_path = $instrument_data->bam_path();
+
+    my $st = stat($bam_path);
+    unless ($st) {
+        die $class->error_message('Unable to find bam file at %s', $bam_path);
+    }
+
+    return 3 * $st->size();
 }
 
 1;

--- a/lib/perl/Genome/InstrumentData/Command/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignAndMerge.pm
@@ -139,9 +139,9 @@ sub _process_alignments {
     my $self = shift;
     my $mode = shift;
 
-    my $class = $self->class->merged_result_class($self->name);
+    my $merged_class = $self->class->merged_result_class($self->name);
     my %params = $self->_alignment_params;
-    my $result = $class->$mode(
+    my $result = $merged_class->$mode(
         instrument_data => [$self->instrument_data],
         %params,
     );
@@ -153,11 +153,11 @@ sub _process_per_lane_alignments {
     my $self = shift;
     my $mode = shift;
 
-    my $class = $self->class->per_lane_result_class($self->name);
+    my $per_lane_class = $self->class->per_lane_result_class($self->name);
     my %params = $self->_alignment_params;
     my @per_lane_results;
     for my $instrument_data ($self->instrument_data) {
-        push @per_lane_results, $class->$mode(
+        push @per_lane_results, $per_lane_class->$mode(
             instrument_data => $instrument_data,
             samtools_version => $self->samtools_version,
             picard_version => $self->picard_version,

--- a/lib/perl/Genome/InstrumentData/Command/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignAndMerge.pm
@@ -162,7 +162,7 @@ sub _process_alignments {
     my $self = shift;
     my $mode = shift;
 
-    my $class = $self->merged_result_class;
+    my $class = $self->class->merged_result_class($self->name);
     my %params = $self->_alignment_params;
     my $result = $class->$mode(
         instrument_data => [$self->instrument_data],
@@ -176,7 +176,7 @@ sub _process_per_lane_alignments {
     my $self = shift;
     my $mode = shift;
 
-    my $class = $self->per_lane_result_class;
+    my $class = $self->class->per_lane_result_class($self->name);
     my %params = $self->_alignment_params;
     my @per_lane_results;
     for my $instrument_data ($self->instrument_data) {
@@ -206,13 +206,15 @@ sub _alignment_params {
 }
 
 sub merged_result_class {
-    my $self = shift;
-    return 'Genome::InstrumentData::AlignmentResult::Merged::' . ucfirst($self->name);
+    my $class = shift;
+    my $name = shift;
+    return 'Genome::InstrumentData::AlignmentResult::Merged::' . ucfirst($name);
 }
 
 sub per_lane_result_class {
-    my $self = shift;
-    return 'Genome::InstrumentData::AlignmentResult::' . ucfirst($self->name);
+    my $class = shift;
+    my $name = shift;
+    return 'Genome::InstrumentData::AlignmentResult::' . ucfirst($name);
 }
 
 1;

--- a/lib/perl/Genome/InstrumentData/Command/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignAndMerge.pm
@@ -88,30 +88,7 @@ class Genome::InstrumentData::Command::AlignAndMerge {
             doc => 'The per-lane results generated/found when running the command',
         },
     ],
-    has_param => [
-        lsf_resource => {
-            value => &_lsf_resource(),
-        },
-    ],
 };
-
-sub _lsf_resource {
-
-    my $mem_mb = 1024 * 60;
-    my $mem_kb = $mem_mb*1024;
-
-    my $cpus = 8;
-
-    my $queue = Genome::Config::get('lsf_queue_alignment_prod');
-
-    my $select  = "select[ncpus >= $cpus && mem >= $mem_mb] span[hosts=1]";
-    my $rusage  = "rusage[mem=$mem_mb]";
-    my $options = "-M $mem_kb -n $cpus -q $queue";
-
-    my $required_usage = "-R '$select $rusage' $options";
-
-    return $required_usage;
-}
 
 sub execute {
     my $self = shift;

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow.t
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow.t
@@ -190,6 +190,12 @@ subtest 'simple alignments with qc decoration' => sub {
 };
 
 subtest 'simple align_and_merge strategy' => sub {
+    use Genome::InstrumentData::AlignmentResult::Merged::Speedseq;
+    my $gtmp_override = Sub::Override->new(
+        'Genome::InstrumentData::AlignmentResult::Merged::Speedseq::estimated_gtmp_for_instrument_data',
+        sub { return 1; },
+    );
+
     my $ad = Genome::InstrumentData::Composite::Workflow->create(
         inputs => {
             instrument_data => \@two_instrument_data,
@@ -241,6 +247,11 @@ subtest 'simple align_and_merge strategy with qc decoration' => sub {
         sub {
             return {test1 => {class => "TestTool1", params => {param1 => 1}}};
         },
+    );
+    use Genome::InstrumentData::AlignmentResult::Merged::Speedseq;
+    my $gtmp_override = Sub::Override->new(
+        'Genome::InstrumentData::AlignmentResult::Merged::Speedseq::estimated_gtmp_for_instrument_data',
+        sub { return 1; },
     );
 
     my $config_name = 'qc2 for Workflow test';

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -3,6 +3,8 @@ package Genome::InstrumentData::Composite::Workflow::Generator::AlignAndMerge;
 use strict;
 use warnings;
 use Genome;
+use POSIX qw(ceil);
+use List::Util qw(sum);
 
 class Genome::InstrumentData::Composite::Workflow::Generator::AlignAndMerge {
     is => 'Genome::InstrumentData::Composite::Workflow::Generator::Base',
@@ -35,6 +37,14 @@ sub generate {
             command_class_name => 'Genome::InstrumentData::Command::AlignAndMerge',
         ),
     );
+
+    my $instrument_data = $input_data->{instrument_data};
+    my $lsf_resource_string = $class->_get_lsf_resource_string_for_aligner_and_instrument_data(
+        $aligner_name,
+        @$instrument_data
+    );
+
+    $operation->operation_type->lsf_resource($lsf_resource_string);
 
     #Connect input connectors to the operation
     my $inputs = [];
@@ -70,6 +80,40 @@ sub generate {
     }
 
     return $workflows, $inputs;
+}
+
+sub _get_lsf_resource_string_for_aligner_and_instrument_data {
+    my $class = shift;
+    my $aligner_name = shift;
+    my @instrument_data = @_;
+
+    my $merged_result_class = Genome::InstrumentData::Command::AlignAndMerge->merged_result_class($aligner_name);
+    my $estimated_gtmp_bytes = sum(map { $merged_result_class->estimated_gtmp_for_instrument_data($_) } @instrument_data);
+    return $class->_format_lsf_resource_string($estimated_gtmp_bytes);
+}
+
+sub _format_lsf_resource_string {
+    my $class = shift;
+    my $gtmp_bytes = shift;
+
+    my $cpus = 8;
+    my $mem_gb = 36;
+    my $queue = Genome::Config::get('lsf_queue_alignment_prod');
+
+    my $gtmp_kb = ceil($gtmp_bytes / 1024);
+    my $gtmp_mb = ceil($gtmp_kb / 1024);
+    my $gtmp_gb = ceil($gtmp_mb / 1024);
+
+    my $mem_mb = $mem_gb * 1024;
+    my $mem_kb = $mem_mb * 1024;
+
+    my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $gtmp_gb] span[hosts=1]";
+    my $rusage  = "rusage[mem=$mem_mb, gtmp=$gtmp_gb]";
+    my $options = "-M $mem_kb -n $cpus -q $queue";
+
+    my $required_usage = "-R \'$select $rusage\' $options";
+
+    return $required_usage;
 }
 
 # sub _workflow_


### PR DESCRIPTION
Previously, lsf resource usage for `AlignAndMerge` was hardcoded (and did not include gtmp). Now tmp usage will be calculated dynamically based on the size of the input instrument data.

Unfortunately, that necessitates the sort of kludgey approach taken here. The `lsf_resource` param on the command does not have access to the particular command instance of a given run, and thus cannot know how many instrument data are attached. Instead, we staple the lsf resource requirements in at workflow construction time (this is done in other places as well, so it isn't unprecedented in our codebase).