### PR TITLE
Disconnect Database Handles before potentially long-running actions

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfBase.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfBase.pm
@@ -690,6 +690,8 @@ sub generate_and_run_readcounts_in_parallel {
         $self->error_message(@errors);
         die "Errors validating workflow\n";
     }
+
+    Genome::Sys->disconnect_default_handles;
     $self->debug_message("Now launching readcount generation jobs");
     my $result = Workflow::Simple::run_workflow_lsf( $workflow, %inputs);
     unless($result) {

--- a/lib/perl/Genome/Sys/Lock.pm
+++ b/lib/perl/Genome/Sys/Lock.pm
@@ -84,6 +84,8 @@ sub lock_resource {
         }
     };
 
+    Genome::Sys->disconnect_default_handles;
+
     for my $backend (backends($args{scope})) {
         my @lock_args = $backend->translate_lock_args(%args);
         my $lock = $backend->lock(@lock_args);

--- a/lib/perl/Genome/WorkflowBuilder/DAG.pm
+++ b/lib/perl/Genome/WorkflowBuilder/DAG.pm
@@ -148,6 +148,7 @@ sub _execute_with_ptero {
     my $wf_proxy = $wf_builder->submit( inputs => encode($inputs) );
     $self->status_message("Waiting on PTero workflow (%s) to complete",
         $wf_proxy->url);
+    Genome::Sys->disconnect_default_handles;
     $wf_proxy->wait(polling_interval => $polling_interval);
 
     if ($wf_proxy->has_succeeded) {

--- a/lib/perl/Genome/WorkflowBuilder/DAG.pm
+++ b/lib/perl/Genome/WorkflowBuilder/DAG.pm
@@ -126,7 +126,11 @@ sub _execute_with_workflow {
 
     my ($self, $inputs) = @_;
 
-    my $result = Workflow::Simple::run_workflow_lsf($self->get_xml, %$inputs);
+    my $xml = $self->get_xml;
+
+    Genome::Sys->disconnect_default_handles;
+
+    my $result = Workflow::Simple::run_workflow_lsf($xml, %$inputs);
     unless (defined($result)) {
         die $self->error_message(
             "Workflow failed with these errors: %s",


### PR DESCRIPTION
The specific motivation for this change: The database "pausing" feature will disconnect handles, but not if the pause is both set and cleared before the program has a chance to notice.  It may then be left holding a stale handle when it does return.
