### PR TITLE
Add status to AnalysisMenu Items

### DIFF
--- a/lib/perl/Genome/Config/AnalysisMenu/Item.pm
+++ b/lib/perl/Genome/Config/AnalysisMenu/Item.pm
@@ -24,6 +24,11 @@ class Genome::Config::AnalysisMenu::Item {
         description => {
             is => 'Text',
         },
+        status => {
+            is => 'Text',
+            valid_values => ['active', 'inactive'],
+            default_value => 'active',
+        },
     ],
     has_many => [
         config_items => {

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddMenuItem.pm
@@ -67,7 +67,7 @@ sub _get_menu_items {
                 {
                     name => 'analysis_menu_items',
                     class => $class_name,
-                    value => [$class_name->get()],
+                    value => [$class_name->get(status => 'active')],
                 }
             )];
     }

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
@@ -129,7 +129,7 @@ sub _get_menu_items {
                 {
                     name => 'analysis_menu_items',
                     class => $class_name,
-                    value => [$class_name->get()],
+                    value => [$class_name->get(status => 'active')],
                 }
             )];
     }


### PR DESCRIPTION
This helps reduce the list shown by default to the commonly used options.

The two statuses are `active` and `inactive` since in neither case does the menu item cease to function (i.e. `disabled`).

The changed commands won't work until the database is updated to add this column.