### PR TITLE
Don't require builds to be from the same model to diff

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -2135,9 +2135,6 @@ sub compare_output {
     my $other_build = Genome::Model::Build->get($other_build_id);
     confess "Could not get build $other_build_id!" unless $other_build;
 
-    unless ($self->model_id eq $other_build->model_id) {
-        confess "Builds $build_id and $other_build_id are not from the same model!";
-    }
     unless ($self->class eq $other_build->class) {
         confess "Builds $build_id and $other_build_id are not the same type!";
     }


### PR DESCRIPTION
We have a use case for CLE regression testing where
we are making new models in a testdb and want to diff
the resulting builds with builds from old models.  They
should be equivalent, but not the same model.
I don't see any reason why this check adds to the
integrity of the diff