### PR TITLE
Iterate through ldapsearch output

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Genome;
+use IO::File;
 
 class Genome::Site::TGI::Command::SyncSysUserWithLdap{
     is => 'Command::V2',
@@ -52,12 +53,13 @@ sub execute {
 
 sub get_ldap_users {
     my $ldap_user = {};
-    my @c = `ldapsearch -z 0 -x`;
+    my $cmd = 'ldapsearch -z 0 -x';
+    my $fh  = IO::File->new($cmd . "|");
     my @users;
     my $user;
 
     # go through each line of ldapsearch output
-    for my $c (@c) {
+    while (my $c = $fh->getline) {
         next if $c =~ /^\#/;
         chomp($c);
 
@@ -70,6 +72,7 @@ sub get_ldap_users {
             $user->{$key} = $value;
         }
     }
+    $fh->close;
 
     # filter out users that didnt have email address entry in ldap
     for my $u (@users) {

--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
@@ -52,7 +52,7 @@ sub execute {
 
 sub get_ldap_users {
     my $ldap_user = {};
-    my @c = `ldapsearch -z 1000 -x`; # gets max 1000 records
+    my @c = `ldapsearch -z 0 -x`;
     my @users;
     my $user;
 

--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.t
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.t
@@ -4,10 +4,17 @@ use strict;
 use warnings;
 
 use above 'Genome';
-use Test::More tests => 1;
+use Set::Scalar;
+use Test::More tests => 2;
 
-# This test was auto-generated because './Site/TGI/Command/SyncSysUserWithLdap.pm'
-# had no '.t' file beside it.  Please remove this test if you believe it was
-# created unnecessarily.  This is a bare minimum test that just compiles Perl
-# and the UR class.
-use_ok('Genome::Site::TGI::Command::SyncSysUserWithLdap');
+my $class = 'Genome::Site::TGI::Command::SyncSysUserWithLdap';
+use_ok($class);
+
+my $ldap_users = $class->get_ldap_users;
+my $users = Set::Scalar->new(keys %$ldap_users);
+my $apipe_users = Set::Scalar->new(map{$_.'@genome.wustl.edu'}qw(apipe apipe-builder apipe-tester));
+
+ok($users->is_proper_superset($apipe_users), 'Found apipe users in ldap users');
+
+
+

--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.t
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.t
@@ -12,7 +12,7 @@ use_ok($class);
 
 my $ldap_users = $class->get_ldap_users;
 my $users = Set::Scalar->new(keys %$ldap_users);
-my $apipe_users = Set::Scalar->new(map{$_.'@genome.wustl.edu'}qw(apipe apipe-builder apipe-tester));
+my $apipe_users = Set::Scalar->new(map{$_.'@'.Genome::Config::get('email_domain')}qw(apipe apipe-builder apipe-tester));
 
 ok($users->is_proper_superset($apipe_users), 'Found apipe users in ldap users');
 


### PR DESCRIPTION
Currently 1000 is used as response size limit for ldapsearch.  Modify this so more info can be obtained.