### PR TITLE
Don't auto-retry MEMLIMIT errors and orphaned allocations.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DetermineError.pm
+++ b/lib/perl/Genome/Model/Build/Command/DetermineError.pm
@@ -444,7 +444,7 @@ sub get_failed_key {
     if ($self->error_text =~ m/gscarchive/) {
         return "Failed: Archived Data";
     }
-    if ($self->error_source_line ne 'Unknown') {
+    if ($self->error_source_line ne 'Unknown' and $self->error_source_line ne 'n/a') {
         (my $delocalized_file = $self->error_source_file) =~ s/^.*\/lib\/perl\///;
         return sprintf("Failed: %s %s", $delocalized_file, $self->error_source_line);
     } else {

--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -226,8 +226,7 @@ sub should_review_model {
     # If it has failed >X times in a row then submit for review.
     return 1 if $self->model_has_failed_too_many_times($model);
 
-    # If it hasn't made progress since last time then submit for review.
-    return 1 unless $self->model_has_progressed($model);
+    return 1 if $self->latest_failure_requires_review($model);
 
     return;
 }
@@ -246,25 +245,41 @@ sub model_has_failed_too_many_times {
 }
 
 
-sub model_has_progressed {
+sub latest_failure_requires_review {
     my $self = shift;
     my $model = shift;
 
     my $failure_set = $self->failure_build_set($model);
+    my $count = $failure_set->count;
 
-    #a first build has always made progress
-    return 1 unless ($failure_set->count > 1);
+    return unless $count > 0; #nothing to review
 
     my $it = $failure_set->member_iterator(-order_by => ['-created_at']);
     my $latest_build = $it->next;
     my $latest_error = determine_error_for_build($latest_build);
-    return unless $latest_error;
+    return 1 unless $latest_error;
+
+    return 1 if $self->_error_requires_review($latest_error);
+
+    #if this error doesn't require review, retry first failures
+    return unless $count > 1;
 
     my $previous_build = $it->next;
     my $previous_error = determine_error_for_build($previous_build);
-    return unless $previous_error;
+    return 1 unless $previous_error;
 
-    return $latest_error ne $previous_error;
+    #review if consistently failing
+    return $latest_error eq $previous_error;
+}
+
+sub _error_requires_review {
+    my $self = shift;
+    my $latest_error = shift;
+
+    return 1 if ($latest_error =~ /TERM_MEMLIMIT/);
+    return 1 if ($latest_error =~ /the allocation has been orphaned/);
+
+    return;
 }
 
 sub failure_build_set {


### PR DESCRIPTION
Without manual intervention these builds will eventually fail again, possibly after wasting hours or days of CPU.