### PR TITLE
Rewrite get_merged_bam_to_revivify_per_lane_bam method to meet the need of removing superseded merged bams

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1821,10 +1821,6 @@ sub revivified_alignment_bam_file_path {
     my $revivified_bam = File::Spec->join($temp_allocation->absolute_path, 'all_sequences.bam');
     my $merged_bam = $self->get_merged_bam_to_revivify_per_lane_bam;
 
-    unless ($merged_bam and -s $merged_bam) {
-        die $self->error_message('Failed to get valid merged bam to recreate per lane bam '.$self->id);
-    }
-
     my $bam_header_path = $self->create_bam_header;
     $self->create_bam_flagstat_and_revivify($merged_bam, $revivified_bam, $bam_header_path);
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1899,7 +1899,7 @@ sub get_merged_bam_to_revivify_per_lane_bam {
     my $self = shift;
     my $merged_bam;
 
-    for my $mr ($self->get_unarchived_merged_alignment_results) {
+    for my $mr ($self->get_active_merged_alignment_results) {
         my $unarchived_merged_bam = $mr->merged_alignment_bam_path;
         if (-s $unarchived_merged_bam) {
             $merged_bam = $unarchived_merged_bam;
@@ -1998,6 +1998,16 @@ sub get_archived_merged_alignment_results {
         }
     }
     return @archived;
+}
+
+sub get_active_merged_alignment_results {
+    my @mrs;
+    for my $mr (shift->get_merged_alignment_results) {
+        if ( grep { $_->status eq 'active' } $mr->disk_allocations ) {
+            push @mrs, $mr;
+        }
+    }
+    return @mrs;
 }
 
 sub get_smallest_merged_alignment_result {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1907,12 +1907,9 @@ sub get_merged_bam_to_revivify_per_lane_bam {
         }
     }
 
-    if ($merged_bam) {
-        return $merged_bam;
-    }
-    else {
-        $self->debug_message('Failed to get merged bam from unarchived results for per lane alignment '.$self->id.'. Now try to get one from archived results');
-    }
+    return $merged_bam if $merged_bam;
+    
+    $self->debug_message('Failed to get merged bam from unarchived results for per lane alignment '.$self->id.'. Now try to get one from archived results');
 
     my $merged_result = $self->get_smallest_merged_alignment_result($self->get_archived_merged_alignment_results);
     unless ($merged_result) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1901,19 +1901,32 @@ sub _get_uuid_string {
 
 sub get_merged_bam_to_revivify_per_lane_bam {
     my $self = shift;
-    my $merged_result = $self->get_smallest_merged_alignment_result($self->get_unarchived_merged_alignment_results);
+    my $merged_bam;
 
-    unless ($merged_result) {
-        $merged_result = $self->get_smallest_merged_alignment_result($self->get_merged_alignment_results);
-        unless ($merged_result) {
-            die $self->error_message('Failed to get archived merged result for per lane alignment '.$self->id);
+    for my $mr ($self->get_unarchived_merged_alignment_results) {
+        my $unarchived_merged_bam = $mr->merged_alignment_bam_path;
+        if (-s $unarchived_merged_bam) {
+            $merged_bam = $unarchived_merged_bam;
+            last;
         }
-        $merged_result->_auto_unarchive;
     }
 
-    my $merged_bam = $merged_result->merged_alignment_bam_path;
+    if ($merged_bam) {
+        return $merged_bam;
+    }
+    else {
+        $self->debug_message('Failed to get merged bam from unarchived results for per lane alignment '.$self->id.'. Now try to get one from archived results');
+    }
+
+    my $merged_result = $self->get_smallest_merged_alignment_result($self->get_archived_merged_alignment_results);
+    unless ($merged_result) {
+        die $self->error_message('Failed to get archived merged result for per lane alignment '.$self->id);
+    }
+    $merged_result->_auto_unarchive;
+
+    $merged_bam = $merged_result->merged_alignment_bam_path;
     unless (-s $merged_bam) {
-        die $self->error_message("Merged bam (%s) does not exist for merged result id (%s)", $merged_bam, $merged_result->id);
+        die $self->error_message("Merged bam (%s) does not exist for archived merged result id (%s)", $merged_bam, $merged_result->id);
     }
     return $merged_bam;
 }
@@ -1977,6 +1990,18 @@ sub get_unarchived_merged_alignment_results {
         }
     }
     return @unarchived;
+}
+
+sub get_archived_merged_alignment_results {
+    my $self = shift;
+    my @merged = $self->get_merged_alignment_results;
+    my @archived;
+    for my $merged (@merged) {
+        if ( grep { $_->is_archived } $merged->disk_allocations ) {
+            push @archived, $merged;
+        }
+    }
+    return @archived;
 }
 
 sub get_smallest_merged_alignment_result {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.t
@@ -14,6 +14,7 @@ use Genome::Test::Factory::InstrumentData::Solexa;
 use Genome::Test::Factory::Model::ImportedReferenceSequence;
 use Genome::Test::Factory::Build;
 use Genome::Test::Factory::SoftwareResult::User;
+use Genome::Test::Factory::DiskAllocation;
 use Genome::Test::Data qw(get_test_file);
 use Sub::Override;
 use Cwd qw(abs_path);
@@ -71,6 +72,9 @@ my $override4 = Sub::Override->new(
     'Genome::InstrumentData::AlignmentResult::Merged::Speedseq::merged_alignment_bam_path',
     sub { return File::Spec->join($test_data_dir, 'merged_alignment_result.bam'); }
 );
+
+my $merged_allocation = Genome::Test::Factory::DiskAllocation->generate_obj(owner => $merged_alignment_result);
+ok($merged_allocation, 'Disk allocation generated ok for merged result');
 
 my $alignment_result = $pkg->create(
     instrument_data => $instrument_data,

--- a/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
@@ -62,17 +62,24 @@ subtest 'get_unarchived_merged_alignment_results' => sub {
 
 
 subtest 'get_smallest_merged_alignment_result and get_merged_bam_to_revivify_per_lane_bam' => sub {
+    my $small_merged_bam = File::Spec->join($smaller_merged_result->output_dir, $small_merge_id.'.bam');
+    my $merged_bam       = File::Spec->join($merged_result->output_dir, $merge_id.'.bam');
+
     is_deeply([$ar1->get_smallest_merged_alignment_result($ar1->get_merged_alignment_results)], [$smaller_merged_result], 'Got smallest merged result for ar1');
-    is($ar1->get_merged_bam_to_revivify_per_lane_bam, File::Spec->join($smaller_merged_result->output_dir, $small_merge_id.'.bam'), 'Got smallest merged bam to revivify per lane bam for ar1');
+    is($ar1->get_merged_bam_to_revivify_per_lane_bam, $small_merged_bam, 'Got smallest merged bam to revivify per lane bam for ar1');
+
+    unlink $small_merged_bam;
+    ok(!-s $small_merged_bam, "Small merged bam is deleted");
+    is($ar1->get_merged_bam_to_revivify_per_lane_bam, $merged_bam, 'Got merged bam to revivify per lane bam for ar1 since small merged bam is deleted');
 
     is_deeply([$ar2->get_smallest_merged_alignment_result($ar2->get_merged_alignment_results)], [$merged_result], 'Got smallest merged result for ar2');
-    is($ar2->get_merged_bam_to_revivify_per_lane_bam, File::Spec->join($merged_result->output_dir, $merge_id.'.bam'), 'Got smallest merged result to revivify per lane bam for ar2');
+    is($ar2->get_merged_bam_to_revivify_per_lane_bam, $merged_bam, 'Got smallest merged result to revivify per lane bam for ar2');
 
     my $archived_allocation = Test::MockObject::Extends->new($smaller_merged_result->_disk_allocation);
     is($archived_allocation->owner, $smaller_merged_result, 'The new archived allocation has the smaller merged result as the owner');
     $archived_allocation->mock('is_archived', sub { 1 });
 
-    is($ar1->get_merged_bam_to_revivify_per_lane_bam, File::Spec->join($merged_result->output_dir, $merge_id.'.bam'), 'We prefer the unarchived bam to the smaller one');
+    is($ar1->get_merged_bam_to_revivify_per_lane_bam, $merged_bam, 'We prefer the unarchived bam to the smaller one');
     $archived_allocation->unmock('is_archived');
 };
 


### PR DESCRIPTION
The original get_merged_bam_to_revivify_per_lane_bam will get smallest unarchived merged bam to revivify per lane bam. It will fail after we remove superseded merged bam. This rewrite will get whatever bam that is available.