### PR TITLE
Deduplicate between config and prime-db script

### DIFF
--- a/lib/perl/Genome/Site/TGI/CleTest.pm
+++ b/lib/perl/Genome/Site/TGI/CleTest.pm
@@ -3,11 +3,11 @@ package Genome::Site::TGI::CleTest;
 use strict;
 use warnings;
 use Genome;
-use YAML;
+use YAML::Syck qw(LoadFile);
 
 sub get_config {
     my $file = __FILE__.".yaml";
-    my ($config, undef, undef) = YAML::LoadFile($file);
+    my ($config, undef, undef) = LoadFile($file);
     return $config;
 }
 

--- a/lib/perl/Genome/Site/TGI/CleTest.pm
+++ b/lib/perl/Genome/Site/TGI/CleTest.pm
@@ -3,11 +3,10 @@ package Genome::Site::TGI::CleTest;
 use strict;
 use warnings;
 use Genome;
-use YAML::Syck qw(LoadFile);
 
 sub get_config {
     my $file = __FILE__.".yaml";
-    my ($config, undef, undef) = LoadFile($file);
+    my ($config, undef, undef) = Genome::Config::Parser->parse($file);
     return $config;
 }
 

--- a/lib/perl/Genome/Site/TGI/CleTest.pm.yaml
+++ b/lib/perl/Genome/Site/TGI/CleTest.pm.yaml
@@ -35,3 +35,26 @@ blessed_builds:
     - f87701c292e843958d088e171a65a67a
     - 301d5d51c96e41308d015008720f3962
 blessed_process: 2b2b3d8481284fcf8a1632d65ba58083
+annotation_builds:
+    - d00a39c84382427fa0efdec3229e8f5f
+imported_variation_builds:
+    - 7fd9ca9a6bf74a098c23b32c1b00fbc0 #dbsnp
+    - 126747180 #NHLBI version 2012.07.23
+    - 847b3cacad1249b8b7e46f89e02d96da #DOCM SNV
+    - 1040bf09070c4176a5256fa8a075378f #DOCM INDEL
+reference_sequence_builds:
+    - '106942997' #build37, other references may crop up in feature lists
+    - 108563338 #nimblegen refseq for feature list
+    - 102671028 #g1k-human-build37 for segdups
+feature_lists:
+    - a2733b8111c24110805025137c878e13 #Full ROI
+    - 0e4973c600244c3f804d54bee6f81145 #RMG ROI
+    - ef6583623a614c8ebaea471a4c9748fc #AML Complex Mutation Region ROI
+    - 696318bab30d47d49fab9afa845691b7 #homopolymer regions from G::VR::C::Wrapper::ModelPair
+    - 4e77d10f29f44a0792ebc8d6ea0c4a2b #segdups my $b = Genome::Model::Build->get('26e65adaa8034dd99ef92b27f61ad862'); $b->get_feature_list("segmental_duplications")->id
+processing_profiles:
+    - a813f8067a8c4c9791fec53dd29d85ca #somatic CLE PP
+    - 6cab54acdf704c7c9e8adc7aa8facff4 #germline CLE PP
+misc_software_results:
+    - 265673ea574246b49d211151107dfee9 #vep cache
+    - 44d72413f6af43e99386f7f6c92ed59a #ensembl api

--- a/lib/perl/Genome/Site/TGI/CleTest.t
+++ b/lib/perl/Genome/Site/TGI/CleTest.t
@@ -52,7 +52,33 @@ my $expected_config = {
     '2893815492'
     ],
     'region_of_interest_set_name' => 'SeqCap EZ Human Exome v3.0 + AML RMG pooled probes + WO2830729 pooled probes + WO2840081 pooled probes',
-    'subject_mapping_string' => "H_KA-174556-1309237\tH_KA-174556-1309246\t\t\t\tfollowup\nH_KA-174556-1309245\tH_KA-174556-1309246\t\t\t\tdiscovery\nH_KA-174556-1309246\t\t\t\t\tgermline\n"
+    'subject_mapping_string' => "H_KA-174556-1309237\tH_KA-174556-1309246\t\t\t\tfollowup\nH_KA-174556-1309245\tH_KA-174556-1309246\t\t\t\tdiscovery\nH_KA-174556-1309246\t\t\t\t\tgermline\n",
+    annotation_builds => ['d00a39c84382427fa0efdec3229e8f5f'],
+    imported_variation_builds => ['7fd9ca9a6bf74a098c23b32c1b00fbc0',
+        '126747180',
+        '847b3cacad1249b8b7e46f89e02d96da',
+        '1040bf09070c4176a5256fa8a075378f',
+    ],
+    reference_sequence_builds => [
+        '106942997',
+        '108563338',
+        '102671028'
+    ],
+    feature_lists => [
+        'a2733b8111c24110805025137c878e13',
+        '0e4973c600244c3f804d54bee6f81145',
+        'ef6583623a614c8ebaea471a4c9748fc',
+        '696318bab30d47d49fab9afa845691b7',
+        '4e77d10f29f44a0792ebc8d6ea0c4a2b'
+    ],
+    processing_profiles => [
+        'a813f8067a8c4c9791fec53dd29d85ca',
+        '6cab54acdf704c7c9e8adc7aa8facff4',
+    ],
+    misc_software_results => [
+        '265673ea574246b49d211151107dfee9',
+        '44d72413f6af43e99386f7f6c92ed59a'
+    ],
 };
 is_deeply($config, $expected_config, "Config read in correctly");
 

