### PR TITLE
Add ability to skip exome CNV calling in ClinSeq.

### DIFF
--- a/lib/perl/Genome/Model/Build/ClinSeq.pm
+++ b/lib/perl/Genome/Model/Build/ClinSeq.pm
@@ -4,9 +4,10 @@ use warnings;
 
 use Genome;
 class Genome::Model::Build::ClinSeq {
-  is => ['Genome::Model::Build',
-    'Genome::Model::Build::ClinSeq::FileAccessors',
-    'Genome::Model::Build::ClinSeq::InputBuilds'],
+    is => ['Genome::Model::Build',
+           'Genome::Model::Build::ClinSeq::FileAccessors',
+           'Genome::Model::Build::ClinSeq::InputBuilds'
+          ],
 };
 
 sub special_compare_functions {
@@ -16,11 +17,11 @@ sub special_compare_functions {
 }
 
 sub diff_circos_conf {
-  my ($first_file, $second_file) = @_;
-  Carp::confess('Missing files to diff!') if @_ != 2;
-  my $first_md5  = qx(grep -vP '\\w+/\\w+/info/model_data/\\w+/build\\w+/\\w+/circos/data' $first_file | md5sum);
-  my $second_md5 = qx(grep -vP '\\w+/\\w+/info/model_data/\\w+/build\\w+/\\w+/circos/data' $second_file | md5sum);
-  return ($first_md5 eq $second_md5 ? 1 : 0);
+    my ($first_file, $second_file) = @_;
+    Carp::confess('Missing files to diff!') if @_ != 2;
+    my $first_md5  = qx(grep -vP '\\w+/\\w+/info/model_data/\\w+/build\\w+/\\w+/circos/data' $first_file | md5sum);
+    my $second_md5 = qx(grep -vP '\\w+/\\w+/info/model_data/\\w+/build\\w+/\\w+/circos/data' $second_file | md5sum);
+    return ($first_md5 eq $second_md5 ? 1 : 0);
 }
 
 1;

--- a/lib/perl/Genome/Model/Build/ClinSeq.pm
+++ b/lib/perl/Genome/Model/Build/ClinSeq.pm
@@ -24,4 +24,9 @@ sub diff_circos_conf {
     return ($first_md5 eq $second_md5 ? 1 : 0);
 }
 
+sub should_run_exome_cnv {
+    my $self = shift;
+    return ($self->exome_build and $self->processing_profile->exome_cnv);
+}
+
 1;

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -29,7 +29,10 @@ class Genome::Model::ClinSeq {
 
         #processing_profile      => { is => 'Genome::ProcessingProfile::ClinSeq', id_by => 'processing_profile_id', default_value => { } },
     ],
-    has_param => [ # Processing profile parameters
+    #Processing profile parameters
+    #If you add/modify params here make sure to add/modify params in
+    # Genome/Test/Factory/ProcessingProfile/ClinSeq.pm
+    has_param => [
         bam_readcount_version => { is => 'Text', doc => 'The bam readcount version to use during clonality analysis' },
         sireport_min_tumor_vaf => { is => 'Number', doc => 'Variants with a tumor VAF less than this (in any tumor sample) will be filtered out.'},
         sireport_max_normal_vaf => { is => 'Number', doc => 'Variants with a normal VAF greater than this (in any normal sample) will be filtered out.'},

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -399,7 +399,7 @@ sub map_workflow_inputs {
     }
 
     #ExomeCNV
-    if ($exome_build and $self->exome_cnv) {
+    if ($build->should_run_exome_cnv) {
       my $exome_cnv_dir = $patient_dir . "/cnv/exome_cnv/";
       push @dirs, $exome_cnv_dir;
       push @inputs, exome_cnv_dir => $exome_cnv_dir;
@@ -470,7 +470,7 @@ sub map_workflow_inputs {
                                                      "/snv_indel_report/" . "b" . $bq . "_" . "q" . $mq);
         push @dirs, $snv_indel_report_dir1;
         push @inputs, "snv_indel_report_dir" . $i => $snv_indel_report_dir1;
-        if($wgs_build or ($exome_build and $self->exome_cnv)) {
+        if($wgs_build or $build->should_run_exome_cnv) {
             my $sciclone_dir1 = File::Spec->join($patient_dir,
                                                  "/clonality/sciclone/" . "b" . $bq . "_" . "q" . $mq);
             push @dirs, $sciclone_dir1;
@@ -585,9 +585,9 @@ sub _resolve_workflow_for_build {
       }
       if($build->exome_build) {
         push @output_properties, 'exome_mutation_spectrum_result' . $i;
-        if($self->exome_cnv) {
-            push @output_properties, 'sciclone_result' . $i;
-        }
+      }
+      if($build->should_run_exome_cnv) {
+        push @output_properties, 'sciclone_result' . $i;
       }
       push @output_properties, 'converge_snv_indel_report_result' . $i;
     }
@@ -597,7 +597,7 @@ sub _resolve_workflow_for_build {
       push @output_properties, 'microarray_cnv_result';
   }
 
-  if ($build->exome_build and $self->exome_cnv) {
+  if ($build->should_run_exome_cnv) {
       push @output_properties, 'exome_cnv_result';
   }
 
@@ -971,7 +971,7 @@ sub _resolve_workflow_for_build {
 
   #RunExomeCNV - produce cnv plots using WEx results
   my $exome_cnv_op;
-  if ($build->exome_build and $self->exome_cnv) {
+  if ($build->should_run_exome_cnv) {
     my $msg = "Call somatic copy number changes using exome data";
     $exome_cnv_op = $add_step->($msg, "Genome::Model::Tools::CopyNumber::Cnmops");
     $add_link->($input_connector, 'exome_cnv_dir', $exome_cnv_op, 'outdir');
@@ -1286,7 +1286,7 @@ sub _resolve_workflow_for_build {
   }
 
   #GenerateSciClonePlots - Run clonality analysis and produce clonality plots
-  if ($build->wgs_build or ($build->exome_build and $self->exome_cnv)){
+  if ($build->wgs_build or $build->should_run_exome_cnv){
     my $iterator = List::MoreUtils::each_arrayref([1..@$mqs], $mqs, $bqs);
     while(my ($i, $mq, $bq) = $iterator->()) {
       my $msg = "Run clonality analysis and produce clonality plots using SciClone " . $i;
@@ -1299,7 +1299,7 @@ sub _resolve_workflow_for_build {
       if ($build->wgs_build) {
         $add_link->($run_cn_view_op, 'result', $sciclone_op, 'wgs_cnv_result');
       }
-      if ($build->exome_build and $self->exome_cnv) {
+      if ($build->should_run_exome_cnv) {
         $add_link->($exome_cnv_op, 'result', $sciclone_op, 'exome_cnv_result');
       }
       if ($self->has_microarray_build()) {
@@ -1598,4 +1598,3 @@ sub _get_docm_variants_file {
 }
 
 1;
-

--- a/lib/perl/Genome/Model/ClinSeq.t
+++ b/lib/perl/Genome/Model/ClinSeq.t
@@ -51,6 +51,7 @@ my $p = Genome::ProcessingProfile::ClinSeq->create(
     sireport_max_normal_vaf => 10,
     sireport_min_coverage => 20,
     sireport_min_mq_bq => "30,40;30,20",
+    exome_cnv => 1,
 );
 ok($p, "created a processing profile") or diag(Genome::ProcessingProfile::ClinSeq->error_message);
 

--- a/lib/perl/Genome/Test/Factory/ProcessingProfile/ClinSeq.pm
+++ b/lib/perl/Genome/Test/Factory/ProcessingProfile/ClinSeq.pm
@@ -7,30 +7,42 @@ use strict;
 use warnings;
 
 our @required_params = qw(bam_readcount_version
+    exome_cnv
     sireport_min_coverage
     sireport_min_tumor_vaf
     sireport_max_normal_vaf
     sireport_min_mq_bq
 );
 
+#Version of bam-readcount version to use
 sub create_bam_readcount_version {
     return Genome::Model::Tools::Sam::Readcount->default_version;
 }
 
+#Run exome-cnv step or not?
+sub create_exome_cnv {
+    return 1;
+}
+
+#Minimum coverage parameter for SNV-Indel report
 sub create_sireport_min_coverage {
     return 20;
 }
 
+#Minimum tumor VAF for SNV-Indel report
 sub create_sireport_min_tumor_vaf {
     return 2.5;
 }
 
+#Mamximum normal VAF for SNV-Indel report
 sub create_sireport_max_normal_vaf {
     return 10;
 }
 
+#Minimum base and mapping qualities for SNV Indel report
 sub create_sireport_min_mq_bq {
     return "30,40;10,20";
 }
+
 
 1;

--- a/lib/perl/Genome/Test/Factory/ProcessingProfile/ClinSeq.pm
+++ b/lib/perl/Genome/Test/Factory/ProcessingProfile/ClinSeq.pm
@@ -44,5 +44,4 @@ sub create_sireport_min_mq_bq {
     return "30,40;10,20";
 }
 
-
 1;


### PR DESCRIPTION
Sometimes it doesn't make a lot of sense to do copy-number calling for e.g when the data is from targeted capture of a handful of genes etc and we'd like to turn off this step. This pull-request uses a parameter in the clin-seq processing profile to handle this.