### PR TITLE
Add entry for speedseq version to bwa version mapping

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -176,6 +176,7 @@ sub bwa_version {
     my %speedseq_version_to_bwa_version = (
         'test' => '0.7.10',
         '0.0.3a-gms' => '0.7.10',
+        '0.1.0-gms' => '0.7.10',
     );
     my $bwa_version = $speedseq_version_to_bwa_version{$speedseq_version};
     unless ($bwa_version) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.t
@@ -10,6 +10,7 @@ use warnings;
 
 use above "Genome";
 use Test::More;
+use Test::Exception;
 use Genome::Test::Factory::InstrumentData::Solexa;
 use Genome::Test::Factory::Model::ImportedReferenceSequence;
 use Genome::Test::Factory::Build;
@@ -21,6 +22,16 @@ use Cwd qw(abs_path);
 
 my $pkg = 'Genome::InstrumentData::AlignmentResult::Speedseq';
 use_ok($pkg);
+
+my @speedseq_versions = Genome::Model::Tools::Speedseq::Base->available_versions;
+for my $version (@speedseq_versions) {
+    my $sub = sub { return $version; };
+    my $fake_refindex = bless {}, "DummyIndex";
+    *DummyIndex::aligner_version = $sub;
+    lives_ok {
+        Genome::InstrumentData::AlignmentResult::Speedseq->bwa_version($fake_refindex);
+    } "BWA version found for Speedseq version $version";
+}
 
 my $test_data_dir = __FILE__.'.d';
 


### PR DESCRIPTION
SpeedSeq bundles its own version of BWA. This mapping identifies the version of BWA packaged with a particular version of SpeedSeq so that we can pass it along to other results. The 0.1.0 release of SpeedSeq is already out, but I missed updating this at the time.