--- a/lib/perl/Genome/Site/TGI/CleTest/prime-db.pl
+++ b/lib/perl/Genome/Site/TGI/CleTest/prime-db.pl
@@ -10,6 +10,7 @@
 # 5. use `test-db template create` to create a new template
 # 6. Use the new template in the jenkins configuration
 use Genome;
+use Genome::Site::TGI::CleTest;
 use List::MoreUtils qw(uniq);
 
 #things we need to load
@@ -145,7 +146,6 @@ sub load_users_by_username {
 
 sub main {
 
-    use Genome::Site::TGI::CleTest;
     my $config = Genome::Site::TGI::CleTest::get_config();
     my @instrument_data_ids = @{$config->{instrument_data}};
     load_instrument_data(@instrument_data_ids);

--- a/lib/perl/Genome/Site/TGI/CleTest/prime-db.pl
+++ b/lib/perl/Genome/Site/TGI/CleTest/prime-db.pl
@@ -154,36 +154,19 @@ sub main {
     my @blessed_builds = @{$config->{blessed_builds}};
     load_builds(@blessed_builds);
 
-    my @build_ids = (
-        'd00a39c84382427fa0efdec3229e8f5f', #annotation build
-    );
+    my @build_ids = @{$config->{annotation_builds}};
 
-    my @imported_variation_list_ids = (
-        '7fd9ca9a6bf74a098c23b32c1b00fbc0', #dbsnp
-        '126747180', #NHLBI version 2012.07.23
-        '847b3cacad1249b8b7e46f89e02d96da', #DOCM SNV
-        '1040bf09070c4176a5256fa8a075378f', #DOCM INDEL
+    my @imported_variation_list_ids = @{$config->{imported_variation_builds}};
 
-    );
     load_builds(@build_ids);
     load_imported_annotation_builds(@imported_variation_list_ids);
 
-    my @reference_sequences = (
-        '106942997', #build37, other references may crop up in feature lists
-        '108563338', #nimblegen refseq for feature list
-        '102671028', #g1k-human-build37 for segdups
-    );
+    my @reference_sequences = @{$config->{reference_sequence_builds}};
     load_builds_without_results(@reference_sequences);
     load_converters(@reference_sequences);
 
 
-    my @featurelist_ids = (
-        'a2733b8111c24110805025137c878e13', #Full ROI
-        '0e4973c600244c3f804d54bee6f81145', #RMG ROI
-        'ef6583623a614c8ebaea471a4c9748fc', #AML Complex Mutation Region ROI
-        '696318bab30d47d49fab9afa845691b7', #homopolymer regions from G::VR::C::Wrapper::ModelPair
-        '4e77d10f29f44a0792ebc8d6ea0c4a2b', #segdups my $b = Genome::Model::Build->get('26e65adaa8034dd99ef92b27f61ad862'); $b->get_feature_list("segmental_duplications")->id
-    );
+    my @featurelist_ids = @{$config->{feature_lists}};
     load_feature_lists(@featurelist_ids);
 
     my %tag_to_menu_item = %{$config->{tag_to_menu_item}};
@@ -192,10 +175,7 @@ sub main {
     my @menu_items = uniq(values %tag_to_menu_item);
     load_menu_items(@menu_items);
 
-    my @processing_profiles = (
-        'a813f8067a8c4c9791fec53dd29d85ca', #somatic CLE PP
-        '6cab54acdf704c7c9e8adc7aa8facff4', #germline CLE PP
-    );
+    my @processing_profiles = @{$config->{processing_profiles}};
     load_processing_profiles(@processing_profiles);
 
     load_users_by_username('apipe-tester');
@@ -203,8 +183,9 @@ sub main {
     my $process = $config->{blessed_process};
     load_processes($process); #our report process to diff
 
-    my @vep_results = Genome::SoftwareResult->get(id => ['265673ea574246b49d211151107dfee9', '44d72413f6af43e99386f7f6c92ed59a']);
-    load_software_results(@vep_results); #vep cache and api
+    my @misc_software_results = Genome::SoftwareResult->get(
+        id => $config->{misc_software_results});
+    load_software_results(@misc_software_results);
     return UR::Context->commit();
 }
 


### PR DESCRIPTION
Some of the items from config are also needed in the prime db script
We might consider putting all of the items needed in the prime db script
in the config, but that might also be confusing, I'm not sure