### PR TITLE
Allow Programmatic Access to ModelSummary information

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -84,9 +84,11 @@ sub execute {
         }
     };
 
+    Genome::Model::Build::Set->class; #generate type before creating pool
+
     for my $model (@models) {
-        my $per_model_txn = UR::Context::Transaction->begin();
         my $guard = UR::Context::AutoUnloadPool->create();
+        my $per_model_txn = UR::Context::Transaction->begin();
 
         my $summary = $self->generate_model_summary($model);
 

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -86,11 +86,9 @@ sub execute {
 
     for my $model (@models) {
         my $per_model_txn = UR::Context::Transaction->begin();
-
         my $guard = UR::Context::AutoUnloadPool->create();
-        my ($latest_build, $latest_build_status) = $self->_build_and_status_for_model($model);
 
-        my $summary = $self->generate_model_summary($model, $latest_build, $latest_build_status);
+        my $summary = $self->generate_model_summary($model);
 
         #take action if requested
         my $action = $summary->{action};
@@ -133,8 +131,6 @@ sub execute {
 sub generate_model_summary {
     my $self = shift;
     my $model = shift;
-    my $latest_build = shift;
-    my $latest_build_status = shift;
 
     my %summary;
 
@@ -144,6 +140,7 @@ sub generate_model_summary {
     $summary{model_name}   = ($model ? $model->name                     : '-');
     $summary{pp_name}      = ($model ? $model->processing_profile->name : '-');
 
+    my ($latest_build, $latest_build_status) = $self->_build_and_status_for_model($model);
     $summary{latest_build_status} = $latest_build_status;
 
     my $first_nondone_step;

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -106,16 +106,6 @@ sub execute {
         }
         $first_nondone_step ||= '-';
 
-        my $track_change = sub {
-            $change_count++;
-            $classes_to_unload{$latest_build->class}++ if $latest_build;
-        };
-
-        my $request_build = sub {
-            $model->build_requested(1, 'ModelSummary recommended rebuild.');
-            $build_requested_count++;
-        };
-
         $first_nondone_step =~ s/^\d+\s+//;
         $first_nondone_step =~ s/\s+\d+$//;
 
@@ -150,8 +140,14 @@ sub execute {
 
         #take action if requested
         if ($self->auto) {
+            my $track_change = sub {
+                $change_count++;
+                $classes_to_unload{$latest_build->class}++ if $latest_build;
+            };
+
             if ($action eq 'rebuild' or $action eq 'build-needed') {
-                $request_build->();
+                $model->build_requested(1, 'ModelSummary recommended rebuild.');
+                $build_requested_count++;
                 $track_change->();
             }
             elsif ($action eq 'cleanup') {

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -113,7 +113,6 @@ sub execute {
         $latest_build_revision ||= '-';
         ($latest_build_revision) =~ /\/(genome-[^\/])/ if $latest_build_revision =~ /\/genome-[^\/]/;
 
-        $model_name =~ s/\.?$pp_name\.?/.../;
 
         my $action;
         if (!$latest_build && $model->build_requested){


### PR DESCRIPTION
A monitoring tool is being developed to help track the progress of data through sequencing and analysis.  Right now it uses `$model->status`, but it would benefit from being able to grab the full summary (without needing to capture `STDOUT` and parsing it).