### PR TITLE
Add the ability to specify a minimum number of hits required

### DIFF
--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
@@ -94,7 +94,7 @@ sub _get_true_positives {
 
 sub _sv_with_min_support_count {
     my ($self, $file, $original_file, $output) = @_;
-    my $f = new IO::File($file, "r");
+    my $f = Genome::Sys->open_file_for_reading($file);
     my %results;
 
     my $id_index = _count_cols($original_file) + 6;
@@ -120,8 +120,7 @@ sub _sv_with_min_support_count {
     }
     $f->close();
 
-    my $in = new IO::File($original_file, "r");
-
+    my $in = Genome::Sys->open_file_for_reading($original_file);
     my %seen;
     my $count = 0;
     while (my $line = $in->getline) {
@@ -148,7 +147,7 @@ sub _sv_with_min_support_count {
 
 sub _count_cols {
     my $path = shift;
-    my $f = new IO::File($path, "r");
+    my $f = Genome::Sys->open_file_for_reading($path);
     my $line = $f->getline;
     $f->close();
     my @f = split("\t", $line);

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
@@ -108,6 +108,12 @@ sub _sv_with_min_support_count {
         my @f = split("\t", $line);
         my $sv_name = $f[6];
         my $read_id = $f[$id_index];
+        unless (defined $sv_name) {
+            die "Sv name not defined on line:\n$line";
+        }
+        unless (defined $read_id) {
+            die "read id not defined on line:\n$line";
+        }
         ++$results{$sv_name}{count} unless exists $results{$sv_name}{reads}{$read_id};
         $results{$sv_name}{reads}{$read_id} = 1;
         $results{$sv_name}{sv} = \@f;
@@ -122,6 +128,9 @@ sub _sv_with_min_support_count {
         chomp $line;
         my @f = split("\t", $line);
         my $sv_name = $f[6];
+        unless (defined $sv_name) {
+            die "Sv name not defined on line:\n$line";
+        }
         next if exists $seen{$sv_name};
         $seen{$sv_name} = 1;
 

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
@@ -136,7 +136,7 @@ sub _sv_with_min_support_count {
 
         next unless exists $results{$sv_name} && ($results{$sv_name}{count} >= $min_hit_support);
         $count++;
-        if ($output) {
+        if ($out) {
             print $out "$line\n";
         }
     }

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
@@ -22,6 +22,11 @@ class Genome::Model::Tools::Bedpe::EvaluateBedpe {
             is => 'Integer',
             doc => 'The amount of slop (in b.p.). to be added to one set of breakpoints',
         },
+        min_hit_support => {
+            is => 'Integer',
+            doc => 'Minimum # of hits from gold_bedpe required to report an sv as a true positive.  Note, if != 1, the derived stats are probably not valid',
+            default_value => 1,
+        },
     ],
     has_transient_optional_output => [
         rawstats => {
@@ -34,11 +39,11 @@ class Genome::Model::Tools::Bedpe::EvaluateBedpe {
 sub execute {
     my $self = shift;
     $self->rawstats({});
-    $self->rawstats->{true_positive} = $self->_get_stat($self->bedpe, $self->gold_bedpe, 'both');
-    $self->rawstats->{false_positive} = $self->_get_stat($self->bedpe, $self->gold_bedpe, 'notboth');
-    $self->rawstats->{false_negative} = $self->_get_stat($self->gold_bedpe, $self->bedpe, 'notboth');
+    $self->rawstats->{true_positive} = $self->_get_stat($self->bedpe, $self->gold_bedpe, 'both', $self->min_hit_support);
+    $self->rawstats->{false_negative} = $self->_get_stat($self->gold_bedpe, $self->bedpe, 'notboth', 1);
     $self->rawstats->{total_unique_calls} = $self->_unique_sv_count($self->bedpe);
     $self->rawstats->{total_unique_gold_calls} = $self->_unique_sv_count($self->gold_bedpe);
+    $self->rawstats->{false_positive} = $self->rawstats->{total_unique_calls} - $self->rawstats->{true_positive};
     $self->_set_derivative_stats;
     $self->print_stats;
     return 1;
@@ -56,7 +61,7 @@ sub common_params {
 }
 
 sub _get_stat {
-    my ($self, $file_a, $file_b, $type) = @_;
+    my ($self, $file_a, $file_b, $type, $min_hit_support) = @_;
 
     my $output_file = Genome::Sys->create_temp_file_path;
 
@@ -68,7 +73,51 @@ sub _get_stat {
         intersection_type => $type,
     );
 
-    return $self->_unique_sv_count($output_file);
+    return $self->_sv_with_min_support_count($output_file, $file_a, $min_hit_support);
+}
+
+sub _sv_with_min_support_count {
+    my ($self, $file, $original_file, $min_hit_support) = @_;
+    my $f = new IO::File($file, "r");
+    my %results;
+
+    my $id_index = _count_cols($original_file) + 6;
+
+    while (my $line = $f->getline) {
+        chomp $line;
+        my @f = split("\t", $line);
+        my $sv_name = $f[6];
+        my $read_id = $f[$id_index];
+        ++$results{$sv_name}{count} unless exists $results{$sv_name}{reads}{$read_id};
+        $results{$sv_name}{reads}{$read_id} = 1;
+        $results{$sv_name}{sv} = \@f;
+    }
+    $f->close();
+
+    my $in = new IO::File($original_file, "r");
+
+    my %seen;
+    my $count = 0;
+    while (my $line = $in->getline) {
+        chomp $line;
+        my @f = split("\t", $line);
+        my $sv_name = $f[6];
+        next if exists $seen{$sv_name};
+        $seen{$sv_name} = 1;
+
+        next unless exists $results{$sv_name} && ($results{$sv_name}{count} >= $min_hit_support);
+        $count++;
+    }
+    return $count;
+}
+
+sub _count_cols {
+    my $path = shift;
+    my $f = new IO::File($path, "r");
+    my $line = $f->getline;
+    $f->close();
+    my @f = split("\t", $line);
+    return scalar @f;
 }
 
 sub _unique_sv_count {

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
@@ -89,11 +89,11 @@ sub _get_false_negatives {
 sub _get_true_positives {
     my $self = shift;
     my $output_file = $self->_get_pair_to_pair_output($self->bedpe, $self->gold_bedpe, 'both');
-    return $self->_sv_with_min_support_count($output_file, $self->bedpe, $self->min_hit_support, $self->true_positive_file);
+    return $self->_sv_with_min_support_count($output_file, $self->bedpe, $self->true_positive_file);
 }
 
 sub _sv_with_min_support_count {
-    my ($self, $file, $original_file, $min_hit_support, $output) = @_;
+    my ($self, $file, $original_file, $output) = @_;
     my $f = new IO::File($file, "r");
     my %results;
 
@@ -134,7 +134,7 @@ sub _sv_with_min_support_count {
         next if exists $seen{$sv_name};
         $seen{$sv_name} = 1;
 
-        next unless exists $results{$sv_name} && ($results{$sv_name}{count} >= $min_hit_support);
+        next unless exists $results{$sv_name} && ($results{$sv_name}{count} >= $self->min_hit_support);
         $count++;
         if ($out) {
             print $out "$line\n";

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.pm
@@ -109,10 +109,10 @@ sub _sv_with_min_support_count {
         my $sv_name = $f[6];
         my $read_id = $f[$id_index];
         unless (defined $sv_name) {
-            die "Sv name not defined on line:\n$line";
+            die $self->error_message("Sv name not defined on line:\n$line");
         }
         unless (defined $read_id) {
-            die "read id not defined on line:\n$line";
+            die $self->error_message("read id not defined on line:\n$line");
         }
         ++$results{$sv_name}{count} unless exists $results{$sv_name}{reads}{$read_id};
         $results{$sv_name}{reads}{$read_id} = 1;
@@ -128,7 +128,7 @@ sub _sv_with_min_support_count {
         my @f = split("\t", $line);
         my $sv_name = $f[6];
         unless (defined $sv_name) {
-            die "Sv name not defined on line:\n$line";
+            die $self->error_message("Sv name not defined on line:\n$line");
         }
         next if exists $seen{$sv_name};
         $seen{$sv_name} = 1;

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.t
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.t
@@ -10,7 +10,7 @@ use warnings;
 
 use above "Genome";
 use Test::More;
-use Genome::Utility::Test;
+use Genome::Utility::Test qw(compare_ok);
 
 my $pkg = 'Genome::Model::Tools::Bedpe::EvaluateBedpe';
 use_ok($pkg);
@@ -63,12 +63,15 @@ subtest "Only one hit per sv" => sub {
 };
 
 subtest "Require two hits" => sub {
+    my $tp = Genome::Sys->create_temp_file_path;
+    my $expected_tp = File::Spec->join($data_dir, 'expected_tp.bedpe');
     my $cmd = $pkg->create(
         bedpe => File::Spec->join($data_dir, 'a.bedpe'),
         gold_bedpe => File::Spec->join($data_dir, 'gold3.bedpe'),
         bedtools_version => '2.17.0',
         slop => 1000,
         min_hit_support => 2,
+        true_positive_file => $tp,
     );
     ok($cmd->execute, "Command executed ok");
 
@@ -83,6 +86,7 @@ subtest "Require two hits" => sub {
         total_unique_gold_calls => 3,
     };
     is_deeply($cmd->rawstats, $expected_stats, "stats were set correctly");
+    compare_ok($tp, $expected_tp, "True positives were output correctly");
 };
 
 done_testing;

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.t
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.t
@@ -37,7 +37,7 @@ subtest "Basic" => sub {
         total_unique_calls => 2,
         total_unique_gold_calls => 2,
     };
-    is_deeply($expected_stats, $cmd->rawstats, "stats were set correctly");
+    is_deeply($cmd->rawstats, $expected_stats, "stats were set correctly");
 };
 
 subtest "Only one hit per sv" => sub {
@@ -59,7 +59,7 @@ subtest "Only one hit per sv" => sub {
         total_unique_calls => 2,
         total_unique_gold_calls => 2,
     };
-    is_deeply($expected_stats, $cmd->rawstats, "stats were set correctly");
+    is_deeply($cmd->rawstats, $expected_stats, "stats were set correctly");
 };
 done_testing;
 

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.t
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpe.t
@@ -61,5 +61,29 @@ subtest "Only one hit per sv" => sub {
     };
     is_deeply($cmd->rawstats, $expected_stats, "stats were set correctly");
 };
+
+subtest "Require two hits" => sub {
+    my $cmd = $pkg->create(
+        bedpe => File::Spec->join($data_dir, 'a.bedpe'),
+        gold_bedpe => File::Spec->join($data_dir, 'gold3.bedpe'),
+        bedtools_version => '2.17.0',
+        slop => 1000,
+        min_hit_support => 2,
+    );
+    ok($cmd->execute, "Command executed ok");
+
+    my $expected_stats = {
+        true_positive => 1,
+        false_positive => 1,
+        false_negative => 0,
+        ppv => .5,
+        sensitivity => 1,
+        f1 => 0.666666666666667,
+        total_unique_calls => 2,
+        total_unique_gold_calls => 3,
+    };
+    is_deeply($cmd->rawstats, $expected_stats, "stats were set correctly");
+};
+
 done_testing;
 

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpes.pm
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpes.pm
@@ -35,6 +35,8 @@ sub execute {
             $line->{bedpe},
             $line->{gold_bedpe},
             $line->{slop},
+            $line->{min_hit_support},
+            $line->{true_positive_file},
         );
         for my $key (keys %$stats) {
             die "Duplicate key $key: this would overwrite the column provided in the config"
@@ -51,12 +53,14 @@ sub execute {
 }
 
 sub _run_one {
-    my ($self, $bedpe, $gold_bedpe, $slop) = @_;
+    my ($self, $bedpe, $gold_bedpe, $slop, $min_hit_support, $true_positive_file) = @_;
     my $cmd = Genome::Model::Tools::Bedpe::EvaluateBedpe->create(
         bedpe => $bedpe,
         gold_bedpe => $gold_bedpe,
         slop => $slop,
         bedtools_version => $self->bedtools_version,
+        min_hit_support => $min_hit_support || 1,
+        true_positive_file => $true_positive_file,
     );
     $cmd->execute;
     return $cmd->rawstats;

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpes.pm
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpes.pm
@@ -61,9 +61,7 @@ sub execute {
 sub _read_tps {
     my $file = shift;
     my @tps = Genome::Sys->read_file($file);
-    for my $tp (@tps) {
-        chomp $tp;
-    }
+    chomp @tps;
     return @tps;
 }
 

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpes.t
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpes.t
@@ -40,5 +40,27 @@ subtest "Basic" => sub {
     my $expected_json = File::Spec->join($data_dir, "expected.json");
     compare_ok($json, $expected_json);
 };
+
+subtest "With min-hit-support and tp_file" => sub {
+    my $config_file = Genome::Sys->create_temp_file_path;
+    my @config = (
+        join("\t", qw(caller_name gold_name data_name bedpe gold_bedpe slop min_hit_support include_tps)),
+        "\n",
+        join("\t", "Caller1", "Gold1", "Data1", File::Spec->join($data_dir, "a.bedpe"), File::Spec->join($data_dir, "gold.bedpe"), 0, 1, 1),
+        "\n",
+        join("\t", "Caller1", "Gold2", "Data1", File::Spec->join($data_dir, "a.bedpe"), File::Spec->join($data_dir, "gold2.bedpe"), 1000, 2, 1),
+    );
+    Genome::Sys->write_file($config_file, @config);
+    my $json = Genome::Sys->create_temp_file_path;
+    my $expected_json = File::Spec->join($data_dir, "expected2.json");
+
+    my $cmd = $pkg->create(
+        config_file => $config_file,
+        output_json => $json,
+        bedtools_version => '2.17.0',
+    );
+    ok($cmd->execute, "Command executed ok");
+    compare_ok($json, $expected_json);
+};
 done_testing;
 

--- a/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpes.t
+++ b/lib/perl/Genome/Model/Tools/Bedpe/EvaluateBedpes.t
@@ -18,25 +18,27 @@ use_ok($pkg);
 
 my $data_dir = Genome::Utility::Test->data_dir_ok($pkg, $version);
 
-my $config_file = Genome::Sys->create_temp_file_path;
-my @config = (
-    join("\t", qw(caller_name gold_name data_name bedpe gold_bedpe slop)),
-    "\n",
-    join("\t", "Caller1", "Gold1", "Data1", File::Spec->join($data_dir, "a.bedpe"), File::Spec->join($data_dir, "gold.bedpe"), 0),
-    "\n",
-    join("\t", "Caller1", "Gold1", "Data1", File::Spec->join($data_dir, "a.bedpe"), File::Spec->join($data_dir, "gold2.bedpe"), 1000),
-);
-Genome::Sys->write_file($config_file, @config);
-my $json = Genome::Sys->create_temp_file_path;
+subtest "Basic" => sub {
+    my $config_file = Genome::Sys->create_temp_file_path;
+    my @config = (
+        join("\t", qw(caller_name gold_name data_name bedpe gold_bedpe slop)),
+        "\n",
+        join("\t", "Caller1", "Gold1", "Data1", File::Spec->join($data_dir, "a.bedpe"), File::Spec->join($data_dir, "gold.bedpe"), 0),
+        "\n",
+        join("\t", "Caller1", "Gold1", "Data1", File::Spec->join($data_dir, "a.bedpe"), File::Spec->join($data_dir, "gold2.bedpe"), 1000),
+    );
+    Genome::Sys->write_file($config_file, @config);
+    my $json = Genome::Sys->create_temp_file_path;
 
-my $cmd = $pkg->create(
-    config_file => $config_file,
-    output_json => $json,
-    bedtools_version => '2.17.0',
-);
-ok($cmd->execute, "Command executed ok");
+    my $cmd = $pkg->create(
+        config_file => $config_file,
+        output_json => $json,
+        bedtools_version => '2.17.0',
+    );
+    ok($cmd->execute, "Command executed ok");
 
-my $expected_json = File::Spec->join($data_dir, "expected.json");
-compare_ok($json, $expected_json);
+    my $expected_json = File::Spec->join($data_dir, "expected.json");
+    compare_ok($json, $expected_json);
+};
 done_testing;
 


### PR DESCRIPTION
In some cases, we want to require more than one hit to count an sv as a 'true positive'.  We also want to save the actual svs in json for further processing.