### PR TITLE
ClinSeq::LOH - Write results to temp dir first.

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/IdentifyLoh.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/IdentifyLoh.pm
@@ -191,7 +191,6 @@ sub filter_snvs {
     $self->get_tumor_normal_bam($somvar_build);
     my $refbuild = $self->reference_build($somvar_build);
     my $ref_fa = $refbuild->full_consensus_path('fa');
-    my $temp_op_dir = Genome::Sys->create_temp_directory;
     my $filter = Genome::Model::Tools::Varscan::SomaticFilterWorkflow->
     create(
         outdir => $outdir,

--- a/lib/perl/Genome/Model/ClinSeq/Command/IdentifyLoh.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/IdentifyLoh.pm
@@ -3,6 +3,7 @@ package Genome::Model::ClinSeq::Command::IdentifyLoh;
 use strict;
 use warnings;
 use File::Spec;
+use File::Copy;
 use Genome;
 
 class Genome::Model::ClinSeq::Command::IdentifyLoh {
@@ -48,6 +49,11 @@ class Genome::Model::ClinSeq::Command::IdentifyLoh {
         is_optional => 1,
         default => 0,
     },
+    ],
+    has_param => [
+        lsf_resource => {
+            default => "-R 'select[gtmp>10] span[hosts=1] rusage[gtmp=10]'",
+        }
     ],
     doc => 'Identify regions of LOH using clinseq tumor/normal pairs.',
 };
@@ -180,13 +186,15 @@ sub filter_snvs {
     my $self = shift;
     my $somvar_build = shift;
     my $snv_prefix = shift;
+    my $outdir = shift;
     my ($tumor_bam, $normal_bam) =
     $self->get_tumor_normal_bam($somvar_build);
     my $refbuild = $self->reference_build($somvar_build);
     my $ref_fa = $refbuild->full_consensus_path('fa');
+    my $temp_op_dir = Genome::Sys->create_temp_directory;
     my $filter = Genome::Model::Tools::Varscan::SomaticFilterWorkflow->
     create(
-        outdir => $self->outdir,
+        outdir => $outdir,
         tumor_bam => $tumor_bam,
         normal_bam => $normal_bam,
         prefix => $snv_prefix,
@@ -255,11 +263,12 @@ sub filter_loh {
 #Get rid of intermediate files
 sub cleanup {
     my $self = shift;
+    my $outdir = shift;
     my @patterns = qw(*.Somatic* *.readcounts *.hc *.LOH
         *.lc *.Germline *.removed *.formatted
         *.hc.err *.other *.err *.out *.snp snvs.filtered snvs.*.unfiltered *hc.filtered);
     for my $pattern (@patterns) {
-        for my $file (glob File::Spec->join($self->outdir, $pattern)) {
+        for my $file (glob File::Spec->join($outdir, $pattern)) {
             $self->status_message("unlinking $file");
             unlink $file;
         }
@@ -270,18 +279,23 @@ sub cleanup {
 sub execute {
     my $self = shift;
     my $somvar_build = $self->resolve_somvar;
+    my $temp_outdir = Genome::Sys->create_temp_directory;
     my $snv_prefix = File::Spec->join(
-        $self->outdir,
+        $temp_outdir,
         "snvs");
     $self->get_varscan_snvs($somvar_build, $snv_prefix);
-    $self->filter_snvs($somvar_build, $snv_prefix);
+    $self->filter_snvs($somvar_build, $snv_prefix, $temp_outdir);
     my $combined_sorted = $self->combine_sort_snvs($snv_prefix);
     my $loh_basename = File::Spec->join(
-        $self->outdir,
+        $temp_outdir,
         "loh");
     my $loh_segments = $self->segment_loh($combined_sorted, $loh_basename);
     $self->filter_loh($loh_basename);
-    $self->cleanup;
+    $self->cleanup($temp_outdir);
+    for my $file (glob File::Spec->join($temp_outdir, "*")) {
+        $self->status_message("Copying $file");
+        copy($file, $self->outdir);
+    }
     return 1;
 }
 


### PR DESCRIPTION
This PR modifies this module to write the results
to a temp dir and copy the results over at the end for
better performance.