### PR TITLE
It'll now work with aggrs containing any number of digits.

### DIFF
--- a/lib/perl/Genome/Disk/Volume.pm
+++ b/lib/perl/Genome/Disk/Volume.pm
@@ -412,7 +412,7 @@ sub get_trash_folder {
 }
 
 sub _extract_aggr {
-    return (shift =~ m!/(aggr\d{2})/!)[0];
+    return (shift =~ m!/(aggr\d+)/!)[0];
 }
 
 


### PR DESCRIPTION
The regex was failing to match /vol/aggr3/ which only contained one digit