### PR TITLE
CQID: Trust the configuration to know what instrument data to assign.

### DIFF
--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -113,7 +113,8 @@ sub _assign_instrument_data_to_model {
     my %params_hash = (model => $model);
     my $cmd = Genome::Model::Command::InstrumentData::Assign::ByExpression->create(
             model => $model,
-            instrument_data => [$instrument_data]
+            instrument_data => [$instrument_data],
+            force => 1, #trust the configuration to know what it's doing
         );
     my $executed_ok = eval{ $cmd->execute };
 


### PR DESCRIPTION
CQID tries to assign instrument data for models that were gotten or created by the configuration matching that instrument data.  It doesn't make sense to then not assign that instrument data to the model, so ensure the assignment always happens.