### PR TITLE
LDAP Synch: Fix counting bug and cleanup

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
@@ -16,8 +16,8 @@ sub execute {
     my @db_users = Genome::Sys::User->fix_params_and_get();
 
     my $changes = get_changes($ldap_user,\@db_users);
-    my $creates = $changes->{'create'};  
-    my $deletes = $changes->{'deletes'};  
+    my $creates = $changes->{'create'};
+    my $deletes = $changes->{'deletes'};
 
     my $create_count = $creates ? scalar(@$creates) : 0;
     my $delete_count = $deletes ? scalar(@$deletes) : 0;
@@ -40,12 +40,12 @@ sub execute {
             name => $u->{'cn'},
             username => $u->{'uid'},
         );
-    } 
+    }
 
     for my $u (@{ $changes->{'delete'} }) {
         $self->status("DELETE: " . $u->email . "\n");
         $u->delete();
-    } 
+    }
 
     $self->status("done- $create_count creates, $delete_count deletes, $changes_count total\n");
 }
@@ -67,7 +67,7 @@ sub get_ldap_users {
             undef $user;
         } else {
             my ($key, $value) = split(/\:\s+/,$c);
-            $user->{$key} = $value;       
+            $user->{$key} = $value;
         }
     }
 

--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
@@ -17,7 +17,7 @@ sub execute {
 
     my $changes = get_changes($ldap_user,\@db_users);
     my $creates = $changes->{'create'};
-    my $deletes = $changes->{'deletes'};
+    my $deletes = $changes->{'delete'};
 
     my $create_count = $creates ? scalar(@$creates) : 0;
     my $delete_count = $deletes ? scalar(@$deletes) : 0;

--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
@@ -29,7 +29,7 @@ sub execute {
     }
 
     if ($changes_count > 10) {
-        print "Too many changes ($create_count creates, $delete_count deletes, $changes_count total). Sync manually if this is OK.";
+        print "Too many changes ($create_count creates, $delete_count deletes, $changes_count total). Sync manually if this is OK.\n";
         return;
     }
 


### PR DESCRIPTION
* The tool has a threshold to avoid doing too much work, but it was failing to count deletes towards that limit.
* If the limit is exceeded it prints a message, but that message had no newline (so it would potentially be buffered for a long while).
