### PR TITLE
Don't try to run LOH without a normal to compare to.

### DIFF
--- a/lib/perl/Genome/Model/SomaticVariation/Command/Loh.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/Loh.pm
@@ -130,9 +130,9 @@ sub should_skip_run {
         return 1;
     }
 
-    my $normal_build = $build->normal_build;
-    unless($normal_build->can('snv_detection_strategy') and $normal_build->snv_detection_strategy) {
-        $self->debug_message("No SNV Detection Strategy on normal build, skipping LOH.");
+    my $normal_model = $build->normal_model;
+    unless($normal_model->can('snv_detection_strategy') and $normal_model->snv_detection_strategy) {
+        $self->debug_message("No SNV Detection Strategy on normal model, skipping LOH.");
         return 1;
     }
 

--- a/lib/perl/Genome/Model/SomaticVariation/Command/Loh.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/Loh.pm
@@ -130,6 +130,12 @@ sub should_skip_run {
         return 1;
     }
 
+    my $normal_build = $build->normal_build;
+    unless($normal_build->can('snv_detection_strategy') and $normal_build->snv_detection_strategy) {
+        $self->debug_message("No SNV Detection Strategy on normal build, skipping LOH.");
+        return 1;
+    }
+
     return;
 }
 


### PR DESCRIPTION
This lets a `SomaticVariation` build proceed even though the combination of inputs and processing profile doesn't work.  (This is similar to #891.)  I could see a stronger argument for this one leaning the `Unstartable` way.  On the other hand, we should stop using `SomaticVariation` altogether!