### PR TITLE
Only unlock SoftwareResults once.

### DIFF
--- a/lib/perl/Genome/Db/Ensembl/AnnotationStructures.pm
+++ b/lib/perl/Genome/Db/Ensembl/AnnotationStructures.pm
@@ -575,7 +575,9 @@ sub create
     $self->_promote_data;
     $self->_reallocate_disk_allocation;
 
-    unless ($self->_user_test_name) {
+    if ($self->_user_test_name) {
+        $self->test_name($self->_user_test_name);
+    } else {
         $self->remove_test_name();
     }
     UR::Context->commit;

--- a/lib/perl/Genome/Db/Ensembl/AnnotationStructures.pm
+++ b/lib/perl/Genome/Db/Ensembl/AnnotationStructures.pm
@@ -581,8 +581,19 @@ sub create
         $self->remove_test_name();
     }
     UR::Context->commit;
+    $self->_unlock;
 
     return $self;
+}
+
+sub _add_unlock_observers {
+    my $self = shift;
+
+    my $unlock_callback = sub {
+        $self->_unlock;
+    };
+
+    return $self->add_observer(aspect => 'delete', callback => $unlock_callback);
 }
 
 sub result_paths {

--- a/lib/perl/Genome/SoftwareResult.pm
+++ b/lib/perl/Genome/SoftwareResult.pm
@@ -331,11 +331,7 @@ sub create {
 
     $self->_lock_proxy($lock);
 
-    my $unlock_callback = sub {
-        $self->_unlock;
-    };
-    $self->add_observer(aspect => 'commit', callback => $unlock_callback, once => 1);
-    $self->add_observer(aspect => 'delete', callback => $unlock_callback);
+    $self->_add_unlock_observers;
 
     if (my $output_dir = $self->output_dir) {
         if (-d $output_dir) {
@@ -365,6 +361,19 @@ sub create {
     $self->subclass_name($class);
     $self->lookup_hash($self->calculate_lookup_hash());
     return $self;
+}
+
+sub _add_unlock_observers {
+    my $self = shift;
+
+    my $unlock_callback = sub {
+        $self->_unlock;
+    };
+    my @observers =
+        $self->add_observer(aspect => 'commit', callback => $unlock_callback, once => 1),
+        $self->add_observer(aspect => 'delete', callback => $unlock_callback);
+
+    return @observers;
 }
 
 sub _gather_params_for_get_or_create {

--- a/lib/perl/Genome/SoftwareResult.pm
+++ b/lib/perl/Genome/SoftwareResult.pm
@@ -334,7 +334,7 @@ sub create {
     my $unlock_callback = sub {
         $self->_unlock;
     };
-    $self->add_observer(aspect => 'commit', callback => $unlock_callback);
+    $self->add_observer(aspect => 'commit', callback => $unlock_callback, once => 1);
     $self->add_observer(aspect => 'delete', callback => $unlock_callback);
 
     if (my $output_dir = $self->output_dir) {


### PR DESCRIPTION
* Subsequent commits of SoftwareResults generally don't need to unlock again, as the object already exists and was unlocked.
* `Genome::Db::Ensembl::AnnotationStructures` commits several times as it is working.  To avoid unlocking early, add an explicit unlock after the final commit.
* Minor fix for test names in the aforementioned class is included.