### PR TITLE
Alignment Dispatcher uses WorkflowBuilder

### DIFF
--- a/lib/perl/Genome/InstrumentData/Composite/Decorator.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Decorator.pm
@@ -13,10 +13,11 @@ class Genome::InstrumentData::Composite::Decorator {
 sub decorate {
     my $class = shift;
     my $operation = shift;
+    my $workflow = shift;
     my $decoration = shift;
 
     my $decorator = $class->_resolve_decorator($decoration);
-    return $decorator->decorate($operation, $decoration->{params});
+    return $decorator->decorate($operation, $workflow, $decoration->{params});
 }
 
 sub _resolve_decorator {

--- a/lib/perl/Genome/InstrumentData/Composite/Decorator.t
+++ b/lib/perl/Genome/InstrumentData/Composite/Decorator.t
@@ -22,7 +22,7 @@ my $called_params;
         is => 'Genome::InstrumentData::Composite::Decorator::Base',
     };
     sub decorate {
-        my($class, $operation, $params) = @_;
+        my($class, $operation, $workflow, $params) = @_;
         $call_count++;
         $called_params = $params;
     }
@@ -34,9 +34,11 @@ my $decoration = {
     params => $test_params,
 };
 
-my $operation = Workflow::Operation->__define__(name => 'test operation for decorators');
+my $dag = Genome::WorkflowBuilder::DAG->create(name => 'test workflow');
+my $operation = Genome::WorkflowBuilder::Command->create(name => 'test operation for decorators', command => 'Genome::Model::Tools::Example1');
+$dag->add_operation($operation);
 
-Genome::InstrumentData::Composite::Decorator->decorate($operation, $decoration);
+Genome::InstrumentData::Composite::Decorator->decorate($operation, $dag, $decoration);
 
 is($call_count, 1, 'decorator got called');
 is($called_params, $test_params, 'decorator was passed params');

--- a/lib/perl/Genome/InstrumentData/Composite/Decorator/AlignAndMergeQc.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Decorator/AlignAndMergeQc.pm
@@ -24,12 +24,11 @@ sub add_alignment_link {
     my $operation = shift;
     my $qc_runner_op = shift;
 
-    Genome::InstrumentData::Composite::Workflow::Generator::Base->_add_link_to_workflow(
-        $workflow,
-        left_workflow_operation_id => $operation->id,
-        left_property => 'per_lane_alignment_results',
-        right_workflow_operation_id => $qc_runner_op->id,
-        right_property => 'alignment_result',
+    $workflow->create_link(
+        source => $operation,
+        source_property => 'per_lane_alignment_results',
+        destination => $qc_runner_op,
+        destination_property => 'alignment_result',
     );
 }
 

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow.pm
@@ -57,11 +57,7 @@ sub execute {
         $workflow->log_dir($self->log_directory);
     }
 
-    my @errors = $workflow->validate;
-    if (@errors) {
-        $self->error_message($_) for @errors;
-        die 'Errors validating workflow';
-    }
+    $workflow->validate;
 
     my @results = $self->_run_workflow($workflow, $inputs);
     $self->_result_ids(\@results);
@@ -110,9 +106,8 @@ sub _run_workflow {
     Genome::Sys->disconnect_default_handles;
 
     $self->debug_message('Running workflow...');
-    my $dag = Genome::WorkflowBuilder::DAG->from_xml($workflow->save_to_xml());
     my %inputs_hash = (@$inputs); # For some reason $inputs is an array-ref
-    my $outputs = $dag->execute(inputs => \%inputs_hash);
+    my $outputs = $workflow->execute(inputs => \%inputs_hash);
 
     my @result_ids;
     for my $key (keys %$outputs) {

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator.pm
@@ -226,7 +226,7 @@ sub _wire_object_workflows_to_merge_operations {
     for my $o (@$alignment_objects) {
         my $align_wf = $object_workflows->{$o};
 
-        push @converge_inputs, @{ $align_wf->output_properties };
+        push @converge_inputs, $align_wf->output_properties;
     }
 
     my $converge_operation = Genome::WorkflowBuilder::Converge->create(
@@ -245,7 +245,7 @@ sub _wire_object_workflows_to_merge_operations {
     for my $o (@$alignment_objects) {
         my $align_wf = $object_workflows->{$o};
 
-        for my $property (@{ $align_wf->output_properties }) {
+        for my $property ($align_wf->output_properties) {
             $master_workflow->create_link(
                 source => $align_wf,
                 source_property => $property,

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator.pm
@@ -204,7 +204,7 @@ sub _wire_merge_to_refinement_operation {
     my $merge_operation = shift;
     my $refinement_operation = shift;
 
-    $class->_add_link_to_workflow($master_workflow,
+    $master_workflow->create_link(
         source => $merge_operation,
         source_property => 'result_id',
         destination => $refinement_operation,
@@ -235,7 +235,7 @@ sub _wire_object_workflows_to_merge_operations {
         output_properties => ['alignment_result_ids'],
     );
     $master_workflow->add_operation($converge_operation);
-    $class->_add_link_to_workflow($master_workflow,
+    $master_workflow->create_link(
         source => $converge_operation,
         source_property => 'alignment_result_ids',
         destination => $merge_operation,
@@ -246,7 +246,7 @@ sub _wire_object_workflows_to_merge_operations {
         my $align_wf = $object_workflows->{$o};
 
         for my $property (@{ $align_wf->output_properties }) {
-            $class->_add_link_to_workflow($master_workflow,
+            $master_workflow->create_link(
                 source => $align_wf,
                 source_property => $property,
                 destination => $converge_operation,

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Align.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Align.pm
@@ -47,17 +47,6 @@ sub _generate_workflow_for_instrument_data {
         push @operations, $class->_create_operations_for_alignment_tree($subtree, $instrument_data, %options);
     }
 
-    my @input_properties = (
-        $class->_general_workflow_input_properties(),
-        $class->_instrument_data_workflow_input_properties($instrument_data, %options),
-        (map { $class->_input_properties_for_operation($_) } @operations)
-    );
-
-    my @output_properties;
-    for my $leaf (@{ $tree->{action} }) {
-        push @output_properties, join('_', 'result_id', $leaf->{$class->_operation_key($instrument_data, %options)}->name);
-    }
-
     #Next create the model, and add all the operations to it
     my $workflow_name = 'Alignment Dispatcher for ' . $instrument_data->id;
     if(exists $options{instrument_data_segment_id}) {
@@ -96,25 +85,6 @@ sub _create_operations_for_alignment_tree {
     }
 
     return @operations;
-}
-
-sub _input_properties_for_operation {
-    my $class = shift;
-    my $operation = shift;
-
-    my @input_properties = ();
-    my $op_name = $operation->name;
-    my $op_type = $operation->operation_type;
-
-    for my $prop ('reference_build_id', 'annotation_build_id') {
-        if(grep $_ eq $prop, @{ $op_type->input_properties }) {
-            push @input_properties, join('_', $prop, $op_name);
-        }
-    }
-
-    push @input_properties, join('_', 'name', $op_name), join('_', 'params', $op_name), join('_', 'version', $op_name);
-
-    return @input_properties;
 }
 
 sub _generate_alignment_workflow_links {

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Align.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Align.pm
@@ -64,7 +64,7 @@ sub _generate_workflow_for_instrument_data {
     #Last wire up the workflow
     my $inputs_for_links = $class->_generate_alignment_workflow_links($workflow, $tree, $input_data, $instrument_data, %options);
 
-    push @$inputs_for_links, map { $class->_process_decorations($_, $instrument_data, %options) } @{ $tree->{action} } ;
+    push @$inputs_for_links, map { $class->_process_decorations($_, $workflow, $instrument_data, %options) } @{ $tree->{action} } ;
 
     return $workflow, $inputs_for_links;
 }
@@ -298,6 +298,7 @@ sub get_unique_action_name {
 sub _process_decorations {
     my $class = shift;
     my $action = shift;
+    my $workflow = shift;
     my $instrument_data = shift;
     my %options = @_;
 
@@ -305,7 +306,7 @@ sub _process_decorations {
 
     if (exists $action->{decoration}) {
         my $operation_key = $class->_operation_key($instrument_data, %options);
-        push @additional_inputs, Genome::InstrumentData::Composite::Decorator->decorate($action->{$operation_key}, $action->{decoration});
+        push @additional_inputs, Genome::InstrumentData::Composite::Decorator->decorate($action->{$operation_key}, $workflow, $action->{decoration});
     }
 
     if (exists $action->{parent}) {

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Align.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Align.pm
@@ -105,7 +105,6 @@ sub _generate_alignment_workflow_links {
         $class->_add_link_to_workflow($workflow,
             source => $op,
             source_property => 'result_id',
-            destination => $workflow,
             destination_property => join('_', 'result_id', $op->name),
         );
     }
@@ -138,7 +137,6 @@ sub _create_links_for_subtree {
     for my $property (@properties) {
         my $source_property = join('_', $property, $operation->name);
         $class->_add_link_to_workflow($workflow,
-            source => $workflow,
             source_property => $source_property,
             destination => $operation,
             destination_property => $property,
@@ -169,7 +167,6 @@ sub _create_links_for_subtree {
 
     for my $property ($class->_general_workflow_input_properties) {
         $class->_add_link_to_workflow($workflow,
-            source => $workflow,
             source_property => $property,
             destination => $operation,
             destination_property => $property,
@@ -191,7 +188,6 @@ sub _create_links_for_subtree {
         for my $property ($class->_instrument_data_workflow_input_properties($instrument_data, %options)) {
             my ($simple_property_name) = $property =~ m/^(.+?)__/;
             $class->_add_link_to_workflow($workflow,
-                source => $workflow,
                 source_property => $property,
                 destination => $operation,
                 destination_property => $simple_property_name,
@@ -336,7 +332,6 @@ sub _wire_object_workflow_to_master_workflow {
             );
         } else {
             $class->_add_link_to_workflow($master_workflow,
-                source => $master_workflow,
                 source_property => 'm_' . $property,
                 destination => $workflow,
                 destination_property => $property,
@@ -348,7 +343,6 @@ sub _wire_object_workflow_to_master_workflow {
         $class->_add_link_to_workflow($master_workflow,
             source => $workflow,
             source_property => $property,
-            destination => $master_workflow,
             destination_property => 'm_' . $property,
         );
     }

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -104,7 +104,6 @@ sub _wire_object_workflow_to_master_workflow {
             );
         }else {
             $class->_add_link_to_workflow($master_workflow,
-                source => $master_workflow,
                 source_property => 'm_' . $property,
                 destination => $workflow,
                 destination_property => $property,
@@ -116,7 +115,6 @@ sub _wire_object_workflow_to_master_workflow {
         $class->_add_link_to_workflow($master_workflow,
             source => $workflow,
             source_property => $property,
-            destination => $master_workflow,
             destination_property => 'm_' . $property,
         );
     }

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -47,33 +47,29 @@ sub generate {
     #Connect input connectors to the operation
     my $inputs = [];
     for my $input_property (@$input_properties) {
-        $class->_add_link_to_workflow(
-            $workflow,
-            source => $workflow,
-            source_property => $input_property,
+        $workflow->connect_input(
+            input_property => $input_property,
             destination => $operation,
             destination_property => $input_property,
+            is_optional => 1,
         );
         push @$inputs, ( 'm_' . $input_property => $input_data->{$input_property} );
     }
     for my $input_property (@$tree_properties) {
-        $class->_add_link_to_workflow(
-            $workflow,
-            source => $workflow,
-            source_property => $input_property,
+        $workflow->connect_input(
+            input_property => $input_property,
             destination => $operation,
             destination_property => $input_property,
+            is_optional => 1,
         );
         push @$inputs, ( 'm_' . $input_property => $tree->{'action'}->[0]->{$input_property} );
     }
 
     #Connect output connectors to the operation
-    $class->_add_link_to_workflow(
-        $workflow,
+    $workflow->connect_output(
         source => $operation,
         source_property => 'result_id',
-        destination => $workflow,
-        destination_property => 'result_id',
+        output_property => 'result_id',
     );
 
     if (exists $tree->{'action'}->[0]->{decoration}) {
@@ -96,26 +92,27 @@ sub _wire_object_workflow_to_master_workflow {
     #wire up the master to the inner workflows (just pass along the inputs and outputs)
     for my $property ($workflow->input_properties) {
         if($property eq 'force_fragment'){
-            $class->_add_link_to_workflow($master_workflow,
+            $master_workflow->create_link(
                 source => $block_operation,
                 source_property => $property,
                 destination => $workflow,
                 destination_property => $property,
             );
         }else {
-            $class->_add_link_to_workflow($master_workflow,
-                source_property => 'm_' . $property,
+            $master_workflow->connect_input(
+                input_property => 'm_' . $property,
                 destination => $workflow,
                 destination_property => $property,
+                is_optional => 1,
             );
         }
     }
 
     for my $property ($workflow->output_properties) {
-        $class->_add_link_to_workflow($master_workflow,
+            $master_workflow->connect_output(
             source => $workflow,
             source_property => $property,
-            destination_property => 'm_' . $property,
+            output_property => 'm_' . $property,
         );
     }
 

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -10,6 +10,8 @@ class Genome::InstrumentData::Composite::Workflow::Generator::AlignAndMerge {
 
 sub generate {
     my $class = shift;
+    my $master_workflow = shift;
+    my $block_operation = shift;
     my $tree = shift;
     my $input_data = shift;
     my $alignment_objects = shift;
@@ -78,7 +80,48 @@ sub generate {
         push @$inputs, Genome::InstrumentData::Composite::Decorator->decorate($operation, $tree->{'action'}->[0]->{decoration});
     }
 
+    $class->_wire_object_workflow_to_master_workflow($master_workflow, $block_operation, $workflow);
+
     return $workflows, $inputs;
+}
+
+sub _wire_object_workflow_to_master_workflow {
+    my $class = shift;
+    my $master_workflow = shift;
+    my $block_operation = shift;
+    my $workflow = shift;
+
+    $master_workflow->add_operation($workflow);
+
+    #wire up the master to the inner workflows (just pass along the inputs and outputs)
+    for my $property ($workflow->input_properties) {
+        if($property eq 'force_fragment'){
+            $class->_add_link_to_workflow($master_workflow,
+                source => $block_operation,
+                source_property => $property,
+                destination => $workflow,
+                destination_property => $property,
+            );
+        }else {
+            $class->_add_link_to_workflow($master_workflow,
+                source => $master_workflow,
+                source_property => 'm_' . $property,
+                destination => $workflow,
+                destination_property => $property,
+            );
+        }
+    }
+
+    for my $property ($workflow->output_properties) {
+        $class->_add_link_to_workflow($master_workflow,
+            source => $workflow,
+            source_property => $property,
+            destination => $master_workflow,
+            destination_property => 'm_' . $property,
+        );
+    }
+
+    return 1;
 }
 
 1;

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -49,29 +49,32 @@ sub generate {
     #Connect input connectors to the operation
     my $inputs = [];
     for my $input_property (@$input_properties) {
-        $workflow->add_link(
-            left_operation => $workflow->get_input_connector,
+        $class->_add_link_to_workflow(
+            $workflow,
+            left_workflow_operation_id => $workflow->get_input_connector->id,
             left_property => $input_property,
-            right_operation => $operation,
+            right_workflow_operation_id => $operation->id,
             right_property => $input_property,
         );
         push @$inputs, ( 'm_' . $input_property => $input_data->{$input_property} );
     }
     for my $input_property (@$tree_properties) {
-        $workflow->add_link(
-            left_operation => $workflow->get_input_connector,
+        $class->_add_link_to_workflow(
+            $workflow,
+            left_workflow_operation_id => $workflow->get_input_connector->id,
             left_property => $input_property,
-            right_operation => $operation,
+            right_workflow_operation_id => $operation->id,
             right_property => $input_property,
         );
         push @$inputs, ( 'm_' . $input_property => $tree->{'action'}->[0]->{$input_property} );
     }
 
     #Connect output connectors to the operation
-    $workflow->add_link(
-        left_operation => $operation,
+    $class->_add_link_to_workflow(
+        $workflow,
+        left_workflow_operation_id => $operation->id,
         left_property => 'result_id',
-        right_operation => $workflow->get_output_connector,
+        right_workflow_operation_id => $workflow->get_output_connector->id,
         right_property => 'result_id',
     );
 

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -73,7 +73,7 @@ sub generate {
     );
 
     if (exists $tree->{'action'}->[0]->{decoration}) {
-        push @$inputs, Genome::InstrumentData::Composite::Decorator->decorate($operation, $tree->{'action'}->[0]->{decoration});
+        push @$inputs, Genome::InstrumentData::Composite::Decorator->decorate($operation, $workflow, $tree->{'action'}->[0]->{decoration});
     }
 
     $class->_wire_object_workflow_to_master_workflow($master_workflow, $block_operation, $workflow);

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -19,11 +19,8 @@ sub generate {
     #Make a workflow with its input and output connectors
     my $input_properties = ['instrument_data', 'reference_sequence_build', $class->_general_workflow_input_properties];
     my $tree_properties = ['name', 'params', 'version'];
-    my $workflow = Workflow::Model->create(
+    my $workflow = Genome::WorkflowBuilder::DAG->create(
         name => $aligner_name,
-        input_properties => [@$input_properties, @$tree_properties],
-        optional_input_properties => $input_properties,
-        output_properties => ['result_id'],
     );
     my $workflows = {};
     map { $workflows->{$_} = $workflow } @$alignment_objects;
@@ -31,12 +28,11 @@ sub generate {
     my $command_class = 'Genome::InstrumentData::Command::AlignAndMerge';
 
     #Make a align_and_merge operation
-    my $operation = $workflow->add_operation(
+    my $operation = Genome::WorkflowBuilder::Command->create(
         name => "$aligner_name operation",
-        operation_type => Workflow::OperationType::Command->create(
-            command_class_name => $command_class,
-        ),
+        command => $command_class,
     );
+    $workflow->add_operation($operation);
 
     my $instrument_data = $input_data->{instrument_data};
     my $lsf_resource_string = $command_class->lsf_resource_string_for_aligner_and_instrument_data(
@@ -44,27 +40,27 @@ sub generate {
         @$instrument_data
     );
 
-    $operation->operation_type->lsf_resource($lsf_resource_string);
+    $operation->lsf_resource($lsf_resource_string);
 
     #Connect input connectors to the operation
     my $inputs = [];
     for my $input_property (@$input_properties) {
         $class->_add_link_to_workflow(
             $workflow,
-            left_workflow_operation_id => $workflow->get_input_connector->id,
-            left_property => $input_property,
-            right_workflow_operation_id => $operation->id,
-            right_property => $input_property,
+            source => $workflow,
+            source_property => $input_property,
+            destination => $operation,
+            destination_property => $input_property,
         );
         push @$inputs, ( 'm_' . $input_property => $input_data->{$input_property} );
     }
     for my $input_property (@$tree_properties) {
         $class->_add_link_to_workflow(
             $workflow,
-            left_workflow_operation_id => $workflow->get_input_connector->id,
-            left_property => $input_property,
-            right_workflow_operation_id => $operation->id,
-            right_property => $input_property,
+            source => $workflow,
+            source_property => $input_property,
+            destination => $operation,
+            destination_property => $input_property,
         );
         push @$inputs, ( 'm_' . $input_property => $tree->{'action'}->[0]->{$input_property} );
     }
@@ -72,10 +68,10 @@ sub generate {
     #Connect output connectors to the operation
     $class->_add_link_to_workflow(
         $workflow,
-        left_workflow_operation_id => $operation->id,
-        left_property => 'result_id',
-        right_workflow_operation_id => $workflow->get_output_connector->id,
-        right_property => 'result_id',
+        source => $operation,
+        source_property => 'result_id',
+        destination => $workflow,
+        destination_property => 'result_id',
     );
 
     if (exists $tree->{'action'}->[0]->{decoration}) {

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignerIndex.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignerIndex.pm
@@ -97,8 +97,8 @@ sub _wire_operations_to_master_workflow {
         properties => [@block_operation_inputs,'force_fragment'],
     );
     $master_workflow->add_operation($block_operation);
-    $class->_add_link_to_workflow($master_workflow,
-        source_property => "m_force_fragment",
+    $master_workflow->connect_input(
+        input_property => "m_force_fragment",
         destination => $block_operation,
         destination_property => "force_fragment",
     );
@@ -119,13 +119,13 @@ sub _wire_index_operation_to_master_workflow {
     $master_workflow->add_operation($operation->{operation});
 
     #result users are the same for all steps in workflow
-    $class->_add_link_to_workflow($master_workflow,
-        source_property => 'm_result_users',
+    $master_workflow->connect_input(
+        input_property => 'm_result_users',
         destination => $operation->{operation},
         destination_property => 'result_users',
     );
 
-    $class->_add_link_to_workflow($master_workflow,
+    $master_workflow->create_link(
         source => $operation->{operation},
         source_property => "result",
         destination => $block_operation,

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignerIndex.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignerIndex.pm
@@ -98,7 +98,6 @@ sub _wire_operations_to_master_workflow {
     );
     $master_workflow->add_operation($block_operation);
     $class->_add_link_to_workflow($master_workflow,
-        source => $master_workflow,
         source_property => "m_force_fragment",
         destination => $block_operation,
         destination_property => "force_fragment",
@@ -121,7 +120,6 @@ sub _wire_index_operation_to_master_workflow {
 
     #result users are the same for all steps in workflow
     $class->_add_link_to_workflow($master_workflow,
-        source => $master_workflow,
         source_property => 'm_result_users',
         destination => $operation->{operation},
         destination_property => 'result_users',

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignerIndex.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignerIndex.pm
@@ -54,7 +54,7 @@ sub generate {
 
     my $block_operation = $class->_wire_operations_to_master_workflow($master_workflow, $workflow_operations);
 
-    return ($workflow_operations, $block_operation);
+    return $block_operation;
 }
 
 sub _generate_step {

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignerIndex.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignerIndex.pm
@@ -67,16 +67,14 @@ sub _generate_step {
     my ($aligner, $version, $reference, $annotation, $params, $inputs) = @_;
 
     my $index_num = $class->next_counter_value;
-    my $operation = Workflow::Operation->create(
+    my $operation = Genome::WorkflowBuilder::Command->create(
         name => "$aligner index #" . $index_num,
-        operation_type => Workflow::OperationType::Command->create(
-            command_class_name => 'Genome::Model::ReferenceSequence::Command::CreateAlignerIndex',
-        ),
+        command => 'Genome::Model::ReferenceSequence::Command::CreateAlignerIndex',
     );
 
     #overwrite lsf_resource for star aligner
     if ($aligner eq 'star') {
-        $operation->operation_type->lsf_resource("-R \'select[ncpus>=12 && mem>=48000] span[hosts=1] rusage[mem=48000]\' -M 48000000 -n 12");
+        $operation->lsf_resource("-R \'select[ncpus>=12 && mem>=48000] span[hosts=1] rusage[mem=48000]\' -M 48000000 -n 12");
     }
 
     return {

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Base.pm
@@ -60,13 +60,4 @@ sub _general_workflow_input_properties {
     );
 }
 
-my $REFINEMENT_INPUT_PROPERTY_SEPARATOR = ':';
-sub _construct_refiner_input_property {
-    my $class = shift;
-    my $property = shift;
-    my $refiner = shift;
-
-    return join($REFINEMENT_INPUT_PROPERTY_SEPARATOR, $property, $refiner);
-}
-
 1;

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Base.pm
@@ -10,13 +10,6 @@ class Genome::InstrumentData::Composite::Workflow::Generator::Base {
     is_abstract => 1,
 };
 
-
-sub _add_link_to_workflow {
-    my($class, $workflow_obj, %params) = @_;
-
-    return $workflow_obj->add_link(Genome::WorkflowBuilder::Link->create(%params));
-}
-
 my $counter = 0;
 sub next_counter_value {
     return ++$counter;

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Base.pm
@@ -11,33 +11,10 @@ class Genome::InstrumentData::Composite::Workflow::Generator::Base {
 };
 
 
-my @_properties_for_add_link = ('id','destination','destination_property','source','source_property');
-my @_properties_in_template_order;
-my $_add_link_to_workflow_tmpl;
-my $_add_link_workflow_id_pos;
-my $_add_link_id_pos;
 sub _add_link_to_workflow {
     my($class, $workflow_obj, %params) = @_;
 
-    unless ($_add_link_to_workflow_tmpl) {
-        my $tmpl = UR::BoolExpr::Template->resolve('Genome::WorkflowBuilder::Link', @_properties_for_add_link);
-        unless ($tmpl) {
-            Carp::croak('Cannot resolve BoolExpr template for adding Workflow::Link objects');
-        }
-        $tmpl = $tmpl->get_normalized_template_equivalent();
-        for my $name ( @_properties_for_add_link ) {
-            my $pos = $tmpl->value_position_for_property_name($name);
-            if ($name eq 'id') {
-                $_add_link_id_pos = $pos;
-            }
-            $_properties_in_template_order[$pos] = $name;
-        }
-        $_add_link_to_workflow_tmpl = $tmpl;
-    }
-    my @values = @params{@_properties_in_template_order};
-    $values[$_add_link_id_pos] = UR::Object::Type->autogenerate_new_object_id_urinternal();
-    my $rule = $_add_link_to_workflow_tmpl->get_rule_for_values(@values);
-    return $workflow_obj->add_link(UR::Context->create_entity('Genome::WorkflowBuilder::Link', $rule));
+    return $workflow_obj->add_link(Genome::WorkflowBuilder::Link->create(%params));
 }
 
 my $counter = 0;

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Base.pm
@@ -11,8 +11,7 @@ class Genome::InstrumentData::Composite::Workflow::Generator::Base {
 };
 
 
-my @_properties_for_add_link = ('id','workflow_model_id','left_workflow_operation_id','left_property',
-                                'right_workflow_operation_id','right_property');
+my @_properties_for_add_link = ('id','destination','destination_property','source','source_property');
 my @_properties_in_template_order;
 my $_add_link_to_workflow_tmpl;
 my $_add_link_workflow_id_pos;
@@ -21,16 +20,14 @@ sub _add_link_to_workflow {
     my($class, $workflow_obj, %params) = @_;
 
     unless ($_add_link_to_workflow_tmpl) {
-        my $tmpl = UR::BoolExpr::Template->resolve('Workflow::Link', @_properties_for_add_link);
+        my $tmpl = UR::BoolExpr::Template->resolve('Genome::WorkflowBuilder::Link', @_properties_for_add_link);
         unless ($tmpl) {
             Carp::croak('Cannot resolve BoolExpr template for adding Workflow::Link objects');
         }
         $tmpl = $tmpl->get_normalized_template_equivalent();
         for my $name ( @_properties_for_add_link ) {
             my $pos = $tmpl->value_position_for_property_name($name);
-            if ($name eq 'workflow_model_id' ) {
-                $_add_link_workflow_id_pos = $pos;
-            } elsif ($name eq 'id') {
+            if ($name eq 'id') {
                 $_add_link_id_pos = $pos;
             }
             $_properties_in_template_order[$pos] = $name;
@@ -38,10 +35,9 @@ sub _add_link_to_workflow {
         $_add_link_to_workflow_tmpl = $tmpl;
     }
     my @values = @params{@_properties_in_template_order};
-    $values[$_add_link_workflow_id_pos] = $workflow_obj->id;
     $values[$_add_link_id_pos] = UR::Object::Type->autogenerate_new_object_id_urinternal();
     my $rule = $_add_link_to_workflow_tmpl->get_rule_for_values(@values);
-    return UR::Context->create_entity('Workflow::Link', $rule);
+    return $workflow_obj->add_link(UR::Context->create_entity('Genome::WorkflowBuilder::Link', $rule));
 }
 
 my $counter = 0;

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Merge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Merge.pm
@@ -45,7 +45,6 @@ sub generate {
     return ($merge_operation, \@inputs);
 }
 
-my $_mergealignments_command_id;
 my $_generate_merge_operation_tmpl;
 sub _generate_merge_operation {
     my $class = shift;
@@ -53,19 +52,15 @@ sub _generate_merge_operation {
     my $grouping = shift;
 
     unless ($_generate_merge_operation_tmpl) {
-        $_generate_merge_operation_tmpl = UR::BoolExpr::Template->resolve('Workflow::Operation', 'id','name','workflow_operationtype_id')->get_normalized_template_equivalent();
-        $_mergealignments_command_id = Workflow::OperationType::Command->get('Genome::InstrumentData::Command::MergeAlignments')->id;
+        $_generate_merge_operation_tmpl = UR::BoolExpr::Template->resolve('Genome::WorkflowBuilder::Command', 'id','name','command')->get_normalized_template_equivalent();
     }
 
-    my $operation = Workflow::Operation->create(
+    my $operation = Genome::WorkflowBuilder::Command->create(
         $_generate_merge_operation_tmpl->get_rule_for_values(
+                'Genome::InstrumentData::Command::MergeAlignments',
                 UR::Object::Type->autogenerate_new_object_id_urinternal(),
                 'merge_' . $grouping,
-                $_mergealignments_command_id
         )
-
-        #name => 'merge_' . $grouping,
-        #operation_type => $_mergealignments_command_id
     );
 
     return $operation;

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Merge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Merge.pm
@@ -76,7 +76,6 @@ sub _wire_merge_operation_to_master_workflow {
     $master_workflow->add_operation($merge);
     for my $property ($class->_merge_workflow_input_properties) {
         $class->_add_link_to_workflow($master_workflow,
-            source => $master_workflow,
             source_property => 'm_' . $property,
             destination => $merge,
             destination_property => $property,
@@ -87,7 +86,6 @@ sub _wire_merge_operation_to_master_workflow {
         $class->_add_link_to_workflow($master_workflow,
             source => $merge,
             source_property => $property,
-            destination => $master_workflow,
             destination_property => 'm_' . join('_', $property, $merge->name),
         );
     }

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Merge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Merge.pm
@@ -75,18 +75,18 @@ sub _wire_merge_operation_to_master_workflow {
 
     $master_workflow->add_operation($merge);
     for my $property ($class->_merge_workflow_input_properties) {
-        $class->_add_link_to_workflow($master_workflow,
-            source_property => 'm_' . $property,
+        $master_workflow->connect_input(
+            input_property => 'm_' . $property,
             destination => $merge,
             destination_property => $property,
         );
     }
 
     for my $property ($merge->output_properties) {
-        $class->_add_link_to_workflow($master_workflow,
+        $master_workflow->connect_output(
             source => $merge,
             source_property => $property,
-            destination_property => 'm_' . join('_', $property, $merge->name),
+            output_property => 'm_' . join('_', $property, $merge->name),
         );
     }
 

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Merge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Merge.pm
@@ -82,14 +82,6 @@ sub _wire_merge_operation_to_master_workflow {
         );
     }
 
-    for my $property ($merge->output_properties) {
-        $master_workflow->connect_output(
-            source => $merge,
-            source_property => $property,
-            output_property => 'm_' . join('_', $property, $merge->name),
-        );
-    }
-
     return 1;
 }
 

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Refine.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Refine.pm
@@ -94,15 +94,15 @@ sub _wire_refinement_operation_to_master_workflow {
         for my $property ($class->_base_refinement_workflow_input_properties) {
             my $source_property = "m_" . $class->_construct_refiner_input_property($property, $refiner);
             my $destination_property = $property;
-            $class->_add_link_to_workflow($master_workflow,
-                source_property => $source_property,
+            $master_workflow->connect_input(
+                input_property => $source_property,
                 destination => $refinement,
                 destination_property => $destination_property,
             );
         }
 
-        $class->_add_link_to_workflow($master_workflow,
-            source_property => 'm_result_users',
+        $master_workflow->connect_input(
+            input_property => 'm_result_users',
             destination => $refinement,
             destination_property => 'result_users',
         );
@@ -110,10 +110,10 @@ sub _wire_refinement_operation_to_master_workflow {
 
     my $last_refinement = $refinement_operation->[-1];
     for my $property ($last_refinement->output_properties) {
-        $class->_add_link_to_workflow($master_workflow,
+        $master_workflow->connect_output(
             source => $last_refinement,
             source_property => $property,
-            destination_property => 'm_' . join('_', $property, $last_refinement->name),
+            output_property => 'm_' . join('_', $property, $last_refinement->name),
         );
     }
 
@@ -127,7 +127,7 @@ sub _wire_refinement_to_refinement_operations {
 
     if (scalar @$refinement_operations > 1) {
         for my $i (1..$#$refinement_operations) {
-            $class->_add_link_to_workflow($master_workflow,
+            $master_workflow->create_link(
                 source => $refinement_operations->[$i-1],
                 source_property => 'result_id',
                 destination => $refinement_operations->[$i],

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Refine.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Refine.pm
@@ -95,7 +95,6 @@ sub _wire_refinement_operation_to_master_workflow {
             my $source_property = "m_" . $class->_construct_refiner_input_property($property, $refiner);
             my $destination_property = $property;
             $class->_add_link_to_workflow($master_workflow,
-                source => $master_workflow,
                 source_property => $source_property,
                 destination => $refinement,
                 destination_property => $destination_property,
@@ -103,7 +102,6 @@ sub _wire_refinement_operation_to_master_workflow {
         }
 
         $class->_add_link_to_workflow($master_workflow,
-            source => $master_workflow,
             source_property => 'm_result_users',
             destination => $refinement,
             destination_property => 'result_users',
@@ -115,7 +113,6 @@ sub _wire_refinement_operation_to_master_workflow {
         $class->_add_link_to_workflow($master_workflow,
             source => $last_refinement,
             source_property => $property,
-            destination => $master_workflow,
             destination_property => 'm_' . join('_', $property, $last_refinement->name),
         );
     }

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Refine.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Refine.pm
@@ -49,7 +49,6 @@ sub generate {
     return (\@refinement_operations, \@inputs, \@refiners);
 }
 
-my $_refinealignments_command_id;
 my $_generate_refinement_operation_tmpl;
 sub _generate_refinement_operation {
     my $class = shift;
@@ -57,15 +56,14 @@ sub _generate_refinement_operation {
     my $refiner = shift;
 
     unless ($_generate_refinement_operation_tmpl) {
-        $_generate_refinement_operation_tmpl = UR::BoolExpr::Template->resolve('Workflow::Operation', 'id','name','workflow_operationtype_id')->get_normalized_template_equivalent();
-        $_refinealignments_command_id = Workflow::OperationType::Command->get('Genome::InstrumentData::Command::RefineReads')->id;
+        $_generate_refinement_operation_tmpl = UR::BoolExpr::Template->resolve('Genome::WorkflowBuilder::Command', 'id','name','command')->get_normalized_template_equivalent();
     }
 
-    my $operation = Workflow::Operation->create(
+    my $operation = Genome::WorkflowBuilder::Command->create(
         $_generate_refinement_operation_tmpl->get_rule_for_values(
+                'Genome::InstrumentData::Command::RefineReads',
                 UR::Object::Type->autogenerate_new_object_id_urinternal(),
                 'refine_' . $refiner,
-                $_refinealignments_command_id
         )
     );
 

--- a/lib/perl/Genome/WorkflowBuilder/DAG.pm
+++ b/lib/perl/Genome/WorkflowBuilder/DAG.pm
@@ -329,6 +329,7 @@ sub connect_input {
             input_property => { type => Params::Validate::SCALAR },
             destination => { type => Params::Validate::OBJECT },
             destination_property => { type => Params::Validate::SCALAR },
+            is_optional => { type => Params::Validate::SCALAR, default => 0, },
     });
 
     $self->add_link(Genome::WorkflowBuilder::Link->create(
@@ -336,6 +337,11 @@ sub connect_input {
         destination => $args{destination},
         destination_property => $args{destination_property},
     ));
+
+    if ($args{is_optional}) {
+        push @{$self->_optional_input_properties}, $args{input_property};
+    }
+
     return;
 }
 


### PR DESCRIPTION
* A step on our quest to stop relying on `Workflow`!
* The old version had some UR optimizations built into it for the benefit of `PhenotypeCorrelation`.  I took those out in this conversion, but they could potentially be re-added if needed.
* This adds programmatic support for declaring an input `is_optional` in `Genome::WorkflowBuilder::DAG`s.  (The changes backing this were added in #906.)