### PR TITLE
Handle insert_centric Option for Bam Readcount

### DIFF
--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
@@ -476,10 +476,8 @@ sub execute {
             %params,
             output_file       => "$tempdir/readcounts_indel",
             region_list       => "$tempdir/indelpos",
+            insertion_centric => 1,
         );
-        if ( $readcount_cmd->version_has_insertion_centric( $self->bam_readcount_version ) ) {
-            $readcount_cmd->insertion_centric(1);
-        }
         unless($readcount_cmd->execute) {
             $self->error_message("Failed to execute.");
             die $self->error_message;

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
@@ -476,8 +476,10 @@ sub execute {
             %params,
             output_file       => "$tempdir/readcounts_indel",
             region_list       => "$tempdir/indelpos",
-            insertion_centric => 1,
         );
+        if ( $readcount_cmd->version_has_insertion_centric( $self->bam_readcount_version ) ) {
+            $readcount_cmd->insertion_centric(1);
+        }
         unless($readcount_cmd->execute) {
             $self->error_message("Failed to execute.");
             die $self->error_message;

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
@@ -12,7 +12,7 @@ class Genome::Model::Tools::Analysis::Coverage::BamReadcount{
     bam_readcount_version => {
         is => 'String',
         is_optional => 1,
-        default_version => Genome::Model::Tools::Sam::Readcount->default_version,
+        default_value => Genome::Model::Tools::Sam::Readcount->default_version,
         doc => 'version of bam-readcount to use',
     },
 

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
@@ -6,14 +6,13 @@ use warnings;
 use Genome::Model::Tools::Vcf::Helpers qw/convertIub/;
 use Genome::File::BamReadcount::Reader;
 
-
-
 class Genome::Model::Tools::Analysis::Coverage::BamReadcount{
     is => 'Command',
     has => [
     bam_readcount_version => {
         is => 'String',
         is_optional => 1,
+        default_version => Genome::Model::Tools::Sam::Readcount->default_version,
         doc => 'version of bam-readcount to use',
     },
 
@@ -357,11 +356,8 @@ sub execute {
         reference_fasta         => $fasta,
         minimum_base_quality    => $min_base_quality,
         minimum_mapping_quality => $min_mapping_quality,
+        use_version             => $self->bam_readcount_version,
     );
-
-    if ($self->bam_readcount_version){
-        $params{use_version} = $self->bam_readcount_version;
-    }
 
     if (-s "$tempdir/snvpos") {
         my $readcount_cmd = Genome::Model::Tools::Sam::Readcount->create(

--- a/lib/perl/Genome/Model/Tools/Sam/Readcount.pm
+++ b/lib/perl/Genome/Model/Tools/Sam/Readcount.pm
@@ -81,9 +81,20 @@ sub default_version {
     return $DEFAULT_VER;
 }
 
-# The -w option was introduced in 0.5
+# The -w and -i options were introduced in 0.5
 sub version_has_warning_suppression {
     return version->parse($_[1]) >= version->parse('0.5');
+}
+
+sub version_has_insertion_centric {
+    return version->parse($_[1]) >= version->parse('0.5');
+}
+
+sub assert_version_has_insertion_centric {
+    my ($self, $version) = @_;
+    my $version_has_insertion_centric =  $self->version_has_insertion_centric($version);
+    return $version_has_insertion_centric if $version_has_insertion_centric;
+    die $self->error_message('Option insertion_centric is unsupported in version %s', $version);
 }
 
 sub readcount_path {
@@ -120,6 +131,7 @@ sub command {
         $command .= " -p";
     }
     if($self->insertion_centric) {
+        $self->assert_version_has_insertion_centric($version);
         $command .= " -i";
     }
     if($self->version_has_warning_suppression($version)) {

--- a/lib/perl/Genome/Model/Tools/Sam/Readcount.pm
+++ b/lib/perl/Genome/Model/Tools/Sam/Readcount.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use Genome;
 use File::Touch qw(touch);
+use version;
 
 my $DEFAULT_VER = '0.7';
 
@@ -82,8 +83,7 @@ sub default_version {
 
 # The -w option was introduced in 0.5
 sub version_has_warning_suppression {
-    my ($self, $version) = @_;
-    return ($version >= "0.5");
+    return version->parse($_[1]) >= version->parse('0.5');
 }
 
 sub readcount_path {

--- a/lib/perl/Genome/Model/Tools/Sam/Readcount.t
+++ b/lib/perl/Genome/Model/Tools/Sam/Readcount.t
@@ -33,6 +33,14 @@ subtest 'testing command execution' => sub {
     compare_ok($expected, $output, 'readcount file looks as expected');
 };
 
+subtest 'version specific options' => sub {
+    plan tests => 2;
+
+    ok(!$pkg->version_has_warning_suppression('0.4'), 'version 0.4 does not have warning_suppression');
+    ok($pkg->version_has_warning_suppression('0.5'), 'version 0.5 does have warning_suppression');
+
+};
+
 subtest 'testing command strings' => sub {
 
     my %expected_command = (


### PR DESCRIPTION
The bam_readcount insert_centric option was not introduced until version 0.5. This PR adds a check if the bam readcount version supports  the option before using it in the GMT Analysis Coverage BamReadcount class and asserts it is supported in the GMT Sam ReadCount command.