### PR TITLE
Filter out thread count, max memory, and verbosity from lookup hash.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
@@ -85,7 +85,7 @@ sub create {
         version => $self->aligner_version,
         temp_directory => $temp_directory,
     );
-    my %aligner_params = eval($self->aligner_params);
+    my %aligner_params = $class->_parse_aligner_params($self->aligner_params);
     $aligner_params{threads} = $self->_available_cpu_count;
     my $command = Genome::Model::Tools::Speedseq::Realign->create(%params, %aligner_params);
     unless ($command->execute) {
@@ -139,7 +139,7 @@ sub _modify_params_for_lookup_hash {
     my $aligner_param_str = delete $params_ref->{aligner_params};
     return unless $aligner_param_str;
 
-    my %aligner_params = eval($aligner_param_str);
+    my %aligner_params = $class->_parse_aligner_params($aligner_param_str);
 
     delete $aligner_params{sort_memory};
     delete $aligner_params{verbose};
@@ -152,6 +152,20 @@ sub _modify_params_for_lookup_hash {
     $params_ref->{aligner_params} = $aligner_param_str;
 
     return $params_ref;
+}
+
+sub _parse_aligner_params {
+    my $class = shift;
+    my $param_str = shift;
+
+    local $@;
+    my %params_parsed = eval($param_str);
+    my $error = $@;
+    if($error) {
+        die $class->error_message('Failed to parse aligner params: %s', $error);
+    }
+
+    return %params_parsed;
 }
 
 1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
@@ -10,6 +10,7 @@ use Genome::InstrumentData::AlignmentResult::Merged::Helpers qw(
     resolve_allocation_disk_group_name
 );
 use File::stat;
+use Genome::Utility::Text;
 
 class Genome::InstrumentData::AlignmentResult::Merged::Speedseq {
     is => ['Genome::InstrumentData::AlignedBamResult::Merged', 'Genome::SoftwareResult::WithNestedResults'],
@@ -129,6 +130,28 @@ sub estimated_gtmp_for_instrument_data {
     }
 
     return 3 * $st->size();
+}
+
+sub _modify_params_for_lookup_hash {
+    my $class = shift;
+    my $params_ref = shift;
+
+    my $aligner_param_str = delete $params_ref->{aligner_params};
+    return unless $aligner_param_str;
+
+    my %aligner_params = eval($aligner_param_str);
+
+    delete $aligner_params{sort_memory};
+    delete $aligner_params{verbose};
+    delete $aligner_params{threads};
+
+    $aligner_param_str = join(',', map(
+        join(' => ', $_, Genome::Utility::Text::wrap_as_string($aligner_params{$_})),
+        sort keys %aligner_params)
+    );
+    $params_ref->{aligner_params} = $aligner_param_str;
+
+    return $params_ref;
 }
 
 1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -184,4 +184,10 @@ sub bwa_version {
     return $bwa_version;
 }
 
+sub _modify_params_for_lookup_hash {
+    my $class = shift;
+
+    return Genome::InstrumentData::AlignmentResult::Merged::Speedseq->_modify_params_for_lookup_hash(@_);
+}
+
 1;


### PR DESCRIPTION
Threads are overwritten inside the tool.  I heartell it should be safe to ignore the other two as well.

(Existing processing profile mostly have no parameters specified at all, so this shouldn't have much effect on results we already have.)