### PR TITLE
Dump flagstat data when comparison fails.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/RecreatePerLaneBam.pm
@@ -168,16 +168,24 @@ sub _compare_flagstat {
     
     if ($ignore_duplicates) { #expect only one line diff on duplicates
         unless (_parse_flagstat_ignore_duplicates($temp_flagstat, $flagstat)) {
+            $self->debug_flagstats($temp_flagstat, $flagstat);
             die $self->error_message("The diff between extracting bam flagstat and the comparison flagstat $flagstat is not expected");
         }
     }
     else {
         unless (compare($temp_flagstat, $flagstat) == 0) {
+            $self->debug_flagstats($temp_flagstat, $flagstat);
             die $self->error_message("The bam flagstat after reverting markdup is unexpectedly different from the comparison flagstat $flagstat");
         }
     }
 }
 
+sub _debug_flagstats {
+    my ($self, $temp_flagstat, $flagstat) = @_;
+
+    $self->debug_message('Generated flagstat: %s', Data::Dumper::Dumper(Genome::Model::Tools::Sam::Flagstat->parse_file_into_hashref($temp_flagstat)));
+    $self->debug_message('Expected flagstat: %s', Data::Dumper::Dumper(Genome::Model::Tools::Sam::Flagstat->parse_file_into_hashref($flagstat)));
+}
 
 sub _parse_flagstat_ignore_duplicates {
     my ($temp_flagstat, $flagstat) = @_;


### PR DESCRIPTION
Since the `$temp_flagstat` gets cleaned up on failure, this provides a way to see how it was different from expected.