### PR TITLE
Remove unwanted points from LOH plot

### DIFF
--- a/lib/perl/Genome/Model/Tools/Varscan/LohSegments.pm
+++ b/lib/perl/Genome/Model/Tools/Varscan/LohSegments.pm
@@ -291,8 +291,13 @@ if(nrow(CNA.object) != 0) {
     pvalue.segment.CNA.object <- segment.CNA.object\$output
     detach(package:DNAcopy)
     par(mar=c(4,4,2,2))
+    #This could be removed since we pre-select the normal SNPs
+    #using min_freq_for_het and max_freq_for_het, we thus already know
+    #how these points look
     plot(snp\$pos[snp\$chrom=="$chrom"], snp\$nfreq[snp\$chrom=="$chrom"], pch=19, cex=0.25, ylim=c(0,100), xlim=c(1,maxpos), xlab="Position on chr$chrom", ylab="Variant Allele Freq", col="blue")
     points(snp\$pos[snp\$chrom=="$chrom"], snp\$tfreq[snp\$chrom=="$chrom"], pch=19, cex=0.25, ylim=c(0,100), col="green")
+    #The y value is the segment mean, which is essentially
+    #the proportion of LOH SNPs in a segment.
     segments(lohsegs\$chr_start[lohsegs\$chrom=="$chrom"], lohsegs\$one[lohsegs\$chrom=="$chrom"], lohsegs\$chr_stop[lohsegs\$chrom=="$chrom"], lohsegs\$one[lohsegs\$chrom=="$chrom"], col="red")
     segments(pvalue.segment.CNA.object\$loc.start[pvalue.segment.CNA.object\$seg.mean>0.10], pvalue.segment.CNA.object\$seg.mean[pvalue.segment.CNA.object\$seg.mean>0.10] * 100, pvalue.segment.CNA.object\$loc.end[pvalue.segment.CNA.object\$seg.mean>0.10], pvalue.segment.CNA.object\$seg.mean[pvalue.segment.CNA.object\$seg.mean>0.10] * 100, col="red", lwd=2)
     hetDiff <- abs(snp\$nfreq - snp\$tfreq)

--- a/lib/perl/Genome/Model/Tools/Varscan/LohSegments.pm
+++ b/lib/perl/Genome/Model/Tools/Varscan/LohSegments.pm
@@ -261,7 +261,6 @@ sub execute {                               # replace with real execution logic.
     open(OUTFILE, ">$output_basename.R") or die "Can't open outfile: $!\n";
     print OUTFILE "snp <- read.table(\"$output_basename.infile\", header=TRUE)\n";
     print OUTFILE "lohsegs <- read.table(\"$output_basename.rawsegments\", header=TRUE)\n";
-    print OUTFILE "minus1 <- snp\$pos - snp\$pos - 1\n";
 
     my @cbs_files = ();
     my $cbs_fileCounter = 0;
@@ -297,7 +296,6 @@ if(nrow(CNA.object) != 0) {
     segments(lohsegs\$chr_start[lohsegs\$chrom=="$chrom"], lohsegs\$one[lohsegs\$chrom=="$chrom"], lohsegs\$chr_stop[lohsegs\$chrom=="$chrom"], lohsegs\$one[lohsegs\$chrom=="$chrom"], col="red")
     segments(pvalue.segment.CNA.object\$loc.start[pvalue.segment.CNA.object\$seg.mean>0.10], pvalue.segment.CNA.object\$seg.mean[pvalue.segment.CNA.object\$seg.mean>0.10] * 100, pvalue.segment.CNA.object\$loc.end[pvalue.segment.CNA.object\$seg.mean>0.10], pvalue.segment.CNA.object\$seg.mean[pvalue.segment.CNA.object\$seg.mean>0.10] * 100, col="red", lwd=2)
     hetDiff <- abs(snp\$nfreq - snp\$tfreq)
-    points(snp\$pos[snp\$chrom=="$chrom" & snp\$status=="1"], minus1[snp\$chrom=="$chrom" & snp\$status=="1"], pch=19, cex=0.5, ylim=c(0,100), col="red")
     legend("topright", legend = c("Normal","Tumor","LOH"), lty=c(1,1,1), lwd=c(2.5,2.5,2.5), col=c("blue","green","red"))
     dev.off()
     #plot the distribution of VAFs


### PR DESCRIPTION
This pull-request removes individual LOH points from the plots which are a bit confusing and don't add a lot of information. The tumor VAF for these points are still plotted, along with the identified segments which should provide the information we need.