### PR TITLE
Fix typo in method call in PP help generation

### DIFF
--- a/lib/perl/Genome/ProcessingProfile/Command/Create/Base.pm
+++ b/lib/perl/Genome/ProcessingProfile/Command/Create/Base.pm
@@ -52,7 +52,7 @@ sub _get_help {
         return $help;
     }
     elsif ($self->_target_class_name->can($help_fn_name)) {
-        my $help = $self->target_class_name->$help_fn_name();
+        my $help = $self->_target_class_name->$help_fn_name();
         return $help;
     }
     return;


### PR DESCRIPTION
I'm not sure this condition is ever met in production, anyway.