### PR TITLE
Only schedule annotation if we have variants to annotate.

### DIFF
--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -512,7 +512,13 @@ sub transcript_annotation_job_classes{
         'Genome::Model::Event::Build::ReferenceAlignment::AnnotateTranscriptVariants',
         #'Genome::Model::Event::Build::ReferenceAlignment::AnnotateTranscriptVariantsParallel',
     );
-    return @steps;
+
+    if($self->snv_detection_strategy || $self->indel_detection_strategy) {
+        return @steps;
+    }
+    else {
+        return;
+    }
 }
 
 sub generate_reports_job_classes {


### PR DESCRIPTION
A common misconfiguration of a project seems to be to assign an annotation build input to a reference alignment that is not going to run variant detection.  This currently results in a build failure.

With this change, the build should succeed and not worry about the (then unused) annotation input.  (The alternative change would be to make such a build "Unstartable" so it fails fast.)