### PR TITLE
Project purge command

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -136,11 +136,6 @@ sub purge_one_analysis_project {
 
     my $unlocker = $self->_get_lock_for_analysis_project($anp);
 
-    my $sth = $dbh->prepare($sql);
-    die $self->error_message("preparing SQL failed : $DBI::errstr") unless $sth;
-
-    $sth->execute($anp->id);
-
     my $total_kb_purged = 0;
     my $software_result_count = 0;
 
@@ -150,6 +145,11 @@ sub purge_one_analysis_project {
                                 int($total_kb_purged / KB_IN_ONE_GB),
                                 $software_result_count);
     });
+
+    my $sth = $dbh->prepare($sql);
+    die $self->error_message("preparing SQL failed : $DBI::errstr") unless $sth;
+
+    $sth->execute($anp->id);
 
     while (my $data = $sth->fetchrow_hashref()) {
         my $sr = Genome::SoftwareResult->get($data->{result_id});

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -30,7 +30,8 @@ class Genome::Model::Command::Admin::PurgeSoftwareResultsFromAnalysisProject {
 };
 
 my $sql = qq(
-    SELECT * FROM (
+    SELECT candidates.result_id, candidates.profile_item_id, candidates.anp_name, candidates.anp_id, candidates.kilobytes_requested
+    FROM (
         SELECT sr.id result_id, sr.class_name, bridge.analysis_project_id anp_id, anp.name anp_name, cpi.id profile_item_id, sr.outputs_path, da.id allocation_id, da.kilobytes_requested, da.status
         FROM result.software_result sr
         INNER JOIN disk.allocation da ON da.owner_id = sr.id AND da.owner_class_name = sr.class_name

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -167,11 +167,13 @@ sub purge_one_analysis_project {
 sub _do_expunge {
     my($self, $sr, $reason) = @_;
 
-    if ($self->dry_run) {
-        $self->warning_message('Dry run, not removing software result '.$sr->id);
-    } else {
-        $self->status_message($reason);
-        $sr->expunge($reason);
-        UR::Context->commit() || die "commit() failed while expunging software result ".$sr->id;
-    }
+    my $action_message = $self->dry_run
+                            ? 'Dry run, would remove'
+                            : 'Removing';
+
+    $self->status_message('%s software result %s',
+                            $action_message,
+                            $sr->id);
+    $sr->expunge($reason);
+    UR::Context->commit() || die "commit() failed while expunging software result ".$sr->id;
 }

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -174,6 +174,8 @@ sub _do_expunge {
     $self->status_message('%s software result %s',
                             $action_message,
                             $sr->id);
-    $sr->expunge($reason);
-    UR::Context->commit() || die "commit() failed while expunging software result ".$sr->id;
+    unless ($self->dry_run) {
+        $sr->expunge($reason);
+        UR::Context->commit() || die "commit() failed while expunging software result ".$sr->id;
+    }
 }

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -112,15 +112,7 @@ sub _get_lock_for_analysis_project {
 
         die $self->error_message('Cannot get lock for analysis project '.$anp->id) unless $lock;
 
-        my $observer = UR::Context->current->add_observer(
-            aspect => 'commit',
-            callback => sub {
-                $lock->unlock();
-            }
-        );
-
         $unlocker = sub {
-            $observer->delete();
             $lock->unlock();
         };
     }

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -1,0 +1,89 @@
+use strict;
+use warnings;
+
+use Data::Dumper;
+use DateTime::Format::Strptime;
+use Genome;
+
+my $days_to_retain = 30;
+
+my $sql = qq(
+    SELECT * FROM (
+        SELECT sr.id result_id, sr.class_name, bridge.analysis_project_id anp_id, anp.name anp_name, cpi.id profile_item_id, sr.outputs_path, da.id allocation_id, da.kilobytes_requested, da.status
+        FROM result.software_result sr
+        INNER JOIN disk.allocation da ON da.owner_id = sr.id AND da.owner_class_name = sr.class_name
+        INNER JOIN result."user" sru ON sr.id = sru.software_result_id
+        INNER JOIN model.build b ON b.build_id = sru.user_id
+        INNER JOIN config.analysis_project_model_bridge bridge ON bridge.model_id = b.model_id
+        INNER JOIN config.analysis_project anp ON bridge.analysis_project_id = anp.id
+        INNER JOIN config.profile_item cpi ON cpi.id = bridge.profile_item_id
+        WHERE cpi.status = 'disabled'
+        AND anp.id = ?
+        AND da.kilobytes_requested > 0
+    ) candidates
+    WHERE NOT EXISTS (
+        SELECT sr.id
+        FROM result.software_result sr
+        INNER JOIN result."user" sru ON sr.id = sru.software_result_id
+        INNER JOIN model.build b ON b.build_id = sru.user_id
+        INNER JOIN config.analysis_project_model_bridge bridge ON bridge.model_id = b.model_id
+        INNER JOIN config.profile_item cpi ON cpi.id = bridge.profile_item_id
+        WHERE cpi.status = 'active'
+        AND candidates.result_id = sr.id
+    ) AND NOT EXISTS (
+        SELECT sr.id
+        FROM result.software_result sr
+        INNER JOIN result."user" sru ON sr.id = sru.software_result_id
+        WHERE sru.user_class_name = 'Genome::Sys::User'
+        AND candidates.result_id = sr.id
+    )
+);
+
+my $anp_id = $ARGV[0];
+
+my $anp = Genome::Config::AnalysisProject->get($anp_id);
+die unless $anp;
+
+if ($anp->is_cle) {
+    die('Failed to process CLE analysis project: '. $anp->id);
+}
+
+my $strp = DateTime::Format::Strptime->new(
+    pattern   => UR::Context->date_template(),
+);
+
+my $now_str = UR::Context->now();
+my $updated_at_str = $anp->updated_at;
+
+my $dt1 = $strp->parse_datetime($updated_at_str);
+my $dt2 = $strp->parse_datetime($now_str);
+
+my $anp_updated_duration = $dt1->delta_days($dt2);
+
+my $duration_to_retain = DateTime::Duration->new(
+    days        => $days_to_retain,
+);
+
+if ( DateTime::Duration->compare( $anp_updated_duration, $duration_to_retain ) == -1 ) {
+    warn('Analysis project \''. $anp_id .'\' was updated at '. $updated_at_str .' which is less than the '. $days_to_retain .' days to retain disabled results');
+    exit;
+}
+
+my $dbh = Genome::DataSource::GMSchema->get_default_handle();
+die unless $dbh;
+
+my $sth = $dbh->prepare($sql);
+die unless $sth;
+
+$sth->execute($anp_id);
+while (my $data = $sth->fetchrow_hashref()) {
+    my $sr = Genome::SoftwareResult->get($data->{result_id});
+    die unless $sr;
+
+    my $reason = 'Expunge software result uniquely used by model from disabled config item ('. $data->{profile_item_id} .') for analysis project \''. $data->{anp_name} .'\' ('. $data->{anp_id} .')';
+    print $reason ."\n";
+    $sr->expunge($reason);
+    UR::Context->commit();
+}
+
+exit;

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -160,12 +160,18 @@ sub purge_one_analysis_project {
         $software_result_count++;
         $total_kb_purged += $data->{kilobytes_requested};
 
-        if ($self->dry_run) {
-            $self->warning_message('Dry run, not removing software result '.$sr->id);
-        } else {
-            $self->status_message($reason);
-            $sr->expunge($reason);
-            UR::Context->commit();
-        }
+        $self->_do_expunge($sr, $reason);
+    }
+}
+
+sub _do_expunge {
+    my($self, $sr, $reason) = @_;
+
+    if ($self->dry_run) {
+        $self->warning_message('Dry run, not removing software result '.$sr->id);
+    } else {
+        $self->status_message($reason);
+        $sr->expunge($reason);
+        UR::Context->commit() || die "commit() failed while expunging software result ".$sr->id;
     }
 }

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -21,6 +21,11 @@ class Genome::Model::Command::Admin::PurgeSoftwareResultsFromAnalysisProject {
             require_user_verify => 1,
             doc => 'List of AnalysisProjects to purge',
         },
+        dry_run => {
+            is => 'Boolean',
+            default_value => 0,
+            doc => 'Do not actually purge anything',
+        },
     ],
 };
 
@@ -97,9 +102,13 @@ sub execute {
             die unless $sr;
 
             my $reason = 'Expunge software result uniquely used by model from disabled config item ('. $data->{profile_item_id} .') for analysis project \''. $data->{anp_name} .'\' ('. $data->{anp_id} .')';
-            print $reason ."\n";
-            $sr->expunge($reason);
-            UR::Context->commit();
+            if ($self->dry_run) {
+                $self->warning_message('Dry run, not removing software result '.$sr->id);
+            } else {
+                print $reason ."\n";
+                $sr->expunge($reason);
+                UR::Context->commit();
+            }
         }
     }
 }


### PR DESCRIPTION
This adds a command for purging/expunging software results given one or more analysis projects.

It's based on jwalker's basic script, converted to a genome model command, and added locking around each anp to prevent multiple instances from stomping on each other.