### PR TITLE
Don't disconnect if we're not going to wait on the lock.

### DIFF
--- a/lib/perl/Genome/Sys/Lock.pm
+++ b/lib/perl/Genome/Sys/Lock.pm
@@ -84,7 +84,7 @@ sub lock_resource {
         }
     };
 
-    Genome::Sys->disconnect_default_handles;
+    Genome::Sys->disconnect_default_handles if $args{max_try} > 1;
 
     for my $backend (backends($args{scope})) {
         my @lock_args = $backend->translate_lock_args(%args);


### PR DESCRIPTION
If we're not waiting this will return quickly and so we don't need to disconnect.