### PR TITLE
Don't worry about design_set reference in SomaticValidation

### DIFF
--- a/lib/perl/Genome/Model/Build/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation.pm
@@ -267,7 +267,7 @@ sub _validate_required_for_start_properties {
 sub reference_being_replaced_for_input {
     my ($self, $input) = @_;
 
-    if($input->name eq "target_region_set"){
+    if($input->name eq "target_region_set" or $input->name eq "design_set"){
         return 1;
     }
 


### PR DESCRIPTION
The design_set isn't used in the pipeline--it is the source of the target_region_set (whose reference we already ignore).