### PR TITLE
WorkflowBuilder class for Block operations.

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/Block.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Block.pm
@@ -1,0 +1,62 @@
+package Genome::WorkflowBuilder::Block;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::WorkflowBuilder::Block {
+    is => 'Genome::WorkflowBuilder::Detail::Operation',
+    has => [
+        properties => {
+            is_many => 1,
+            is => 'Text',
+        },
+    ],
+};
+
+sub input_properties {
+    return $_[0]->properties;
+}
+
+sub output_properties {
+    return $_[0]->properties;
+}
+
+sub from_xml_element {
+    my ($class, $element) = @_;
+
+    my @properties = map $_->textContent, $element->findnodes('.//property');
+
+    return $class->create(
+        name => $element->getAttribute('name'),
+        properties => \@properties,
+    );
+}
+
+sub is_property {
+    my ($self, $name) = @_;
+
+    return Set::Scalar->new($self->properties)->contains($name);
+}
+
+sub is_input_property {
+    my $self = shift;
+    return $self->is_property(@_);
+}
+
+sub is_output_property {
+    my $self = shift;
+    return $self->is_property(@_);
+}
+
+sub _add_property_xml_elements {
+    my ($self, $element) = @_;
+
+    map $self->_add_property_xml_element($element, 'property', $_), $self->properties;
+
+    return;
+}
+
+
+1;

--- a/lib/perl/Genome/WorkflowBuilder/Block.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Block.pm
@@ -15,6 +15,39 @@ class Genome::WorkflowBuilder::Block {
     ],
 };
 
+sub get_ptero_builder_task {
+    require Ptero::Builder::Detail::Workflow::Task;
+
+    my $self = shift;
+
+    $self->validate;
+
+    my %params = (
+        name => $self->name,
+        methods => [
+            $self->_get_ptero_block_method(),
+        ],
+    );
+    if (defined $self->parallel_by) {
+        $params{parallel_by} = $self->parallel_by;
+    }
+    return Ptero::Builder::Detail::Workflow::Task->new(%params);
+}
+
+sub _get_ptero_block_method {
+    require Ptero::Builder::Detail::Workflow::Converge;
+
+    my $self = shift;
+    my ($output_name) = $self->output_properties;
+    return Ptero::Builder::Detail::Workflow::Block->new(
+        name => 'block',
+        parameters => {
+            input_names => [$self->input_properties],
+            output_name => $output_name,
+        },
+    );
+}
+
 sub input_properties {
     return $_[0]->properties;
 }

--- a/lib/perl/Genome/WorkflowBuilder/Block.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Block.pm
@@ -35,7 +35,7 @@ sub get_ptero_builder_task {
 }
 
 sub _get_ptero_block_method {
-    require Ptero::Builder::Detail::Workflow::Converge;
+    require Ptero::Builder::Detail::Workflow::Block;
 
     my $self = shift;
     my ($output_name) = $self->output_properties;

--- a/lib/perl/Genome/WorkflowBuilder/Detail/Operation.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Detail/Operation.pm
@@ -168,10 +168,7 @@ sub _get_operation_type_xml_element {
 
     $element->setAttribute('typeClass', $self->operation_type);
 
-    map {$self->_add_property_xml_element($element, 'inputproperty', $_)}
-        $self->input_properties;
-    map {$self->_add_property_xml_element($element, 'outputproperty', $_)}
-        $self->output_properties;
+    $self->_add_property_xml_elements($element);
 
     my %attributes = $self->operation_type_attributes;
     for my $attr_name (keys(%attributes)) {
@@ -179,6 +176,17 @@ sub _get_operation_type_xml_element {
     }
 
     return $element;
+}
+
+sub _add_property_xml_elements {
+    my ($self, $element) = @_;
+
+    map {$self->_add_property_xml_element($element, 'inputproperty', $_)}
+        $self->input_properties;
+    map {$self->_add_property_xml_element($element, 'outputproperty', $_)}
+        $self->output_properties;
+
+    return;
 }
 
 sub _add_property_xml_element {

--- a/lib/perl/Genome/WorkflowBuilder/Detail/TypeMap.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Detail/TypeMap.pm
@@ -8,6 +8,7 @@ my %_CLASS_TO_TYPE_MAPPING = (
     'Genome::WorkflowBuilder::Command' => 'Workflow::OperationType::Command',
     'Genome::WorkflowBuilder::Converge' => 'Workflow::OperationType::Converge',
     'Genome::WorkflowBuilder::Event' => 'Workflow::OperationType::Event',
+    'Genome::WorkflowBuilder::Block' => 'Workflow::OperationType::Block',
 );
 
 my %_TYPE_TO_CLASS_MAPPING;

--- a/lib/perl/Genome/WorkflowBuilder/Detail/TypeMap.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Detail/TypeMap.pm
@@ -7,8 +7,8 @@ my %_CLASS_TO_TYPE_MAPPING = (
     'Genome::WorkflowBuilder::DAG' => 'Workflow::OperationType::Model',
     'Genome::WorkflowBuilder::Command' => 'Workflow::OperationType::Command',
     'Genome::WorkflowBuilder::Converge' => 'Workflow::OperationType::Converge',
-    'Genome::WorkflowBuilder::Event' => 'Workflow::OperationType::Event',
     'Genome::WorkflowBuilder::Block' => 'Workflow::OperationType::Block',
+    'Genome::WorkflowBuilder::Event' => 'Workflow::OperationType::Event',
 );
 
 my %_TYPE_TO_CLASS_MAPPING;


### PR DESCRIPTION
The "gene-prediction eukaryotic" pipeline was broken by the switchover to `WorkflowBuilder` for all build validation.  This is one step towards making it work again.