### PR TITLE
Increase speedseq LSF memory requested 

### DIFF
--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -97,7 +97,7 @@ sub _format_lsf_resource_string {
     my $gtmp_bytes = shift;
 
     my $cpus = 8;
-    my $mem_gb = 36;
+    my $mem_gb = 60;
     my $queue = Genome::Config::get('lsf_queue_alignment_prod');
 
     my $gtmp_kb = ceil($gtmp_bytes / 1024);


### PR DESCRIPTION
36GB is not enough for some large instrument data. Ultimately this well get calculated based on the size of the instrument data once we have run more samples and have a better idea what the formula should be (similar to gtmp requested).