### PR TITLE
PTero: Control flow feature

### DIFF
--- a/lib/perl/Genome/Command.pm
+++ b/lib/perl/Genome/Command.pm
@@ -39,6 +39,7 @@ my %command_map = (
     'task' => 'Genome::Task::Command',
     'taxon' => 'Genome::Taxon::Command',
     'tools' => 'Genome::Model::Tools',
+    'test' => 'Genome::Test::Command',
 );
 
 $Genome::Command::SUB_COMMAND_MAPPING = \%command_map;

--- a/lib/perl/Genome/Command/PteroWorkflowMixin.pm
+++ b/lib/perl/Genome/Command/PteroWorkflowMixin.pm
@@ -178,7 +178,7 @@ sub _write_ptero_workflow {
 sub _top_level_dag {
     my ($self, $workflow) = @_;
 
-    return $workflow->{tasks}{$workflow->{name}}{methods}[1];
+    return $workflow->{tasks}{$workflow->{name}}{methods}[0];
 }
 
 sub _top_level_tasks {

--- a/lib/perl/Genome/Ptero/workflow_tests/converge/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/converge/ptero_workflow.json
@@ -2,13 +2,7 @@
    "links" : [
       {
          "dataFlow" : {
-            "a" : "a"
-         },
-         "destination" : "Convergence",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
+            "a" : "a",
             "b" : "b"
          },
          "destination" : "Convergence",

--- a/lib/perl/Genome/Ptero/workflow_tests/converge/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/converge/ptero_workflow_for_process.json
@@ -1,14 +1,16 @@
 {
    "links" : [
       {
-         "dataFlow" : {
-            "a" : "a"
-         },
-         "destination" : "Converge Test",
+         "destination" : "set status Running",
          "source" : "input connector"
       },
       {
+         "destination" : "Converge Test",
+         "source" : "set status Running"
+      },
+      {
          "dataFlow" : {
+            "a" : "a",
             "b" : "b"
          },
          "destination" : "Converge Test",
@@ -22,16 +24,10 @@
          "source" : "Converge Test"
       },
       {
-         "dataFlow" : {
-            "out" : "out"
-         },
          "destination" : "set status Succeeded",
          "source" : "Converge Test"
       },
       {
-         "dataFlow" : {
-            "dummy_output" : "dummy_output for Genome::Process(123)"
-         },
          "destination" : "output connector",
          "source" : "set status Succeeded"
       }
@@ -40,38 +36,12 @@
       "Converge Test" : {
          "methods" : [
             {
-               "name" : "set status Running",
-               "parameters" : {
-                  "commandLine" : [
-                     "genome",
-                     "process",
-                     "set-status",
-                     "123",
-                     "Running",
-                     "--exit-code",
-                     1
-                  ],
-                  "environment" : {
-                     "FOO" : "bar"
-                  },
-                  "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
-               },
-               "service" : "shell-command"
-            },
-            {
                "name" : "Converge Test",
                "parameters" : {
                   "links" : [
                      {
                         "dataFlow" : {
-                           "a" : "a"
-                        },
-                        "destination" : "Convergence",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "a" : "a",
                            "b" : "b"
                         },
                         "destination" : "Convergence",
@@ -122,7 +92,31 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
+               },
+               "service" : "shell-command"
+            }
+         ]
+      },
+      "set status Running" : {
+         "methods" : [
+            {
+               "name" : "set status Running",
+               "parameters" : {
+                  "commandLine" : [
+                     "genome",
+                     "process",
+                     "set-status",
+                     "123",
+                     "Running",
+                     "--exit-code",
+                     0
+                  ],
+                  "environment" : {
+                     "FOO" : "bar"
+                  },
+                  "user" : "dmorton",
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -146,7 +140,7 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -2,13 +2,7 @@
    "links" : [
       {
          "dataFlow" : {
-            "model_prefix_lists" : "prefix_list"
-         },
-         "destination" : "Outer",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
+            "model_prefix_lists" : "prefix_list",
             "model_suffixes" : "suffixes"
          },
          "destination" : "Outer",
@@ -23,13 +17,7 @@
       },
       {
          "dataFlow" : {
-            "command_prefixes" : "prefix"
-         },
-         "destination" : "Appender",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
+            "command_prefixes" : "prefix",
             "command_suffix" : "suffix"
          },
          "destination" : "Appender",
@@ -62,7 +50,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             },
@@ -82,7 +70,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -97,13 +85,7 @@
                   "links" : [
                      {
                         "dataFlow" : {
-                           "prefix_list" : "prefixes"
-                        },
-                        "destination" : "Inner",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "prefix_list" : "prefixes",
                            "suffixes" : "suffixes"
                         },
                         "destination" : "Inner",
@@ -126,13 +108,7 @@
                                  "links" : [
                                     {
                                        "dataFlow" : {
-                                          "prefixes" : "prefix"
-                                       },
-                                       "destination" : "Appender",
-                                       "source" : "input connector"
-                                    },
-                                    {
-                                       "dataFlow" : {
+                                          "prefixes" : "prefix",
                                           "suffixes" : "suffix"
                                        },
                                        "destination" : "Appender",
@@ -165,7 +141,7 @@
                                                 ],
                                                 "environment" : {},
                                                 "user" : "dmorton",
-                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "shell-command"
                                           },
@@ -185,7 +161,7 @@
                                                 ],
                                                 "environment" : {},
                                                 "user" : "dmorton",
-                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "shell-command"
                                           }

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -1,14 +1,18 @@
 {
    "links" : [
       {
-         "dataFlow" : {
-            "model_prefix_lists" : "model_prefix_lists"
-         },
-         "destination" : "Parallel Model Test",
+         "destination" : "set status Running",
          "source" : "input connector"
       },
       {
+         "destination" : "Parallel Model Test",
+         "source" : "set status Running"
+      },
+      {
          "dataFlow" : {
+            "command_prefixes" : "command_prefixes",
+            "command_suffix" : "command_suffix",
+            "model_prefix_lists" : "model_prefix_lists",
             "model_suffixes" : "model_suffixes"
          },
          "destination" : "Parallel Model Test",
@@ -16,43 +20,17 @@
       },
       {
          "dataFlow" : {
+            "command_outputs" : "command_outputs",
             "model_outputs" : "model_outputs"
          },
          "destination" : "output connector",
          "source" : "Parallel Model Test"
       },
       {
-         "dataFlow" : {
-            "command_prefixes" : "command_prefixes"
-         },
-         "destination" : "Parallel Model Test",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
-            "command_suffix" : "command_suffix"
-         },
-         "destination" : "Parallel Model Test",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
-            "command_outputs" : "command_outputs"
-         },
-         "destination" : "output connector",
-         "source" : "Parallel Model Test"
-      },
-      {
-         "dataFlow" : {
-            "command_outputs" : "command_outputs"
-         },
          "destination" : "set status Succeeded",
          "source" : "Parallel Model Test"
       },
       {
-         "dataFlow" : {
-            "dummy_output" : "dummy_output for Genome::Process(123)"
-         },
          "destination" : "output connector",
          "source" : "set status Succeeded"
       }
@@ -61,38 +39,12 @@
       "Parallel Model Test" : {
          "methods" : [
             {
-               "name" : "set status Running",
-               "parameters" : {
-                  "commandLine" : [
-                     "genome",
-                     "process",
-                     "set-status",
-                     "123",
-                     "Running",
-                     "--exit-code",
-                     1
-                  ],
-                  "environment" : {
-                     "FOO" : "bar"
-                  },
-                  "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
-               },
-               "service" : "shell-command"
-            },
-            {
                "name" : "Parallel Model Test",
                "parameters" : {
                   "links" : [
                      {
                         "dataFlow" : {
-                           "model_prefix_lists" : "prefix_list"
-                        },
-                        "destination" : "Outer",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "model_prefix_lists" : "prefix_list",
                            "model_suffixes" : "suffixes"
                         },
                         "destination" : "Outer",
@@ -107,13 +59,7 @@
                      },
                      {
                         "dataFlow" : {
-                           "command_prefixes" : "prefix"
-                        },
-                        "destination" : "Appender",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "command_prefixes" : "prefix",
                            "command_suffix" : "suffix"
                         },
                         "destination" : "Appender",
@@ -148,7 +94,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            },
@@ -170,7 +116,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            }
@@ -185,13 +131,7 @@
                                  "links" : [
                                     {
                                        "dataFlow" : {
-                                          "prefix_list" : "prefixes"
-                                       },
-                                       "destination" : "Inner",
-                                       "source" : "input connector"
-                                    },
-                                    {
-                                       "dataFlow" : {
+                                          "prefix_list" : "prefixes",
                                           "suffixes" : "suffixes"
                                        },
                                        "destination" : "Inner",
@@ -214,13 +154,7 @@
                                                 "links" : [
                                                    {
                                                       "dataFlow" : {
-                                                         "prefixes" : "prefix"
-                                                      },
-                                                      "destination" : "Appender",
-                                                      "source" : "input connector"
-                                                   },
-                                                   {
-                                                      "dataFlow" : {
+                                                         "prefixes" : "prefix",
                                                          "suffixes" : "suffix"
                                                       },
                                                       "destination" : "Appender",
@@ -255,7 +189,7 @@
                                                                   "FOO" : "bar"
                                                                },
                                                                "user" : "dmorton",
-                                                               "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                               "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                                             },
                                                             "service" : "shell-command"
                                                          },
@@ -277,7 +211,7 @@
                                                                   "FOO" : "bar"
                                                                },
                                                                "user" : "dmorton",
-                                                               "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                               "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                                             },
                                                             "service" : "shell-command"
                                                          }
@@ -318,7 +252,31 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
+               },
+               "service" : "shell-command"
+            }
+         ]
+      },
+      "set status Running" : {
+         "methods" : [
+            {
+               "name" : "set status Running",
+               "parameters" : {
+                  "commandLine" : [
+                     "genome",
+                     "process",
+                     "set-status",
+                     "123",
+                     "Running",
+                     "--exit-code",
+                     0
+                  ],
+                  "environment" : {
+                     "FOO" : "bar"
+                  },
+                  "user" : "dmorton",
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -342,7 +300,7 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -97,7 +97,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             },
@@ -117,7 +117,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -141,7 +141,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             },
@@ -161,7 +161,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -185,7 +185,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             },
@@ -205,7 +205,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -229,7 +229,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             },
@@ -249,7 +249,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -1,28 +1,18 @@
 {
    "links" : [
       {
-         "dataFlow" : {
-            "a" : "a"
-         },
-         "destination" : "Mark likes the letter N",
+         "destination" : "set status Running",
          "source" : "input connector"
       },
       {
-         "dataFlow" : {
-            "b" : "b"
-         },
          "destination" : "Mark likes the letter N",
-         "source" : "input connector"
+         "source" : "set status Running"
       },
       {
          "dataFlow" : {
-            "c" : "c"
-         },
-         "destination" : "Mark likes the letter N",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
+            "a" : "a",
+            "b" : "b",
+            "c" : "c",
             "d" : "d"
          },
          "destination" : "Mark likes the letter N",
@@ -30,43 +20,19 @@
       },
       {
          "dataFlow" : {
-            "out_a" : "out_a"
-         },
-         "destination" : "output connector",
-         "source" : "Mark likes the letter N"
-      },
-      {
-         "dataFlow" : {
-            "out_b" : "out_b"
-         },
-         "destination" : "output connector",
-         "source" : "Mark likes the letter N"
-      },
-      {
-         "dataFlow" : {
-            "out_c" : "out_c"
-         },
-         "destination" : "output connector",
-         "source" : "Mark likes the letter N"
-      },
-      {
-         "dataFlow" : {
+            "out_a" : "out_a",
+            "out_b" : "out_b",
+            "out_c" : "out_c",
             "out_d" : "out_d"
          },
          "destination" : "output connector",
          "source" : "Mark likes the letter N"
       },
       {
-         "dataFlow" : {
-            "out_d" : "out_d"
-         },
          "destination" : "set status Succeeded",
          "source" : "Mark likes the letter N"
       },
       {
-         "dataFlow" : {
-            "dummy_output" : "dummy_output for Genome::Process(123)"
-         },
          "destination" : "output connector",
          "source" : "set status Succeeded"
       }
@@ -74,26 +40,6 @@
    "tasks" : {
       "Mark likes the letter N" : {
          "methods" : [
-            {
-               "name" : "set status Running",
-               "parameters" : {
-                  "commandLine" : [
-                     "genome",
-                     "process",
-                     "set-status",
-                     "123",
-                     "Running",
-                     "--exit-code",
-                     1
-                  ],
-                  "environment" : {
-                     "FOO" : "bar"
-                  },
-                  "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
-               },
-               "service" : "shell-command"
-            },
             {
                "name" : "Mark likes the letter N",
                "parameters" : {
@@ -197,7 +143,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            },
@@ -219,7 +165,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            }
@@ -245,7 +191,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            },
@@ -267,7 +213,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            }
@@ -293,7 +239,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            },
@@ -315,7 +261,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            }
@@ -341,7 +287,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            },
@@ -363,7 +309,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            }
@@ -389,7 +335,31 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
+               },
+               "service" : "shell-command"
+            }
+         ]
+      },
+      "set status Running" : {
+         "methods" : [
+            {
+               "name" : "set status Running",
+               "parameters" : {
+                  "commandLine" : [
+                     "genome",
+                     "process",
+                     "set-status",
+                     "123",
+                     "Running",
+                     "--exit-code",
+                     0
+                  ],
+                  "environment" : {
+                     "FOO" : "bar"
+                  },
+                  "user" : "dmorton",
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -413,7 +383,7 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -2,13 +2,7 @@
    "links" : [
       {
          "dataFlow" : {
-            "prefix_lists" : "prefix_list"
-         },
-         "destination" : "Outer",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
+            "prefix_lists" : "prefix_list",
             "suffixes" : "suffixes"
          },
          "destination" : "Outer",
@@ -31,13 +25,7 @@
                   "links" : [
                      {
                         "dataFlow" : {
-                           "prefix_list" : "prefixes"
-                        },
-                        "destination" : "Inner",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "prefix_list" : "prefixes",
                            "suffixes" : "suffixes"
                         },
                         "destination" : "Inner",
@@ -60,13 +48,7 @@
                                  "links" : [
                                     {
                                        "dataFlow" : {
-                                          "prefixes" : "prefix"
-                                       },
-                                       "destination" : "Appender",
-                                       "source" : "input connector"
-                                    },
-                                    {
-                                       "dataFlow" : {
+                                          "prefixes" : "prefix",
                                           "suffixes" : "suffix"
                                        },
                                        "destination" : "Appender",
@@ -99,7 +81,7 @@
                                                 ],
                                                 "environment" : {},
                                                 "user" : "dmorton",
-                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "shell-command"
                                           },
@@ -119,7 +101,7 @@
                                                 ],
                                                 "environment" : {},
                                                 "user" : "dmorton",
-                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "shell-command"
                                           }

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -1,14 +1,16 @@
 {
    "links" : [
       {
-         "dataFlow" : {
-            "prefix_lists" : "prefix_lists"
-         },
-         "destination" : "Parallel Model Test",
+         "destination" : "set status Running",
          "source" : "input connector"
       },
       {
+         "destination" : "Parallel Model Test",
+         "source" : "set status Running"
+      },
+      {
          "dataFlow" : {
+            "prefix_lists" : "prefix_lists",
             "suffixes" : "suffixes"
          },
          "destination" : "Parallel Model Test",
@@ -22,16 +24,10 @@
          "source" : "Parallel Model Test"
       },
       {
-         "dataFlow" : {
-            "outputs" : "outputs"
-         },
          "destination" : "set status Succeeded",
          "source" : "Parallel Model Test"
       },
       {
-         "dataFlow" : {
-            "dummy_output" : "dummy_output for Genome::Process(123)"
-         },
          "destination" : "output connector",
          "source" : "set status Succeeded"
       }
@@ -40,38 +36,12 @@
       "Parallel Model Test" : {
          "methods" : [
             {
-               "name" : "set status Running",
-               "parameters" : {
-                  "commandLine" : [
-                     "genome",
-                     "process",
-                     "set-status",
-                     "123",
-                     "Running",
-                     "--exit-code",
-                     1
-                  ],
-                  "environment" : {
-                     "FOO" : "bar"
-                  },
-                  "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
-               },
-               "service" : "shell-command"
-            },
-            {
                "name" : "Parallel Model Test",
                "parameters" : {
                   "links" : [
                      {
                         "dataFlow" : {
-                           "prefix_lists" : "prefix_list"
-                        },
-                        "destination" : "Outer",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "prefix_lists" : "prefix_list",
                            "suffixes" : "suffixes"
                         },
                         "destination" : "Outer",
@@ -94,13 +64,7 @@
                                  "links" : [
                                     {
                                        "dataFlow" : {
-                                          "prefix_list" : "prefixes"
-                                       },
-                                       "destination" : "Inner",
-                                       "source" : "input connector"
-                                    },
-                                    {
-                                       "dataFlow" : {
+                                          "prefix_list" : "prefixes",
                                           "suffixes" : "suffixes"
                                        },
                                        "destination" : "Inner",
@@ -123,13 +87,7 @@
                                                 "links" : [
                                                    {
                                                       "dataFlow" : {
-                                                         "prefixes" : "prefix"
-                                                      },
-                                                      "destination" : "Appender",
-                                                      "source" : "input connector"
-                                                   },
-                                                   {
-                                                      "dataFlow" : {
+                                                         "prefixes" : "prefix",
                                                          "suffixes" : "suffix"
                                                       },
                                                       "destination" : "Appender",
@@ -164,7 +122,7 @@
                                                                   "FOO" : "bar"
                                                                },
                                                                "user" : "dmorton",
-                                                               "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                               "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                                             },
                                                             "service" : "shell-command"
                                                          },
@@ -186,7 +144,7 @@
                                                                   "FOO" : "bar"
                                                                },
                                                                "user" : "dmorton",
-                                                               "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                               "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                                             },
                                                             "service" : "shell-command"
                                                          }
@@ -227,7 +185,31 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
+               },
+               "service" : "shell-command"
+            }
+         ]
+      },
+      "set status Running" : {
+         "methods" : [
+            {
+               "name" : "set status Running",
+               "parameters" : {
+                  "commandLine" : [
+                     "genome",
+                     "process",
+                     "set-status",
+                     "123",
+                     "Running",
+                     "--exit-code",
+                     0
+                  ],
+                  "environment" : {
+                     "FOO" : "bar"
+                  },
+                  "user" : "dmorton",
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -251,7 +233,7 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -2,13 +2,7 @@
    "links" : [
       {
          "dataFlow" : {
-            "prefixes" : "prefix"
-         },
-         "destination" : "Appender",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
+            "prefixes" : "prefix",
             "suffix" : "suffix"
          },
          "destination" : "Appender",
@@ -41,7 +35,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             },
@@ -61,7 +55,7 @@
                   ],
                   "environment" : {},
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -1,14 +1,16 @@
 {
    "links" : [
       {
-         "dataFlow" : {
-            "prefixes" : "prefixes"
-         },
-         "destination" : "Parallel Model Test",
+         "destination" : "set status Running",
          "source" : "input connector"
       },
       {
+         "destination" : "Parallel Model Test",
+         "source" : "set status Running"
+      },
+      {
          "dataFlow" : {
+            "prefixes" : "prefixes",
             "suffix" : "suffix"
          },
          "destination" : "Parallel Model Test",
@@ -22,16 +24,10 @@
          "source" : "Parallel Model Test"
       },
       {
-         "dataFlow" : {
-            "outputs" : "outputs"
-         },
          "destination" : "set status Succeeded",
          "source" : "Parallel Model Test"
       },
       {
-         "dataFlow" : {
-            "dummy_output" : "dummy_output for Genome::Process(123)"
-         },
          "destination" : "output connector",
          "source" : "set status Succeeded"
       }
@@ -40,38 +36,12 @@
       "Parallel Model Test" : {
          "methods" : [
             {
-               "name" : "set status Running",
-               "parameters" : {
-                  "commandLine" : [
-                     "genome",
-                     "process",
-                     "set-status",
-                     "123",
-                     "Running",
-                     "--exit-code",
-                     1
-                  ],
-                  "environment" : {
-                     "FOO" : "bar"
-                  },
-                  "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
-               },
-               "service" : "shell-command"
-            },
-            {
                "name" : "Parallel Model Test",
                "parameters" : {
                   "links" : [
                      {
                         "dataFlow" : {
-                           "prefixes" : "prefix"
-                        },
-                        "destination" : "Appender",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "prefixes" : "prefix",
                            "suffix" : "suffix"
                         },
                         "destination" : "Appender",
@@ -106,7 +76,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            },
@@ -128,7 +98,7 @@
                                     "FOO" : "bar"
                                  },
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            }
@@ -155,7 +125,31 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
+               },
+               "service" : "shell-command"
+            }
+         ]
+      },
+      "set status Running" : {
+         "methods" : [
+            {
+               "name" : "set status Running",
+               "parameters" : {
+                  "commandLine" : [
+                     "genome",
+                     "process",
+                     "set-status",
+                     "123",
+                     "Running",
+                     "--exit-code",
+                     0
+                  ],
+                  "environment" : {
+                     "FOO" : "bar"
+                  },
+                  "user" : "dmorton",
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -179,7 +173,7 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -2,13 +2,7 @@
    "links" : [
       {
          "dataFlow" : {
-            "prefixes" : "prefix"
-         },
-         "destination" : "Inner",
-         "source" : "input connector"
-      },
-      {
-         "dataFlow" : {
+            "prefixes" : "prefix",
             "suffix" : "suffix"
          },
          "destination" : "Inner",
@@ -31,13 +25,7 @@
                   "links" : [
                      {
                         "dataFlow" : {
-                           "prefix" : "prefix"
-                        },
-                        "destination" : "Appender",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "prefix" : "prefix",
                            "suffix" : "suffix"
                         },
                         "destination" : "Appender",
@@ -70,7 +58,7 @@
                                  ],
                                  "environment" : {},
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            },
@@ -90,7 +78,7 @@
                                  ],
                                  "environment" : {},
                                  "user" : "dmorton",
-                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "shell-command"
                            }

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -1,14 +1,16 @@
 {
    "links" : [
       {
-         "dataFlow" : {
-            "prefixes" : "prefixes"
-         },
-         "destination" : "Parallel Model Test",
+         "destination" : "set status Running",
          "source" : "input connector"
       },
       {
+         "destination" : "Parallel Model Test",
+         "source" : "set status Running"
+      },
+      {
          "dataFlow" : {
+            "prefixes" : "prefixes",
             "suffix" : "suffix"
          },
          "destination" : "Parallel Model Test",
@@ -22,16 +24,10 @@
          "source" : "Parallel Model Test"
       },
       {
-         "dataFlow" : {
-            "outputs" : "outputs"
-         },
          "destination" : "set status Succeeded",
          "source" : "Parallel Model Test"
       },
       {
-         "dataFlow" : {
-            "dummy_output" : "dummy_output for Genome::Process(123)"
-         },
          "destination" : "output connector",
          "source" : "set status Succeeded"
       }
@@ -40,38 +36,12 @@
       "Parallel Model Test" : {
          "methods" : [
             {
-               "name" : "set status Running",
-               "parameters" : {
-                  "commandLine" : [
-                     "genome",
-                     "process",
-                     "set-status",
-                     "123",
-                     "Running",
-                     "--exit-code",
-                     1
-                  ],
-                  "environment" : {
-                     "FOO" : "bar"
-                  },
-                  "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
-               },
-               "service" : "shell-command"
-            },
-            {
                "name" : "Parallel Model Test",
                "parameters" : {
                   "links" : [
                      {
                         "dataFlow" : {
-                           "prefixes" : "prefix"
-                        },
-                        "destination" : "Inner",
-                        "source" : "input connector"
-                     },
-                     {
-                        "dataFlow" : {
+                           "prefixes" : "prefix",
                            "suffix" : "suffix"
                         },
                         "destination" : "Inner",
@@ -94,13 +64,7 @@
                                  "links" : [
                                     {
                                        "dataFlow" : {
-                                          "prefix" : "prefix"
-                                       },
-                                       "destination" : "Appender",
-                                       "source" : "input connector"
-                                    },
-                                    {
-                                       "dataFlow" : {
+                                          "prefix" : "prefix",
                                           "suffix" : "suffix"
                                        },
                                        "destination" : "Appender",
@@ -135,7 +99,7 @@
                                                    "FOO" : "bar"
                                                 },
                                                 "user" : "dmorton",
-                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "shell-command"
                                           },
@@ -157,7 +121,7 @@
                                                    "FOO" : "bar"
                                                 },
                                                 "user" : "dmorton",
-                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "shell-command"
                                           }
@@ -190,7 +154,31 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
+               },
+               "service" : "shell-command"
+            }
+         ]
+      },
+      "set status Running" : {
+         "methods" : [
+            {
+               "name" : "set status Running",
+               "parameters" : {
+                  "commandLine" : [
+                     "genome",
+                     "process",
+                     "set-status",
+                     "123",
+                     "Running",
+                     "--exit-code",
+                     0
+                  ],
+                  "environment" : {
+                     "FOO" : "bar"
+                  },
+                  "user" : "dmorton",
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }
@@ -214,7 +202,7 @@
                      "FOO" : "bar"
                   },
                   "user" : "dmorton",
-                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome/Ptero"
+                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "shell-command"
             }

--- a/lib/perl/Genome/Test/Command.pm
+++ b/lib/perl/Genome/Test/Command.pm
@@ -1,0 +1,12 @@
+package Genome::Test::Command;
+
+use strict;
+use warnings FATAL => 'all';
+use Genome;
+
+class Genome::Test::Command {
+    is => 'Command::Tree',
+    doc => 'commands for testing various parts of the GMS',
+};
+
+1;

--- a/lib/perl/Genome/Test/Command/Echo.pm
+++ b/lib/perl/Genome/Test/Command/Echo.pm
@@ -1,0 +1,46 @@
+package Genome::Test::Command::Echo;
+
+use strict;
+use warnings FATAL => 'all';
+use Genome;
+
+class Genome::Test::Command::Echo {
+    is => 'Command::V2',
+
+    has_input => [
+        input_statement => {
+            is => 'Text',
+        },
+        fail_intentionally => {
+            is => 'Boolean',
+            default => 0,
+        },
+    ],
+    has_optional_output => [
+        output_statement => {
+            is => 'Text',
+        },
+    ],
+    doc => 'Echos a statement',
+};
+
+sub shortcut {
+    my $self = shift;
+    return $self->execute();
+}
+
+sub execute {
+    my $self = shift;
+
+    die "I was told to fail, so here goes!" if $self->fail_intentionally;
+
+    $self->status_message("I'm about to echo a statement");
+    $self->status_message($self->input_statement);
+    $self->status_message("I just echoed a statement, did you like it?");
+
+    $self->output_statement($self->input_statement);
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Test/Command/RunSimpleProcess.pm
+++ b/lib/perl/Genome/Test/Command/RunSimpleProcess.pm
@@ -1,0 +1,85 @@
+package Genome::Test::Command::RunSimpleProcess;
+
+use strict;
+use warnings FATAL => 'all';
+use Genome;
+use Genome::WorkflowBuilder::DAG;
+use Genome::WorkflowBuilder::Command;
+
+class Genome::Test::Command::RunSimpleProcess {
+    is => 'Command::V2',
+
+    has_input => [
+        statement => {
+            is => 'Text',
+            doc => "Something to expect in the workflow outputs",
+        },
+        wait_and_check_outputs => {
+            is => 'Boolean',
+            default => '0',
+        },
+        fail_intentionally => {
+            is => 'Boolean',
+            default => '0',
+        }
+    ],
+    doc => 'Runs a simple Genome::Process',
+};
+
+sub execute {
+    my $self = shift;
+
+    my $p = Genome::Process::Test::Process->create(
+        statement => $self->statement,
+    );
+
+    $self->status_message("Constructing workflow from inputs. (this may take a while...)");
+    my %run_params = (
+        workflow_xml => $self->dag->get_xml,
+        workflow_inputs => {statement => $self->statement,
+                            fail_intentionally => $self->fail_intentionally},
+    );
+    if ($self->wait_and_check_outputs) {
+        my $outputs = $p->run_and_wait(%run_params);
+        die "Unexpected outputs!" unless $outputs->{statement} eq $self->statement;
+    } else {
+        $p->run(%run_params);
+    }
+
+    return $p;
+}
+
+sub dag {
+    my $self = shift;
+
+    my $dag = Genome::WorkflowBuilder::DAG->create(
+        name => 'SimpleProcess',
+    );
+
+    my $command = Genome::WorkflowBuilder::Command->create(
+        name => 'Run Echo Command',
+        command => 'Genome::Test::Command::Echo',
+    );
+    $dag->add_operation($command);
+
+    $dag->connect_input(
+        input_property => 'statement',
+        destination => $command,
+        destination_property => 'input_statement',
+    );
+    $dag->connect_input(
+        input_property => 'fail_intentionally',
+        destination => $command,
+        destination_property => 'fail_intentionally',
+    );
+
+    $dag->connect_output(
+        output_property => 'statement',
+        source => $command,
+        source_property => 'output_statement',
+    );
+
+    return $dag;
+}
+
+1;


### PR DESCRIPTION
The PTero system now understands links between tasks that are not data-flow related.  This PR updates the building of PTero workflows to utilize this new feature.

I've also added a couple of commands related to running a Genome::Process::Test::Process that are helpful for manually testing the ability to submit to Processes to PTero without using the more computationally intensive and complex trio variant-report.

Since libptero-perl 0.1.7 has been deployed before this PR, the unit-tests in Genome::Ptero will fail until this PR is merged.  That is because the libptero-perl library changed how it renders JSON representations of workflows to be compatible with the PTero workflow service.