### PR TITLE
Picard

### DIFF
--- a/lib/perl/Genome/Model/ReferenceAlignment/Command/GenotypeMicroarrayConcordance.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Command/GenotypeMicroarrayConcordance.pm
@@ -27,7 +27,7 @@ class Genome::Model::ReferenceAlignment::Command::GenotypeMicroarrayConcordance 
         picard_version => {
             is => 'Text',
             doc => 'The version of picard to use.',
-            valid_values => [ Genome::Model::Tools::Picard->available_picard_versions ],
+            valid_values => [ Genome::Model::Tools::Picard::GenotypeConcordance->available_picard_versions ],
         },
         dbsnp_build => {
             is => 'Genome::Model::Build::ImportedVariationList',

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -229,9 +229,12 @@ sub version_at_least {
     return $self->version_compare($self->use_version, $version) >= 0;
 }
 
-# die if $self->use_version is less than the $min_version argument passed here
-sub enforce_minimum_version {
-    my ($self, $min_version) = @_;
+sub minimum_version_required { return; }
+sub enforce_minimum_version_required {
+    my $self = shift;
+
+    my $min_version = $self->minimum_version_required;
+    return 1 if not defined $min_version;
 
     if ($self->version_older_than($min_version)) {
         confess sprintf "This module requires picard version >= %s (%s requested)",

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -246,8 +246,15 @@ sub enforce_minimum_version_required {
 
 # in decreasing order of recency
 sub available_picard_versions {
+    my $self = shift;
     my @all_versions = uniq(installed_picard_versions(), keys %PICARD_VERSIONS);
-    return sort { __PACKAGE__->version_compare($b, $a) } @all_versions;
+    my $minimum_version_required = $self->minimum_version_required || 0;
+    return sort { 
+        $self->version_compare($b, $a)
+    }
+    grep {
+        $self->version_compare($_, $minimum_version_required) >= 0 
+    } @all_versions;
 }
 
 sub path_for_picard_version {

--- a/lib/perl/Genome/Model/Tools/Picard.t
+++ b/lib/perl/Genome/Model/Tools/Picard.t
@@ -129,7 +129,7 @@ subtest 'Available picard versions' => sub{
 
     $obj->minimum_version_required($versions[2]);
     my @versions_with_miniumum_required = $obj->available_picard_versions;
-    is(@versions_with_miniumum_required, 3, '3 available verions with minimum required version set');
+    is(@versions_with_miniumum_required, 3, '3 available versions with minimum required version set');
     cmp_ok(
         @versions, '>', @versions_with_miniumum_required, 
         'less versions available with minimum set',

--- a/lib/perl/Genome/Model/Tools/Picard.t
+++ b/lib/perl/Genome/Model/Tools/Picard.t
@@ -77,13 +77,14 @@ subtest "Version compare" => sub {
     }
 };
 
+class PicardTest {
+    is => $pkg,
+    has => { minimum_version_required => { is => 'Text', }, },
+};
+my $obj = PicardTest->create;
+
 subtest "Enforce minimum version" => sub {
 
-    class PicardTest {
-        is => $pkg,
-        has => { minimum_version_required => { is => 'Text', }, },
-    };
-    my $obj = PicardTest->create;
 
     # These are ordered from greatest to least
     my @versions = $pkg->_versions_serial;
@@ -116,6 +117,23 @@ subtest "Enforce minimum version" => sub {
         ok(!@failures, "version $ver behaves as expected")
             or diag("Failures: " . Data::Dumper::Dumper(\@failures));
     }
+
+};
+
+subtest 'Available picard versions' => sub{
+    plan tests => 3;
+
+    $obj->minimum_version_required(undef);
+    my @versions = $obj->available_picard_versions;
+    ok(@versions, 'all available picard versions');
+
+    $obj->minimum_version_required($versions[2]);
+    my @versions_with_miniumum_required = $obj->available_picard_versions;
+    is(@versions_with_miniumum_required, 3, '3 available verions with minimum required version set');
+    cmp_ok(
+        @versions, '>', @versions_with_miniumum_required, 
+        'less versions available with minimum set',
+    );
 
 };
 

--- a/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
@@ -56,9 +56,4 @@ sub _shellcmd_extra_params {
         );
 }
 
-sub _validate_params {
-    my $self = shift;
-    $self->enforce_minimum_version("1.29");
-}
-
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BamIndexStats.pm
@@ -32,6 +32,8 @@ sub help_detail {
 EOS
 }
 
+sub minimum_version_required { '1.29'; }
+
 sub _jar_name {
     return 'BamIndexStats.jar';
 }

--- a/lib/perl/Genome/Model/Tools/Picard/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/Base.pm
@@ -109,7 +109,6 @@ sub _cmdline_args {
 sub _validate_params {
     # example:
     # my $self = shift;
-    # $self->enforce_minimum_version('1.85');
     # die unless -s $self->input_file;
     # $self->be_noisy(0) unless $self->log_file;
 }
@@ -170,6 +169,7 @@ sub build_cmdline_string {
 sub execute {
     my $self = shift;
 
+    $self->enforce_minimum_version_required;
     $self->_validate_params;
 
     my %params = (

--- a/lib/perl/Genome/Model/Tools/Picard/BedToIntervalList.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BedToIntervalList.pm
@@ -40,6 +40,8 @@ Converts a BED file to an Picard Interval List.
 EOS
 }
 
+sub minimum_version_required { '1.120'; }
+
 sub _jar_name {
     return 'BedToIntervalList.jar';
 }

--- a/lib/perl/Genome/Model/Tools/Picard/BedToIntervalList.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BedToIntervalList.pm
@@ -58,9 +58,4 @@ sub _shellcmd_extra_params {
         );
 }
 
-sub _validate_params {
-    my $self = shift;
-    $self->enforce_minimum_version('1.120');
-}
-
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
@@ -44,11 +44,6 @@ sub _java_class {
     return qw(picard sam BuildBamIndex);
 }
 
-sub _validate_params {
-    my $self = shift;
-    $self->enforce_minimum_version("1.23");
-}
-
 sub _shellcmd_extra_params {
     my $self = shift;
     return (

--- a/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/BuildBamIndex.pm
@@ -34,6 +34,8 @@ sub help_detail {
 EOS
 }
 
+sub minimum_version_required { '1.23'; }
+
 sub _jar_name {
     return 'BuildBamIndex.jar';
 }

--- a/lib/perl/Genome/Model/Tools/Picard/CollectMultipleMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectMultipleMetrics.pm
@@ -84,9 +84,4 @@ sub _cmdline_args {
     return @args;
 }
 
-sub _validate_params {
-    my $self = shift;
-    $self->enforce_minimum_version('1.40');
-}
-
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/CollectMultipleMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectMultipleMetrics.pm
@@ -61,6 +61,8 @@ sub help_detail {
 EOS
 }
 
+sub minimum_version_required { '1.40'; }
+
 sub _jar_name {
     return 'CollectMultipleMetrics.jar';
 }

--- a/lib/perl/Genome/Model/Tools/Picard/CollectWgsMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectWgsMetrics.pm
@@ -76,9 +76,4 @@ sub _java_class {
     return qw(picard analysis CollectWgsMetrics);
 }
 
-sub _validate_params {
-    my $self = shift;
-    $self->enforce_minimum_version('1.114');
-}
-
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/CollectWgsMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectWgsMetrics.pm
@@ -66,6 +66,8 @@ sub help_detail {
 EOS
 }
 
+sub minimum_version_required { '1.114'; }
+
 sub _jar_name {
     return 'CollectWgsMetrics.jar';
 }

--- a/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
@@ -35,6 +35,8 @@ sub help_detail {
 EOS
 }
 
+sub minimum_version_required { '1.17'; }
+
 sub _jar_name {
     return 'CompareSAMs.jar';
 }

--- a/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CompareSams.pm
@@ -48,11 +48,6 @@ sub _java_class {
         : qw(picard sam CompareSAMs); # 1.21 and later
 }
 
-sub _validate_params {
-    my $self = shift;
-    $self->enforce_minimum_version('1.17');
-}
-
 sub _redirects {
     my $self = shift;
     return sprintf('> %s', $self->output_file);

--- a/lib/perl/Genome/Model/Tools/Picard/GenotypeConcordance.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/GenotypeConcordance.pm
@@ -5,15 +5,6 @@ use warnings;
 
 use Genome;
 
-my %STATES_TO_IGNORE = (
-    'MISSING' => 1,
-    'NO_CALL' => 1,
-    'VC_FILTERED' => 1,
-    'LOW_DP' => 1,
-    'LOW_GQ' => 1,
-    'GT_FILTERED' => 1,
-);
-
 class Genome::Model::Tools::Picard::GenotypeConcordance {
     is  => 'Genome::Model::Tools::Picard::Base',
     has_input => [
@@ -140,15 +131,6 @@ sub parse_file_into_metrics_hashref {
         }
     }
     return \%data;
-}
-
-sub ignore_state {
-    my $class = shift;
-    my $state = shift;
-    if ( defined($STATES_TO_IGNORE{$state}) ) {
-        return $STATES_TO_IGNORE{$state};
-    }
-    return 0;
 }
 
 1;

--- a/lib/perl/Genome/Model/Tools/Picard/GenotypeConcordance.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/GenotypeConcordance.pm
@@ -92,6 +92,8 @@ Note that for any pair of variants to compare, only the alleles for the samples 
 EOS
 }
 
+sub minimum_version_required { return 1.122; }
+
 sub execute {
     my $self = shift;
 

--- a/lib/perl/Genome/Model/Tools/Picard/GenotypeConcordance.t
+++ b/lib/perl/Genome/Model/Tools/Picard/GenotypeConcordance.t
@@ -66,8 +66,8 @@ ok(-e $output_detailed_metrics, 'detailed metrics exist');
 my $filters = [
    qr(^# .*$),
 ];
-compare_ok($expected_detailed_metrics,$output_detailed_metrics, filters => $filters );
-compare_ok($expected_summary_metrics,$output_summary_metrics, filters => $filters );
+compare_ok($expected_detailed_metrics,$output_detailed_metrics, name => 'detailed metrics files mactch', filters => $filters );
+compare_ok($expected_summary_metrics,$output_summary_metrics, name => 'summary metrics files match', filters => $filters );
 
 # test the parsing of the metrics
 my $expected_summary_metrics_hashref = Genome::Model::Tools::Picard->parse_file_into_metrics_hashref($expected_summary_metrics);  


### PR DESCRIPTION
add minimumrequired versions to commands that need a min version
move enforcing min version to exectue from validate params
restrict available versions if minimum required version set
use GC vesions in ref-align command

did NOT try to set available versions as valid values for use_version