### PR TITLE
Ignore strelka subdirectory

### DIFF
--- a/lib/perl/Genome/Model/Build/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation.pm
@@ -247,6 +247,8 @@ sub dirs_ignored_by_diff {
         variants/sv/union
         validation/small_indel/realigned_bams
         /validation/small_indel
+        variants/snv/strelka
+        variants/indel/strelka
     );
 }
 

--- a/lib/perl/Genome/Model/Build/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation.pm
@@ -247,8 +247,7 @@ sub dirs_ignored_by_diff {
         variants/sv/union
         validation/small_indel/realigned_bams
         /validation/small_indel
-        variants/snv/strelka
-        variants/indel/strelka
+        output
     );
 }
 

--- a/lib/perl/Genome/Model/Build/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation.pm
@@ -235,6 +235,8 @@ sub files_ignored_by_diff {
         validation/large_indel/normal.csv
         variants/(.*)\.tbi$
         control_variants_for_loh/(.*)\.tbi$
+        variants/snv/strelka.*/output/.*
+        variants/indel/strelka.*/output/.*
     );
 }
 sub dirs_ignored_by_diff {
@@ -247,7 +249,6 @@ sub dirs_ignored_by_diff {
         variants/sv/union
         validation/small_indel/realigned_bams
         /validation/small_indel
-        output
     );
 }
 


### PR DESCRIPTION
The important strelka results will be diffed in the vcf files.
The remaining files in this directory are intermediate files
and contain a lot of non-diffable items like times and file
paths.

Our current model test for somatic validation doesn't run strelka, but the ones we want to use for the cle regression test do.