### PR TITLE
GenotypeMicroarray: remove unused import_format param

### DIFF
--- a/lib/perl/Genome/Model/Command/Define/GenotypeMicroarray.pm
+++ b/lib/perl/Genome/Model/Command/Define/GenotypeMicroarray.pm
@@ -42,10 +42,6 @@ sub execute {
         Carp::confess "Could not resolve processing profile!";
     }
 
-    unless ($self->processing_profile->input_format eq 'wugc') {
-        Carp:confess "GenotypeMicroarray Models must use a 'wugc' input_format processing profile.";
-    }
-
     return $self->SUPER::_execute_body(@_);
 }
 

--- a/lib/perl/Genome/Model/GenotypeMicroarray.pm
+++ b/lib/perl/Genome/Model/GenotypeMicroarray.pm
@@ -20,11 +20,6 @@ class Genome::Model::GenotypeMicroarray{
         },
     },
     has_param => {
-        input_format => {
-            doc => 'file format, defaults to "wugc", which is currently the only format supported',
-            valid_values => ['wugc'],
-            default_value => 'wugc',
-        },
         instrument_type => {
             doc => 'the type of microarray instrument',
             valid_values => [qw/ affymetrix illumina infinium plink unknown /],


### PR DESCRIPTION
I will remove the params params params from the DB once the PR is in a snapshot.