### PR TITLE
Use shellcmd instead of IPC::Run.

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/StreamGraph.pm
+++ b/lib/perl/Genome/WorkflowBuilder/StreamGraph.pm
@@ -3,7 +3,6 @@ package Genome::WorkflowBuilder::StreamGraph;
 use strict;
 use warnings;
 use Genome;
-use IPC::Run qw(run);
 use XML::LibXML;
 
 class Genome::WorkflowBuilder::StreamGraph {
@@ -71,7 +70,7 @@ sub execute {
     unless ($output_xml) {
         $output_xml = Genome::Sys->create_temp_file_path;
     }
-    run(qw(/usr/bin/streamgraph run -x), $xml_file, '-o', $output_xml);
+    Genome::Sys->shellcmd(cmd =>[qw(/usr/bin/streamgraph run -x), $xml_file, '-o', $output_xml]);
     return 1;
 }
 


### PR DESCRIPTION
The motivation for this change is to make sure the database handle is disconnected before running.  Alternatively we could add an explicit disconnect before the call here.