### PR TITLE
Inactive analysis project config profile item status

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddConfigFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddConfigFile.pm
@@ -40,7 +40,7 @@ EOS
 sub _create_profile_items {
     my $self = shift;
 
-    my $status = $self->store_only ? 'disabled' : 'active';
+    my $status = $self->store_only ? 'inactive' : 'active';
 
     my $result = Genome::Config::Profile::Item->create_from_file_path(
         file_path => $self->config_file,

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.pm
@@ -59,8 +59,8 @@ sub _verify_config_status {
     my $self = shift;
 
     my $profile_item = $self->profile_item;
-    if($profile_item->status eq 'active') {
-        $self->error_message('Cannot manually assign a model to an active configuration.');
+    if($profile_item->status ne 'inactive') {
+        $self->error_message('Can only assign a model to an inactive configuration.');
         return;
     }
 

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddModel.t
@@ -74,7 +74,7 @@ isa_ok($cmd6, $class, 'created command');
 ok(!$cmd6->execute, 'command fails when attempting to assign to a config profile item for the wrong model type');
 ok(!$other_model->analysis_project, 'unassigned model not assigned to');
 
-$other_profile_item->status('disabled');
+$other_profile_item->status('inactive');
 my $cmd7 = $class->create(
     profile_item => $other_profile_item,
     models => [$other_model],
@@ -98,7 +98,7 @@ EOFILE
     my $config_file = Genome::Sys->create_temp_file_path;
     Genome::Sys->write_file($config_file, $config);
 
-    my $early_profile_item = Genome::Config::Profile::Item->get(analysis_project => $analysis_project, status => 'disabled');
+    my $early_profile_item = Genome::Config::Profile::Item->get(analysis_project => $analysis_project, status => 'inactive');
     ok(!$early_profile_item, 'config does not already exist before testing command');
     my $add_cmd = Genome::Config::AnalysisProject::Command::AddConfigFile->create(
         analysis_project => $analysis_project,
@@ -108,7 +108,7 @@ EOFILE
     );
     my $ok = $add_cmd->execute();
     ok($ok, 'executed add command');
-    my $profile_item = Genome::Config::Profile::Item->get(analysis_project => $analysis_project, status => 'disabled');
+    my $profile_item = Genome::Config::Profile::Item->get(analysis_project => $analysis_project, status => 'inactive');
     isa_ok($profile_item, 'Genome::Config::Profile::Item', 'created config');
     return $profile_item;
 }

--- a/lib/perl/Genome/Config/AnalysisProject/Command/View.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/View.pm
@@ -98,6 +98,7 @@ my %STATUS_COLORS = (
 
     # values for config items
     active => "green",
+    inactive => "yellow",
     disabled => "magenta",
 );
 my $MAX_STATUS_WIDTH = max(map {length($_)} keys %STATUS_COLORS) + 1;

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -29,7 +29,7 @@ sub create_from_analysis_project {
 
     my @config_rule_maps = map {
         Genome::Config::Translator->get_rule_model_map_from_config($_)
-    } grep{ $_->status ne 'disabled' } $analysis_project->config_items;
+    } grep{ $_->status eq 'active' } $analysis_project->config_items;
 
     return $class->create(
         config_rule_maps => \@config_rule_maps,

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -32,7 +32,7 @@ class Genome::Config::Profile::Item {
         },
         status => {
             is => 'Text',
-            valid_values => [ "disabled", "active" ],
+            valid_values => [ "disabled", "active", "inactive" ],
             default_value => 'active',
         },
         model_bridges => {

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -182,7 +182,7 @@ sub _is_created {
 sub is_current {
     my $self = shift;
 
-    return $self->status eq 'active' and $self->analysis_project->is_current;
+    return $self->status ne 'disabled' and $self->analysis_project->is_current;
 }
 
 1;


### PR DESCRIPTION
Add inactive status for analysis project config profile items.  The inactive status is used for the store-only option when adding config.