### PR TITLE
added new hard-coded path for mm10 tiering files

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -199,6 +199,9 @@ sub get_or_create_ucsc_tiering_directory {
     elsif ($self->id eq "107494762") {
         return "/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-mouse-build37/mm9";
     }
+    elsif ($self->id eq "3ca0ea4786dd4ebebaf3935f3d3ccab8") {
+        return "/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-mouse-build38/mm10";
+    }
     else {
         $self->status_message("UCSC Tiering Directory not currently available for this species: ".$self->species_name);
         return;


### PR DESCRIPTION
This is a brutal proliferation of hard-coded paths to UCSC tiering files but necessary (I think) in the effort to get a new annotation build to succeed for mm10.