### PR TITLE
verifyBamId: Make the --ignoreRG param optional

### DIFF
--- a/lib/perl/Genome/Model/Tools/VerifyBamId.pm
+++ b/lib/perl/Genome/Model/Tools/VerifyBamId.pm
@@ -27,6 +27,11 @@ class Genome::Model::Tools::VerifyBamId {
             is => "Boolean",
             doc => "Recommended for max-depth > 20",
         },
+        ignore_read_group => {
+            is => 'Boolean',
+            doc => 'Check the entire input file instead of examining each read group separately.',
+            default_value => 1,
+        },
         version => {
             is => "Text",
             doc => "Version of VerifyBamId to run",
@@ -51,8 +56,10 @@ sub _get_cmd_list {
     my $self = shift;
     my $executable = _get_exe_path($self->version);
     my @cmd_list = ($executable, "--vcf", $self->vcf, "--bam", $self->bam,
-                    "--out", $self->out_prefix, "--maxDepth", $self->max_depth,
-                    "--ignoreRG");
+                    "--out", $self->out_prefix, "--maxDepth", $self->max_depth);
+    if ($self->ignore_read_group) {
+        push (@cmd_list, "--ignoreRG");
+    }
     if ($self->precise) {
         push (@cmd_list, "--precise");
     }


### PR DESCRIPTION
For production QC we want to be able to run verifyBamId by read group.