### PR TITLE
Minor Cleanup of PerLaneTophat module

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
@@ -454,12 +454,10 @@ sub _get_modified_tophat_params {
     }
 
     if ($self->annotation_build) {
-        #TODOthis method doesn't exist
         my $annotation_index = $self->get_annotation_index;
         if (_aliger_params_has_gtf($params)) {
             die ('This processing_profile is requesting annotation_reference_transcripts \''. $self->annotation_build->__display_name__ .'\', but there seems to be a GTF file already defined in the read_aligner_params: '. $params);
         }
-        #TODO: get ref index with annotation build
         my $transcriptome_index_prefix = $annotation_index->full_consensus_path();
         $params .= ' --transcriptome-index '. $transcriptome_index_prefix;
     }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
@@ -316,7 +316,7 @@ sub _get_bowtie_path_to_generate_annotation_index {
     return $bowtie_path;
 }
 
-sub _aliger_params_has_gtf {
+sub _aligner_params_include_gtf {
     my $params = shift;
     return ($params =~ /(^| )(-G|--GTF)/ ? 1 : 0);
 }
@@ -334,7 +334,7 @@ sub _get_aligner_params_to_generate_annotation_index {
     $aligner_params .= " --transcriptome-index '$index_prefix'";
 
     # add -G <gtf_file> option to tell TopHat what to make the index out of
-    if (_aliger_params_has_gtf($aligner_params)) {
+    if (_aligner_params_include_gtf($aligner_params)) {
         my $annotation_build = $annotation_index->annotation_build;
         $class->error_message('Annotation build \''. $annotation_build->__display_name__ .
             '\' is defined, but there seems to be a GTF file already in the read_aligner_params: ' .
@@ -455,7 +455,7 @@ sub _get_modified_tophat_params {
 
     if ($self->annotation_build) {
         my $annotation_index = $self->get_annotation_index;
-        if (_aliger_params_has_gtf($params)) {
+        if (_aligner_params_include_gtf($params)) {
             die ('This processing_profile is requesting annotation_reference_transcripts \''. $self->annotation_build->__display_name__ .'\', but there seems to be a GTF file already defined in the read_aligner_params: '. $params);
         }
         my $transcriptome_index_prefix = $annotation_index->full_consensus_path();

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
@@ -30,17 +30,17 @@ sub required_arch_os { 'x86_64' }
 #THE FILE Genome::InstrumentData::Command::AlignReads::PerLaneTophat INSTEAD!!!
 sub required_rusage {
     my $class = shift;
-    
+
     my $mem_mb = 32000;
     my $mem_kb = $mem_mb*1024;
     my $tmp_gb = 400;
     my $cpus = 4;
-    
+
     my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $tmp_gb] span[hosts=1]";
     my $rusage  = "rusage[mem=$mem_mb, gtmp=$tmp_gb]";
     my $options = "-M $mem_kb -n $cpus";
     my $required_usage = "-R '$select $rusage' $options";
-    
+
     return $required_usage;
 }
 
@@ -328,7 +328,7 @@ sub _get_aligner_params_to_generate_annotation_index {
 
     # remove --bowtie-version from aligner_params
     $aligner_params = $class->_remove_bowtie_version($aligner_params);
- 
+
     # add in the options that tell TopHat that we want to store the index
     $aligner_params .= " --transcriptome-only";
     $aligner_params .= " --transcriptome-index '$index_prefix'";
@@ -479,9 +479,9 @@ sub _get_modified_tophat_params {
     # Default of 300 should be reasonable for 500bp PE libraries sequenced 2x100bp
     my $estimated_library_size = 350;
     my $estimated_sd = 50;
-    
+
     my $median_inner_insert_size = ($estimated_library_size - ($instrument_data->read_length * 2) );
-    
+
     my $sd_insert_size = $estimated_sd;
     $params .= ' --mate-inner-dist '. $median_inner_insert_size;
     $params .= ' --mate-std-dev '. $sd_insert_size;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.t
@@ -22,8 +22,8 @@ sub _join {
 my $class = 'Genome::InstrumentData::AlignmentResult::PerLaneTophat';
 use_ok($class);
 
-do { # _aliger_params_has_gtf tests
-    my $f = \&Genome::InstrumentData::AlignmentResult::PerLaneTophat::_aliger_params_has_gtf;
+do { # _aligner_params_include_gtf tests
+    my $f = \&Genome::InstrumentData::AlignmentResult::PerLaneTophat::_aligner_params_include_gtf;
     my @tests = (
         ['-G foo',     1],
         [' -G foo',    1],
@@ -34,7 +34,7 @@ do { # _aliger_params_has_gtf tests
     );
     for my $test (@tests) {
         my ($s, $e) = @$test;
-        my $n = '_aliger_params_has_gtf: ' . ($e ? "did match: $s" : "did not match: $s");
+        my $n = '_aligner_params_include_gtf: ' . ($e ? "did match: $s" : "did not match: $s");
         is($f->($s), $e, $n);
     }
 };


### PR DESCRIPTION
* Remove some old `TODO`s left over from before the redaction.
* Add the letter `n` and subject-verb number agreement.
* Remove trailing whitespace.