### PR TITLE
Allow QC framework to work on merged alignment results

### DIFF
--- a/lib/perl/Genome/InstrumentData/Composite/Workflow.t
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow.t
@@ -286,6 +286,72 @@ subtest 'simple align_and_merge strategy with qc decoration' => sub {
     $override->restore;
 };
 
+subtest 'simple align_and_merge strategy with qc decoration for merged result' => sub {
+    {
+        package TestTool1;
+
+        use Genome;
+
+        class TestTool1 {
+            is => ['Genome::Qc::Tool'],
+            has => {param1 => {}},
+        };
+
+        sub cmd_line {
+            my $self = shift;
+            return ("echo", $self->param1);
+        }
+
+        sub supports_streaming { return 0; }
+
+        sub get_metrics {
+            return ( metric1 => 1 );
+        }
+    }
+
+    use Genome::Qc::Config;
+    my $override = Sub::Override->new(
+        'Genome::Qc::Config::get_commands_for_alignment_result',
+        sub {
+            return {test1 => {class => "TestTool1", params => {param1 => 1}}};
+        },
+    );
+    use Genome::InstrumentData::AlignmentResult::Merged::Speedseq;
+    my $gtmp_override = Sub::Override->new(
+        'Genome::InstrumentData::AlignmentResult::Merged::Speedseq::estimated_gtmp_for_instrument_data',
+        sub { return 1; },
+    );
+
+    my $config_name = 'qc3 for Workflow test';
+    my $ad = Genome::InstrumentData::Composite::Workflow->create(
+        inputs => {
+            instrument_data => \@two_instrument_data,
+            reference_sequence_build => $ref,
+            force_fragment => 0,
+            result_users => $result_users,
+        },
+        strategy => sprintf('instrument_data both aligned to reference_sequence_build and merged using speedseq 0.0.3a-gms [sort_memory => 8] @qc [%s] api v1', $config_name),
+    );
+    isa_ok(
+        $ad,
+        'Genome::InstrumentData::Composite::Workflow',
+        'created dispatcher for simple align_and_merge strategy'
+    );
+
+    ok($ad->execute, 'executed dispatcher for simple align_and_merge');
+    my @ad_result_ids = $ad->_result_ids;
+    my @ad_results = Genome::SoftwareResult->get(\@ad_result_ids);
+    is_deeply([$speedseq_result], [sort @ad_results], 'found speedseq result');
+    check_result_bam(@ad_results);
+
+    my $qc_result = Genome::Qc::Result->get(alignment_result => $speedseq_result, config_name => $config_name);
+    ok($qc_result, sprintf('Qc result was created successfully'));
+    is_deeply({ $qc_result->get_metrics }, { metric1 => 1 }, 'Metrics as expected');
+
+    $override->restore;
+};
+
+
 subtest 'simple alignments with merge' => sub {
     my $ad = Genome::InstrumentData::Composite::Workflow->create(
         inputs => {

--- a/lib/perl/Genome/Qc/Result.pm
+++ b/lib/perl/Genome/Qc/Result.pm
@@ -3,6 +3,7 @@ package Genome::Qc::Result;
 use strict;
 use warnings;
 use Genome;
+use List::MoreUtils qw(uniq);
 
 class Genome::Qc::Result {
     is => 'Genome::SoftwareResult::StageableSimple',
@@ -158,7 +159,15 @@ sub _add_metrics {
 
 sub is_capture {
     my $self = shift;
-    return $self->alignment_result->instrument_data->is_capture;
+
+    my @instrument_data = $self->alignment_result->instrument_data;
+    my @is_capture = uniq map {$_->is_capture} @instrument_data;
+    if (scalar(@is_capture) > 1) {
+        die $self->error_message("Some instrument data in alignment result (%s) are capture and others aren't.", $self->alignment_result->id);
+    }
+    else {
+        return $is_capture[0];
+    }
 }
 
 1;

--- a/lib/perl/Genome/Qc/Tool.pm
+++ b/lib/perl/Genome/Qc/Tool.pm
@@ -65,8 +65,12 @@ sub sample {
     my $self = shift;
 
     my @samples = uniq map {$_->sample} $self->alignment_result->instrument_data;
-    die "More than one sample" if scalar(@samples) > 1;
-    return $samples[0];
+    if (scalar(@samples) > 1) {
+        die $self->error_message("More than one sample: %s", join(', ', map {$_->name} @samples));
+    }
+    else {
+        return $samples[0];
+    }
 }
 
 sub sample_id {

--- a/lib/perl/Genome/Qc/Tool.pm
+++ b/lib/perl/Genome/Qc/Tool.pm
@@ -66,7 +66,7 @@ sub sample {
 
     my @samples = uniq map {$_->sample} $self->alignment_result->instrument_data;
     if (scalar(@samples) > 1) {
-        die $self->error_message("More than one sample: %s", join(', ', map {$_->name} @samples));
+        die $self->error_message("More than one sample for alignment result (%s): %s", $self->alignment_result->id, join(', ', map {$_->name} @samples));
     }
     else {
         return $samples[0];


### PR DESCRIPTION
This change is needed to support running verifyBamId on the merged alignment result. The QC framework continues to support running QC tools on the per-lane alignment results.