### PR TITLE
Deduplicate Aligner and Annotation Index Classes

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -26,30 +26,6 @@ sub __display_name__ {
         $self->aligner_params || "");
 }
 
-sub get_or_create {
-    my $class = shift;
-    my %params = @_;
-
-    my @objects = $class->SUPER::get_or_create(%params);
-
-    for my $obj (@objects) {
-        next unless ref($obj); # sometimes UR gives us back the package name when deleting?
-        unless ($obj->generate_dependencies_as_needed($params{users})) {
-            $obj->error_message("Failed to get AlignmentIndex objects for dependencies of " . $obj->__display_name__);
-            return;
-        }
-    }
-
-    if (@objects > 1) {
-        return @objects if wantarray;
-        my @ids = map { $_->id } @objects;
-        die "Multiple matches for $class but get or create was called in scalar context! Found ids: @ids";
-    }
-    else {
-        return $objects[0];
-    }
-}
-
 sub create {
     my $class = shift;
     my %p = @_;
@@ -158,29 +134,6 @@ sub _prepare_reference_index {
     $self->debug_message("Prepared alignment reference index!");
 
     return $self;
-}
-
-sub _modify_params_for_lookup_hash {
-    my ($class, $params_ref) = @_;
-
-    if (exists $params_ref->{aligner_name} &&
-            $class->aligner_requires_param_masking($params_ref->{aligner_name})) {
-        $params_ref->{aligner_params} = undef;
-    }
-}
-
-sub _gather_params_for_get_or_create {
-    my $class = shift;
-    my $p = $class->SUPER::_gather_params_for_get_or_create(@_);
-
-    unless ($p->{params}{test_name}) {
-        $p->{params}{test_name} = (Genome::Config::get('aligner_index_test_name') || undef);
-    }
-    if (exists $p->{params}{aligner_name} && $class->aligner_requires_param_masking($p->{params}{aligner_name})) {
-        $p->{params}{aligner_params} = undef;
-    }
-
-    return $p;
 }
 
 sub _resolve_allocation_subdirectory_components {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -26,12 +26,6 @@ sub __display_name__ {
         $self->aligner_params || "");
 }
 
-sub required_rusage {
-    # override in subclasses
-    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";
-    ''
-}
-
 sub aligner_requires_param_masking {
     my $class = shift;
     my $aligner_name = shift;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -87,18 +87,6 @@ sub _prepare_index {
         return;
     }
 
-    my $output_dir = $self->output_dir || $self->_prepare_output_directory;
-    $self->debug_message("Alignment output path is $output_dir");
-
-    unless ($self->_promote_data)  {
-        $self->error_message("Failed to de-stage data into output path " . $self->output_dir);
-        return;
-    }
-
-    $self->_reallocate_disk_allocation;
-
-    $self->debug_message("Prepared alignment reference index!");
-
     return $self;
 }
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -49,14 +49,6 @@ sub aligner_requires_param_masking {
     return 1;
 }
 
-sub _supports_multiple_reference {
-    my $self = shift;
-    my $aligner_name = $self->aligner_name;
-    my $aligner_class = 'Genome::Model::Tools::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($aligner_name);
-    return unless $aligner_class->can('supports_multiple_reference');
-    return $aligner_class->supports_multiple_reference($self->aligner_version);
-}
-
 sub get_or_create {
     my $class = shift;
     my %params = @_;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -26,29 +26,6 @@ sub __display_name__ {
         $self->aligner_params || "");
 }
 
-sub aligner_requires_param_masking {
-    my $class = shift;
-    my $aligner_name = shift;
-
-    # If $aligner_name is not known then we can't ask.  While this could be an
-    # exception it is the case that while an object is being created its
-    # params/inputs getted added one-by-one which means sometime $aligner_name
-    # was not yet known.
-    unless ($aligner_name) {
-        return 0;
-    }
-
-    my $aligner_class = 'Genome::InstrumentData::AlignmentResult::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($aligner_name);
-
-    # if aligner params are not required for index, and we can   generically create an index for that version, then filter it out.
-    if ($aligner_class->aligner_params_required_for_index) {
-        $class->debug_message("This aligner requires a parameter-specific index.  Can't mask params out.");
-        return 0;
-    }
-
-    return 1;
-}
-
 sub get_or_create {
     my $class = shift;
     my %params = @_;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -47,7 +47,7 @@ sub create {
         return;
     }
 
-    unless ($self->_prepare_reference_index) {
+    unless ($self->_prepare_index) {
         $self->error_message("Failed to prepare reference index!");
         return;
     }
@@ -87,7 +87,7 @@ sub generate_dependencies_as_needed {
     return 1;
 }
 
-sub _prepare_reference_index {
+sub _prepare_index {
     my $self = shift;
 
     my $reference_fasta_file;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -115,11 +115,6 @@ sub create {
     return $self;
 }
 
-# TODO:
-# get() calls this method, and has a side-effect of creating dependent aligner indexes
-# 1. if you have side effects (avoid in general where possible), don't put them in a method called check_*
-# 2. don't override get(), make another method with the combined effect of getting data and doing work
-# -ssmith
 sub generate_dependencies_as_needed {
     my $self = shift;
     my $users = shift;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -26,40 +26,6 @@ sub __display_name__ {
         $self->aligner_params || "");
 }
 
-sub create {
-    my $class = shift;
-    my %p = @_;
-
-    my $aligner_class = 'Genome::InstrumentData::AlignmentResult::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($p{aligner_name});
-    $class->debug_message(sprintf("Resolved aligner class %s, making sure it's real and can be loaded.", $aligner_class));
-    unless ($aligner_class->class) {
-        $class->error_message(sprintf("Failed to load aligner class (%s).", $aligner_class));
-        return;
-    }
-
-    my $self = $class->SUPER::create(%p);
-    return unless $self;
-    $self->aligner_class_name($aligner_class);
-
-    $self->debug_message("Prepare staging directories...");
-    unless ($self->_prepare_staging_directory) {
-        $self->error_message("Failed to prepare working directory");
-        return;
-    }
-
-    unless ($self->_prepare_index) {
-        $self->error_message("Failed to prepare reference index!");
-        return;
-    }
-
-    unless ($self->generate_dependencies_as_needed($self->_user_data_for_nested_results)) {
-        $self->error_message("Failed to create AlignmentIndex objects for dependencies");
-        return;
-    }
-
-    return $self;
-}
-
 sub generate_dependencies_as_needed {
     my $self = shift;
     my $users = shift;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -249,14 +249,4 @@ sub resolve_allocation_subdirectory {
     return $directory;
 }
 
-sub full_consensus_path {
-    my $self = shift;
-    my $extension = shift;
-
-    return $self->output_dir . "/all_sequences." . $extension;
-}
-
-
-
-
 1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -249,14 +249,6 @@ sub resolve_allocation_subdirectory {
     return $directory;
 }
 
-sub resolve_allocation_disk_group_name {
-    if ($_[0]->reference_build->model->is_rederivable) {
-        return Genome::Config::get('disk_group_models');
-    } else {
-        return Genome::Config::get('disk_group_references');
-    }
-}
-
 sub full_consensus_path {
     my $self = shift;
     my $extension = shift;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -55,20 +55,8 @@ sub generate_dependencies_as_needed {
 
 sub _prepare_index {
     my $self = shift;
+    my $reference_fasta_file = shift;
 
-    my $reference_fasta_file;
-    if ($self->_supports_multiple_reference) {
-        $reference_fasta_file = $self->reference_build->primary_consensus_path('fa');
-    } else {
-        $reference_fasta_file = $self->reference_build->full_consensus_path('fa');
-    }
-
-    unless (-s $reference_fasta_file) {
-        $self->error_message(sprintf("Reference fasta file %s does not exist", $reference_fasta_file));
-        return;
-    }
-
-    $self->debug_message(sprintf("Confirmed non-zero reference fasta file is %s", $reference_fasta_file));
     unless (symlink($reference_fasta_file, sprintf("%s/all_sequences.fa", $self->temp_staging_directory))) {
         $self->error_message("Couldn't symlink reference fasta into the staging directory");
     }

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -7,49 +7,6 @@ use strict;
 
 class Genome::Model::Build::ReferenceSequence::AlignerIndex {
     is => ['Genome::Model::Build::ReferenceSequence::IndexBase'],
-
-    has => [
-
-        reference_build         => {
-                                    is => 'Genome::Model::Build::ImportedReferenceSequence',
-                                    id_by => 'reference_build_id',
-                                },
-        reference_name          => { via => 'reference_build', to => 'name', is_mutable => 0, is_optional => 1 },
-
-        aligner                 => {
-                                    calculate_from => [qw/aligner_name aligner_version aligner_params/],
-                                    calculate => q|no warnings; "$aligner_name $aligner_version $aligner_params"|
-                                },
-    ],
-    has_input => [
-        reference_build_id      => {
-                                    is => 'Number',
-                                    doc => 'the reference to use by id',
-                                },
-    ],
-    has_param => [
-        aligner_name            => {
-                                    is => 'Text', default_value => 'maq',
-                                    doc => 'the name of the aligner to use, maq, blat, newbler etc.',
-                                },
-        aligner_version         => {
-                                    is => 'Text',
-                                    doc => 'the version of the aligner to use, i.e. 0.6.8, 0.7.1, etc.',
-                                    is_optional=>1,
-                                },
-        aligner_params          => {
-                                    is => 'Text',
-                                    is_optional=>1,
-                                    doc => 'any additional params for the aligner in a single string',
-                                },
-    ],
-
-    has_transient => [
-        aligner_class_name      => {
-                                    is => 'Text',
-                                    is_optional => 1,
-        }
-    ]
 };
 
 sub _working_dir_prefix {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -6,7 +6,7 @@ use strict;
 
 
 class Genome::Model::Build::ReferenceSequence::AlignerIndex {
-    is => ['Genome::SoftwareResult::Stageable', 'Genome::SoftwareResult::WithNestedResults'],
+    is => ['Genome::Model::Build::ReferenceSequence::IndexBase'],
 
     has => [
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AlignerIndex.pm
@@ -219,34 +219,10 @@ sub _gather_params_for_get_or_create {
     return $p;
 }
 
-sub resolve_allocation_subdirectory {
+sub _resolve_allocation_subdirectory_components {
     my $self = shift;
-    my $aligner_name_tag = $self->aligner_name;
-    $aligner_name_tag =~ s/[^\w]/_/g;
 
-    my $staged_basename = File::Basename::basename($self->temp_staging_directory);
-    my @path_components = ('model_data','ref_build_aligner_index_data',$self->reference_build->model->id,'build'.$self->reference_build->id, $staged_basename);
-
-    if ($self->test_name) {
-        push @path_components, "test_".$self->test_name;
-    }
-
-    push @path_components, $aligner_name_tag;
-
-    my $aligner_version_tag = $self->aligner_version;
-    $aligner_version_tag =~ s/[^\w]/_/g;
-    push @path_components, $aligner_version_tag;
-
-    if ($self->aligner_params) {
-        my $aligner_params_tag = $self->aligner_params;
-        $aligner_params_tag =~ s/[^\w]/_/g;
-        push @path_components, $aligner_params_tag;
-    }
-
-    my $directory = join('/', @path_components);
-
-    $self->debug_message(sprintf("Resolved allocation subdirectory to %s", $directory));
-    return $directory;
+    return ('ref_build_aligner_index_data',$self->reference_build->model->id,'build'.$self->reference_build->id);
 }
 
 1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -125,29 +125,11 @@ sub create {
 sub generate_dependencies_as_needed {
     my $self = shift;
 
-    my %params = (
-        aligner_name => $self->aligner_name,
-        aligner_params => $self->aligner_params,
-        aligner_version => $self->aligner_version,
-    );
-
     # if the reference is a compound reference
     if ($self->reference_build->append_to and $self->_supports_multiple_reference) {
         die('Compound references are not currently supported in '. __PACKAGE__);
-        for my $b ($self->reference_build->append_to) { # (append_to is_many)
-            $params{reference_build} = $b;
-            $self->debug_message("Creating AlignmentIndex for build dependency " . $b->name);
-            my $result = Genome::Model::Build::ReferenceSequence::AlignerIndex->get_or_create(%params);
-            unless($result) {
-                $self->error_message("Failed to create AlignmentIndex for dependency " . $b->name);
-                return;
-            }
-            unless ($result->generate_dependencies_as_needed()) {
-                $self->error_message("Failed while checking dependencies of " . $b->name);
-                return;
-            }
-        }
     }
+
     return 1;
 }
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -74,18 +74,6 @@ sub _prepare_index {
         return;
     }
 
-    my $output_dir = $self->output_dir || $self->_prepare_output_directory;
-    $self->debug_message("Alignment output path is $output_dir");
-
-    unless ($self->_promote_data)  {
-        $self->error_message("Failed to de-stage data into output path " . $self->output_dir);
-        return;
-    }
-
-    $self->_reallocate_disk_allocation;
-
-    $self->debug_message("Prepared alignment reference index!");
-
     return $self;
 }
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -54,20 +54,7 @@ sub generate_dependencies_as_needed {
 
 sub _prepare_index {
     my $self = shift;
-
-    my $reference_fasta_file;
-    if ($self->_supports_multiple_reference) {
-        $reference_fasta_file = $self->reference_build->primary_consensus_path('fa');
-    } else {
-        $reference_fasta_file = $self->reference_build->full_consensus_path('fa');
-    }
-
-    unless (-s $reference_fasta_file) {
-        $self->error_message(sprintf("Reference fasta file %s does not exist", $reference_fasta_file));
-        return;
-    }
-
-    $self->debug_message(sprintf("Confirmed non-zero reference fasta file is %s", $reference_fasta_file));
+    my $reference_fasta_file = shift;
 
     unless ($self->aligner_class_name->prepare_annotation_index($self)) {
         $self->error_message("Failed to prepare annotation index.");

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -63,7 +63,7 @@ sub create {
         return;
     }
 
-    unless ($self->_prepare_annotation_index) {
+    unless ($self->_prepare_index) {
         $self->error_message("Failed to prepare annotation index!");
         return;
     }
@@ -87,7 +87,7 @@ sub generate_dependencies_as_needed {
     return 1;
 }
 
-sub _prepare_annotation_index {
+sub _prepare_index {
     my $self = shift;
 
     my $reference_fasta_file;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -41,21 +41,6 @@ sub __display_name__ {
                );
 }
 
-sub aligner_requires_param_masking {
-    my $class = shift;
-    my $aligner_name = shift;
-
-    my $aligner_class = 'Genome::InstrumentData::AlignmentResult::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($aligner_name);
-
-    # if aligner params are not required for index, and we can   generically create an index for that version, then filter it out.
-    if ($aligner_class->aligner_params_required_for_index) {
-        $class->debug_message("This aligner requires a parameter-specific index.  Can't mask params out.");
-        return 0;
-    }
-
-    return 1;
-}
-
 sub get {
     my $class = shift;
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -211,33 +211,10 @@ sub _prepare_annotation_index {
     return $self;
 }
 
-sub resolve_allocation_subdirectory {
+sub _resolve_allocation_subdirectory_components {
     my $self = shift;
-    my $aligner_name_tag = $self->aligner_name;
-    $aligner_name_tag =~ s/[^\w]/_/g;
 
-    my $staged_basename = File::Basename::basename($self->temp_staging_directory);
-    my @path_components = ('model_data','annotation_build_aligner_index_data',$self->reference_build->model->id,'reference_build'.$self->reference_build->id,'annotation_build'.$self->annotation_build_id, $staged_basename);
-
-    if ($self->test_name) {
-        push @path_components, "test_".$self->test_name;
-    }
-
-    push @path_components, $aligner_name_tag;
-
-    my $aligner_version_tag = $self->aligner_version;
-    $aligner_version_tag =~ s/[^\w]/_/g;
-    push @path_components, $aligner_version_tag;
-
-    if ($self->aligner_params) {
-        my $aligner_params_tag = $self->aligner_params;
-        $aligner_params_tag =~ s/[^\w]/_/g;
-        push @path_components, $aligner_params_tag;
-    }
-    my $directory = join('/', @path_components);
-
-    $self->debug_message(sprintf("Resolved allocation subdirectory to %s", $directory));
-    return $directory;
+    return ('annotation_build_aligner_index_data',$self->reference_build->model->id,'reference_build'.$self->reference_build->id,'annotation_build'.$self->annotation_build_id);
 }
 
 1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -240,18 +240,4 @@ sub resolve_allocation_subdirectory {
     return $directory;
 }
 
-sub full_consensus_path {
-    my $self = shift;
-    my $extension = shift;
-
-    my $path = $self->output_dir . '/all_sequences';
-    if ($extension) {
-        $path .= '.'. $extension;
-    }
-    return $path;
-}
-
-
-
-
 1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -240,10 +240,6 @@ sub resolve_allocation_subdirectory {
     return $directory;
 }
 
-sub resolve_allocation_disk_group_name {
-    Genome::Config::get('disk_group_references');
-}
-
 sub full_consensus_path {
     my $self = shift;
     my $extension = shift;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -41,41 +41,6 @@ sub __display_name__ {
                );
 }
 
-sub create {
-    my $class = shift;
-    my %p = @_;
-
-    my $aligner_class = 'Genome::InstrumentData::AlignmentResult::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($p{aligner_name});
-
-    $class->debug_message(sprintf("Resolved aligner class %s, making sure it's real and can be loaded.", $aligner_class));
-    unless ($aligner_class->class) {
-        $class->error_message(sprintf("Failed to load aligner class (%s).", $aligner_class));
-        return;
-    }
-
-    my $self = $class->SUPER::create(%p);
-    return unless $self;
-    $self->aligner_class_name($aligner_class);
-
-    $self->debug_message("Prepare staging directories...");
-    unless ($self->_prepare_staging_directory) {
-        $self->error_message("Failed to prepare working directory");
-        return;
-    }
-
-    unless ($self->_prepare_index) {
-        $self->error_message("Failed to prepare annotation index!");
-        return;
-    }
-
-    unless ($self->generate_dependencies_as_needed()) {
-        $self->error_message("Failed to create AnnotationIndex objects for dependencies");
-        return;
-    }
-
-    return $self;
-}
-
 sub generate_dependencies_as_needed {
     my $self = shift;
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -30,7 +30,7 @@ sub __display_name__ {
     my $self = shift;
     my @class_name = split("::", $self->class);
     my $class_name = $class_name[-1];
-    
+
     return sprintf("%s for reference build %s and annotation build %s with %s, version %s, params='%s'",
                    $class_name,
                    $self->reference_name,

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -41,12 +41,6 @@ sub __display_name__ {
                );
 }
 
-sub required_rusage {
-    # override in subclasses
-    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";
-    ''
-}
-
 sub aligner_requires_param_masking {
     my $class = shift;
     my $aligner_name = shift;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -56,14 +56,6 @@ sub aligner_requires_param_masking {
     return 1;
 }
 
-sub _supports_multiple_reference {
-    my $self = shift;
-    my $aligner_name = $self->aligner_name;
-    my $aligner_class = 'Genome::Model::Tools::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($aligner_name);
-    return unless $aligner_class->can('supports_multiple_reference');
-    return $aligner_class->supports_multiple_reference($self->aligner_version);
-}
-
 sub get {
     my $class = shift;
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -6,8 +6,7 @@ use strict;
 
 
 class Genome::Model::Build::ReferenceSequence::AnnotationIndex {
-    is => ['Genome::SoftwareResult::Stageable', 'Genome::SoftwareResult::WithNestedResults'],
-
+    is => ['Genome::Model::Build::ReferenceSequence::IndexBase'],
     has => [
 
         reference_build         => {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -69,7 +69,7 @@ sub __display_name__ {
     my @class_name = split("::", $self->class);
     my $class_name = $class_name[-1];
     
-    return sprintf("%s for reference build %s  and annotation build %s with %s, version %s, params='%s'",
+    return sprintf("%s for reference build %s and annotation build %s with %s, version %s, params='%s'",
                    $class_name,
                    $self->reference_name,
                    $self->annotation_name,

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -8,55 +8,18 @@ use strict;
 class Genome::Model::Build::ReferenceSequence::AnnotationIndex {
     is => ['Genome::Model::Build::ReferenceSequence::IndexBase'],
     has => [
-
-        reference_build         => {
-                                    is => 'Genome::Model::Build::ImportedReferenceSequence',
-                                    id_by => 'reference_build_id',
-                                },
         annotation_build         => {
             is => 'Genome::Model::Build::ImportedAnnotation',
             id_by => 'annotation_build_id',
         },
-        reference_name          => { via => 'reference_build', to => 'name', is_mutable => 0, is_optional => 1 },
         annotation_name         => { via => 'annotation_build', to => 'name', is_mutable => 0, is_optional => 1 },
-        aligner                 => {
-                                    calculate_from => [qw/aligner_name aligner_version aligner_params/],
-                                    calculate => q|no warnings; "$aligner_name $aligner_version $aligner_params"|
-                                },
     ],
     has_input => [
-        reference_build_id      => {
-                                    is => 'Number',
-                                    doc => 'the reference to use by id',
-                                },
         annotation_build_id      => {
             is => 'Number',
             doc => 'the annotation to use by id',
         },
     ],
-    has_param => [
-        aligner_name            => {
-                                    is => 'Text', default_value => 'maq',
-                                    doc => 'the name of the aligner to use, maq, blat, newbler etc.',
-                                },
-        aligner_version         => {
-                                    is => 'Text',
-                                    doc => 'the version of the aligner to use, i.e. 0.6.8, 0.7.1, etc.',
-                                    is_optional=>1,
-                                },
-        aligner_params          => {
-                                    is => 'Text',
-                                    is_optional=>1,
-                                    doc => 'any additional params for the aligner in a single string',
-                                },
-    ],
-
-    has_transient => [
-        aligner_class_name      => {
-                                    is => 'Text',
-                                    is_optional => 1,
-        }
-    ]
 };
 
 sub _working_dir_prefix {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -63,7 +63,7 @@ sub get {
     for my $obj (@objects) {
         next unless ref($obj); # sometimes UR gives us back the package name when deleting?
 
-        unless ($obj->check_dependencies()) {
+        unless ($obj->generate_dependencies_as_needed()) {
             $obj->error_message("Failed to get AnnotationIndex objects for dependencies of " . $obj->__display_name__);
             return;
         }
@@ -114,7 +114,7 @@ sub create {
         return;
     }
 
-    unless ($self->check_dependencies()) {
+    unless ($self->generate_dependencies_as_needed()) {
         $self->error_message("Failed to create AnnotationIndex objects for dependencies");
         return;
     }
@@ -122,7 +122,7 @@ sub create {
     return $self;
 }
 
-sub check_dependencies {
+sub generate_dependencies_as_needed {
     my $self = shift;
 
     my %params = (
@@ -142,7 +142,7 @@ sub check_dependencies {
                 $self->error_message("Failed to create AlignmentIndex for dependency " . $b->name);
                 return;
             }
-            unless ($result->check_dependencies()) {
+            unless ($result->generate_dependencies_as_needed()) {
                 $self->error_message("Failed while checking dependencies of " . $b->name);
                 return;
             }

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/AnnotationIndex.pm
@@ -46,7 +46,6 @@ sub create {
     my %p = @_;
 
     my $aligner_class = 'Genome::InstrumentData::AlignmentResult::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($p{aligner_name});
-    $class->debug_message("Aligner class name is $aligner_class");
 
     $class->debug_message(sprintf("Resolved aligner class %s, making sure it's real and can be loaded.", $aligner_class));
     unless ($aligner_class->class) {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -76,6 +76,11 @@ sub create {
         return;
     }
 
+    unless ($self->_promote_prepared_index) {
+        $self->error_message("Failed to save reference index to output location!");
+        return;
+    }
+
     unless ($self->generate_dependencies_as_needed($self->_user_data_for_nested_results)) {
         $self->error_message("Failed to create AlignmentIndex objects for dependencies");
         return;
@@ -88,6 +93,24 @@ sub _prepare_index {
     my $self = shift;
 
     Carp::confess('Class must implement _prepare_index.');
+}
+
+sub _promote_prepared_index {
+    my $self = shift;
+
+    my $output_dir = $self->output_dir || $self->_prepare_output_directory;
+    $self->debug_message("Alignment output path is $output_dir");
+
+    unless ($self->_promote_data)  {
+        $self->error_message("Failed to de-stage data into output path " . $self->output_dir);
+        return;
+    }
+
+    $self->_reallocate_disk_allocation;
+
+    $self->debug_message("Prepared alignment reference index!");
+
+    return 1;
 }
 
 sub aligner_requires_param_masking {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -50,6 +50,29 @@ class Genome::Model::Build::ReferenceSequence::IndexBase {
     ]
 };
 
+sub aligner_requires_param_masking {
+    my $class = shift;
+    my $aligner_name = shift;
+
+    # If $aligner_name is not known then we can't ask.  While this could be an
+    # exception it is the case that while an object is being created its
+    # params/inputs getted added one-by-one which means sometime $aligner_name
+    # was not yet known.
+    unless ($aligner_name) {
+        return 0;
+    }
+
+    my $aligner_class = 'Genome::InstrumentData::AlignmentResult::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($aligner_name);
+
+    # if aligner params are not required for index, and we can   generically create an index for that version, then filter it out.
+    if ($aligner_class->aligner_params_required_for_index) {
+        $class->debug_message("This aligner requires a parameter-specific index.  Can't mask params out.");
+        return 0;
+    }
+
+    return 1;
+}
+
 sub full_consensus_path {
     my $self = shift;
     my $extension = shift;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -55,4 +55,12 @@ sub required_rusage {
     ''
 }
 
+sub resolve_allocation_disk_group_name {
+    if ($_[0]->reference_build->model->is_rederivable) {
+        return Genome::Config::get('disk_group_models');
+    } else {
+        return Genome::Config::get('disk_group_references');
+    }
+}
+
 1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -1,0 +1,13 @@
+package Genome::Model::Build::ReferenceSequence::IndexBase;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::Build::ReferenceSequence::IndexBase {
+    is_abstract => 1,
+    is => ['Genome::SoftwareResult::Stageable', 'Genome::SoftwareResult::WithNestedResults'],
+};
+
+1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -10,42 +10,47 @@ class Genome::Model::Build::ReferenceSequence::IndexBase {
     is_abstract => 1,
     is => ['Genome::SoftwareResult::Stageable', 'Genome::SoftwareResult::WithNestedResults'],
     has => [
-        reference_build         => {
-                                    is => 'Genome::Model::Build::ImportedReferenceSequence',
-                                    id_by => 'reference_build_id',
-                                },
-        reference_name          => { via => 'reference_build', to => 'name', is_mutable => 0, is_optional => 1 },
-        aligner                 => {
-                                    calculate_from => [qw/aligner_name aligner_version aligner_params/],
-                                    calculate => q|no warnings; "$aligner_name $aligner_version $aligner_params"|
-                                },
+        reference_build => {
+            is => 'Genome::Model::Build::ImportedReferenceSequence',
+            id_by => 'reference_build_id',
+        },
+        reference_name => {
+            via => 'reference_build',
+            to => 'name',
+            is_mutable => 0,
+            is_optional => 1
+        },
+        aligner => {
+            calculate_from => [qw/aligner_name aligner_version aligner_params/],
+            calculate => q|no warnings; "$aligner_name $aligner_version $aligner_params"|
+        },
     ],
     has_input => [
-        reference_build_id      => {
-                                    is => 'Number',
-                                    doc => 'the reference to use by id',
-                                },
+        reference_build_id  => {
+            is => 'Number',
+            doc => 'the reference to use by id',
+        },
     ],
     has_param => [
-        aligner_name            => {
-                                    is => 'Text', default_value => 'maq',
-                                    doc => 'the name of the aligner to use, maq, blat, newbler etc.',
-                                },
-        aligner_version         => {
-                                    is => 'Text',
-                                    doc => 'the version of the aligner to use, i.e. 0.6.8, 0.7.1, etc.',
-                                    is_optional=>1,
-                                },
-        aligner_params          => {
-                                    is => 'Text',
-                                    is_optional=>1,
-                                    doc => 'any additional params for the aligner in a single string',
-                                },
+        aligner_name => {
+            is => 'Text', default_value => 'maq',
+            doc => 'the name of the aligner to use, maq, blat, newbler etc.',
+        },
+        aligner_version => {
+            is => 'Text',
+            doc => 'the version of the aligner to use, i.e. 0.6.8, 0.7.1, etc.',
+            is_optional=>1,
+        },
+        aligner_params => {
+            is => 'Text',
+            is_optional=>1,
+            doc => 'any additional params for the aligner in a single string',
+        },
     ],
     has_transient => [
-        aligner_class_name      => {
-                                    is => 'Text',
-                                    is_optional => 1,
+        aligner_class_name => {
+            is => 'Text',
+            is_optional => 1,
         }
     ]
 };

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -71,7 +71,15 @@ sub create {
         return;
     }
 
-    unless ($self->_prepare_index) {
+    my $reference_fasta_file = $self->_resolve_reference_fasta_file;
+    unless (-s $reference_fasta_file) {
+        $self->error_message(sprintf("Reference fasta file %s does not exist", $reference_fasta_file));
+        return;
+    } else {
+        $self->debug_message(sprintf("Confirmed non-zero reference fasta file is %s", $reference_fasta_file));
+    }
+
+    unless ($self->_prepare_index($reference_fasta_file)) {
         $self->error_message("Failed to prepare reference index!");
         return;
     }
@@ -87,6 +95,16 @@ sub create {
     }
 
     return $self;
+}
+
+sub _resolve_reference_fasta_file {
+    my $self = shift;
+
+    if ($self->_supports_multiple_reference) {
+        return $self->reference_build->primary_consensus_path('fa');
+    } else {
+        return $self->reference_build->full_consensus_path('fa');
+    }
 }
 
 sub _prepare_index {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -8,6 +8,45 @@ use Genome;
 class Genome::Model::Build::ReferenceSequence::IndexBase {
     is_abstract => 1,
     is => ['Genome::SoftwareResult::Stageable', 'Genome::SoftwareResult::WithNestedResults'],
+    has => [
+        reference_build         => {
+                                    is => 'Genome::Model::Build::ImportedReferenceSequence',
+                                    id_by => 'reference_build_id',
+                                },
+        reference_name          => { via => 'reference_build', to => 'name', is_mutable => 0, is_optional => 1 },
+        aligner                 => {
+                                    calculate_from => [qw/aligner_name aligner_version aligner_params/],
+                                    calculate => q|no warnings; "$aligner_name $aligner_version $aligner_params"|
+                                },
+    ],
+    has_input => [
+        reference_build_id      => {
+                                    is => 'Number',
+                                    doc => 'the reference to use by id',
+                                },
+    ],
+    has_param => [
+        aligner_name            => {
+                                    is => 'Text', default_value => 'maq',
+                                    doc => 'the name of the aligner to use, maq, blat, newbler etc.',
+                                },
+        aligner_version         => {
+                                    is => 'Text',
+                                    doc => 'the version of the aligner to use, i.e. 0.6.8, 0.7.1, etc.',
+                                    is_optional=>1,
+                                },
+        aligner_params          => {
+                                    is => 'Text',
+                                    is_optional=>1,
+                                    doc => 'any additional params for the aligner in a single string',
+                                },
+    ],
+    has_transient => [
+        aligner_class_name      => {
+                                    is => 'Text',
+                                    is_optional => 1,
+        }
+    ]
 };
 
 1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -49,6 +49,17 @@ class Genome::Model::Build::ReferenceSequence::IndexBase {
     ]
 };
 
+sub full_consensus_path {
+    my $self = shift;
+    my $extension = shift;
+
+    my $path = $self->output_dir . '/all_sequences';
+    if ($extension) {
+        $path .= '.'. $extension;
+    }
+    return $path;
+}
+
 sub required_rusage {
     # override in subclasses
     # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -27,7 +27,7 @@ class Genome::Model::Build::ReferenceSequence::IndexBase {
     ],
     has_input => [
         reference_build_id  => {
-            is => 'Number',
+            is => 'Text',
             doc => 'the reference to use by id',
         },
     ],

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -3,6 +3,7 @@ package Genome::Model::Build::ReferenceSequence::IndexBase;
 use strict;
 use warnings;
 
+use Carp;
 use Genome;
 
 class Genome::Model::Build::ReferenceSequence::IndexBase {
@@ -72,6 +73,41 @@ sub resolve_allocation_disk_group_name {
     } else {
         return Genome::Config::get('disk_group_references');
     }
+}
+
+sub resolve_allocation_subdirectory {
+    my $self = shift;
+    my $aligner_name_tag = $self->aligner_name;
+    $aligner_name_tag =~ s/[^\w]/_/g;
+
+    my $staged_basename = File::Basename::basename($self->temp_staging_directory);
+    my @path_components = ('model_data', $self->_resolve_allocation_subdirectory_components, $staged_basename);
+    if ($self->test_name) {
+        push @path_components, "test_".$self->test_name;
+    }
+
+    push @path_components, $aligner_name_tag;
+
+    my $aligner_version_tag = $self->aligner_version;
+    $aligner_version_tag =~ s/[^\w]/_/g;
+    push @path_components, $aligner_version_tag;
+
+    if ($self->aligner_params) {
+        my $aligner_params_tag = $self->aligner_params;
+        $aligner_params_tag =~ s/[^\w]/_/g;
+        push @path_components, $aligner_params_tag;
+    }
+
+    my $directory = join('/', @path_components);
+
+    $self->debug_message(sprintf("Resolved allocation subdirectory to %s", $directory));
+    return $directory;
+}
+
+sub _resolve_allocation_subdirectory_components {
+    my $self = shift;
+
+    Carp::confess('Class must implement _resolve_allocation_subdirectory_components');
 }
 
 1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -110,4 +110,12 @@ sub _resolve_allocation_subdirectory_components {
     Carp::confess('Class must implement _resolve_allocation_subdirectory_components');
 }
 
+sub _supports_multiple_reference {
+    my $self = shift;
+    my $aligner_name = $self->aligner_name;
+    my $aligner_class = 'Genome::Model::Tools::'  . Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($aligner_name);
+    return unless $aligner_class->can('supports_multiple_reference');
+    return $aligner_class->supports_multiple_reference($self->aligner_version);
+}
+
 1;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/IndexBase.pm
@@ -49,4 +49,10 @@ class Genome::Model::Build::ReferenceSequence::IndexBase {
     ]
 };
 
+sub required_rusage {
+    # override in subclasses
+    # e.x.: "-R 'span[hosts=1] rusage[tmp=50000:mem=12000]' -M 12000000";
+    ''
+}
+
 1;


### PR DESCRIPTION
AnnotationIndex was copy+pasted from AlignerIndex and the two had started to drift.  This reconciles most of the differences and eliminates most of the duplication between them.