### PR TITLE
GP Eukaryotic: Make fasta_files is_many in SplitFasta

### DIFF
--- a/lib/perl/Genome/Model/GenePrediction/Command/Eukaryotic/SplitFasta.pm
+++ b/lib/perl/Genome/Model/GenePrediction/Command/Eukaryotic/SplitFasta.pm
@@ -37,8 +37,8 @@ class Genome::Model::GenePrediction::Command::Eukaryotic::SplitFasta {
             default => 5000000,
             doc => 'Maximum number of bases allowed in each split fasta file',
         },
-        fasta_files => {
-            is => 'ARRAY',
+        split_fasta_files => {
+            is_many => 1,
             is_output => 1,
             doc => 'An array of split fasta files',
         },
@@ -135,7 +135,7 @@ sub execute {
         $current_chunk_size += $length;
     }
 
-    $self->fasta_files(\@filenames);
+    $self->split_fasta_files(\@filenames);
     $self->genome_size($total_bases);
     $self->debug_message("Created $counter fasta files in $output_directory.");
     $self->debug_message("Altogether, there are $total_bases bases of sequence!");

--- a/lib/perl/Genome/Model/GenePrediction/Eukaryotic.pm.xml
+++ b/lib/perl/Genome/Model/GenePrediction/Eukaryotic.pm.xml
@@ -7,7 +7,7 @@
     <link fromOperation="input connector"          fromProperty="split_fastas_output_directory"      toOperation="split_fasta"              toProperty="output_directory" />
     <link fromOperation="input connector"          fromProperty="max_bases_per_fasta"                toOperation="split_fasta"              toProperty="max_bases_per_file" />
 
-    <link fromOperation="split_fasta"              fromProperty="fasta_files"                        toOperation="contig_predict_genes"     toProperty="fasta_file" />
+    <link fromOperation="split_fasta"              fromProperty="split_fasta_files"                        toOperation="contig_predict_genes"     toProperty="fasta_file" />
     <link fromOperation="input connector"          fromProperty="prediction_directory"               toOperation="contig_predict_genes"     toProperty="prediction_directory" />
     <link fromOperation="input connector"          fromProperty="domain"                             toOperation="contig_predict_genes"     toProperty="domain" />
     <link fromOperation="input connector"          fromProperty="raw_output_directory"               toOperation="contig_predict_genes"     toProperty="raw_output_directory" />


### PR DESCRIPTION
`WorkflowBuilder` cares about the difference between an `ARRAY` and an `is_many` property as the input to a `parallelBy` workflow.  (This is the second and hopefully final part of fixing gene-prediction eukaryotic.)