### PR TITLE
Commit actions

### DIFF
--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -381,9 +381,8 @@ sub _lock {
         die('Unable to acquire the lock! Is ConfigureQueuedInstrumentData already running or did it exit uncleanly?')
             unless $lock;
 
-        UR::Context->current->add_observer(
-            aspect => 'commit',
-            callback => sub {
+        Genome::Sys::CommitAction->create(
+            on_commit => sub {
                 $lock->unlock();
             }
         );

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -700,11 +700,7 @@ sub _create_observer {
         return 1;
     }
 
-    $observer = UR::Context->add_observer(
-        aspect => 'commit',
-        callback => $callback,
-    );
-    return 1;
+    Genome::Sys::CommitAction->create( on_commit => $callback );
 }
 
 # Returns a closure that creates a directory at the given path

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -279,12 +279,9 @@ sub _remove_per_lane_bam_post_commit {
     my ($self, $alignment) = @_;
 
     unless ($ENV{UR_DBI_NO_COMMIT}) {
-        $self->debug_message("Now removing the per lane bam");
-
-        UR::Context->process->add_observer(
-            aspect => 'commit',
-            once => 1,
-            callback => sub {
+        Genome::Sys::CommitAction->create(
+            on_commit => sub {
+                $self->debug_message("Now removing the per lane bam");
                 $alignment->remove_bam;
             }
         );

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -620,9 +620,8 @@ sub delete {
         $input->delete;
     }
 
-    my $observer;
-    $observer = Genome::Sys::CommitAction->create(
-        on_commit => $self->_disk_allocation_cleanup_closure(\$observer)
+    my $observer = Genome::Sys::CommitAction->create(
+        on_commit => $self->_disk_allocation_cleanup_closure()
     );
     if ($observer) {
         $self->status_message("Registered observer to delete disk allocation " .

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -620,7 +620,8 @@ sub delete {
         $input->delete;
     }
 
-    my $observer = Genome::Sys::CommitAction->create(
+    my $observer;
+    $observer = Genome::Sys::CommitAction->create(
         on_commit => $self->_disk_allocation_cleanup_closure(\$observer)
     );
     if ($observer) {

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -620,9 +620,9 @@ sub delete {
         $input->delete;
     }
 
-    my $observer;
-    $observer = UR::Context->current->add_observer(aspect=>'commit',
-        callback=>$self->_disk_allocation_cleanup_closure(\$observer));
+    my $observer = Genome::Sys::CommitAction->create(
+        on_commit => $self->_disk_allocation_cleanup_closure(\$observer)
+    );
     if ($observer) {
         $self->status_message("Registered observer to delete disk allocation " .
             "(%s) upon commit", $self->disk_allocation_id);

--- a/lib/perl/Genome/Process/Command/Run.pm
+++ b/lib/perl/Genome/Process/Command/Run.pm
@@ -187,9 +187,8 @@ sub _ensure_bresume_if_commit {
     my $self = shift;
     my $job_id = shift;
 
-    my $commit_observer = UR::Context->process->add_observer(
-        aspect => 'commit',
-        callback => sub {
+    my $commit_observer = Genome::Sys::CommitAction->create(
+        on_commit => sub {
             my $bresume_output = `bresume $job_id`; chomp $bresume_output;
             $self->error_message($bresume_output) unless ( $bresume_output =~ /^Job <$job_id> is being resumed$/ );
         },

--- a/lib/perl/Genome/Site/TGI/CaptureSet/Command/Synchronize.pm
+++ b/lib/perl/Genome/Site/TGI/CaptureSet/Command/Synchronize.pm
@@ -74,9 +74,8 @@ sub execute {
         return;
     }
 
-    UR::Context->current->add_observer(
-        aspect => 'commit',
-        callback => sub{
+    Genome::Sys::CommitAction->create(
+        on_commit => sub{
             $lock->unlock();
         }
     );

--- a/lib/perl/Genome/SoftwareResult.pm
+++ b/lib/perl/Genome/SoftwareResult.pm
@@ -777,10 +777,8 @@ sub delete {
 
     #creating an anonymous sub to delete allocations when commit happens
     my $id = $self->id;
-    my $observer;
     my $upon_delete_callback = sub {
         print "Now Deleting Allocation with owner_id = $id\n";
-        $observer->delete if $observer;
         my $allocation = Genome::Disk::Allocation->get(owner_id=>$id, owner_class_name=>$class_name);
         if ($allocation) {
             $allocation->deallocate;

--- a/lib/perl/Genome/SoftwareResult.pm
+++ b/lib/perl/Genome/SoftwareResult.pm
@@ -788,7 +788,7 @@ sub delete {
     };
 
     #hook our anonymous sub into the commit callback
-    $observer = $class_name->ghost_class->add_observer(aspect=>'commit', callback=>$upon_delete_callback);
+    Genome::Sys::CommitAction->create( on_commit => $upon_delete_callback );
 
     return $self->SUPER::delete(@_);
 }

--- a/lib/perl/Genome/Sys/CommitAction.pm
+++ b/lib/perl/Genome/Sys/CommitAction.pm
@@ -60,7 +60,7 @@ Genome::Sys::CommitAction - Schedule code to run at commit time
 =head1 DESCRIPTION
 
 This class provides a mechanism to schedule some code to run later when
-changed data is being saved to the database.  The callbacks are only when
+changed data is being saved to the database.  The callbacks are run only when
 the base, Process context is being committed, not when a software transaction
 is committed.  Callbacks are only run once, even if the Process context is
 committed multiple times.
@@ -80,6 +80,16 @@ all their C<con_sync> callbacks may run again, if the original Context commit
 exception is caught and it tries to commit again.  Note that C<on_sync_fail>
 callbacks are _not_ run when the context is rolled back with
 UR::Context->rollback
+
+Also note that if the C<con_sync> or C<on_commit> callbacks change the program
+state by creating, deleting or changing objects, those changes will not be
+saved during the commit() the callbacks are running in; they will be saved
+during the next commit.  The reason being that all the changes are collected
+before any saving and committing is done.  Changes that happen during these
+callbacks will have happened too late to make it into this list.  In
+particular, this behavior differs from a C<precommit> callback on the Context
+in that precommit callbacks run before the list of changes is collected.
+
 
 =head1 SEE ALSO
 

--- a/lib/perl/Genome/Sys/CommitAction.pm
+++ b/lib/perl/Genome/Sys/CommitAction.pm
@@ -37,6 +37,12 @@ sub _run {
     }
 }
 
+# These are never loaded, only created
+sub __load__ {
+    my($class, $bx, $headers) = @_;
+    return($headers, []);
+}
+
 1;
 
 __END__

--- a/lib/perl/Genome/Sys/CommitAction.pm
+++ b/lib/perl/Genome/Sys/CommitAction.pm
@@ -8,6 +8,7 @@ class Genome::Sys::CommitAction {
         on_sync     => { is => 'CODE', doc => 'Callback to run when data is saved to the data sources' },
         on_commit   => { is => 'CODE', doc => 'Callback to run when data sources are committed' },
         on_sync_fail => { is => 'CODE', doc => 'Callback to run when other on_sync callbacks have failed' },
+        data => { doc => 'A piece of data passed to the callbacks' },
     ],
     data_source => 'UR::DataSource::Default',
     id_generator => sub { ++$sequence },
@@ -32,7 +33,7 @@ sub __rollback__ {
 sub _run {
     my($self, $which) = @_;
     if (my $cb = $self->$which) {
-        $cb->();
+        $cb->($self->data);
     }
 }
 
@@ -79,7 +80,10 @@ throws an exception.  CommitActions are then considered live again, and
 all their C<con_sync> callbacks may run again, if the original Context commit
 exception is caught and it tries to commit again.  Note that C<on_sync_fail>
 callbacks are _not_ run when the context is rolled back with
-UR::Context->rollback
+UR::Context->rollback.
+
+The callbacks are passed a single argument, whatever is stored in the
+CommitAction's 'data' attribute.
 
 Also note that if the C<con_sync> or C<on_commit> callbacks change the program
 state by creating, deleting or changing objects, those changes will not be

--- a/lib/perl/Genome/Sys/CommitAction.pm
+++ b/lib/perl/Genome/Sys/CommitAction.pm
@@ -21,6 +21,7 @@ sub __save__ {
 sub __commit__ {
     my $self = shift;
     $self->_run('on_commit');
+    $self->delete();
 }
 
 sub __rollback__ {

--- a/lib/perl/Genome/Sys/CommitAction.pm
+++ b/lib/perl/Genome/Sys/CommitAction.pm
@@ -1,0 +1,87 @@
+package Genome::Sys::CommitAction;
+
+use Genome;
+
+my $sequence = 0;
+class Genome::Sys::CommitAction {
+    has_optional => [
+        on_sync     => { is => 'CODE', doc => 'Callback to run when data is saved to the data sources' },
+        on_commit   => { is => 'CODE', doc => 'Callback to run when data sources are committed' },
+        on_sync_fail => { is => 'CODE', doc => 'Callback to run when other on_sync callbacks have failed' },
+    ],
+    data_source => 'UR::DataSource::Default',
+    id_generator => sub { ++$sequence },
+};
+
+sub __save__ {
+    my $self = shift;
+    $self->_run('on_sync');
+}
+
+sub __commit__ {
+    my $self = shift;
+    $self->_run('on_commit');
+}
+
+sub __rollback__ {
+    my $self = shift;
+    $self->_run('on_sync_fail');
+}
+
+sub _run {
+    my($self, $which) = @_;
+    if (my $cb = $self->$which) {
+        $cb->();
+    }
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Genome::Sys::CommitAction - Schedule code to run at commit time
+
+=head1 SYNOPSIS
+
+  Genome::Sys::CommitAction->create(
+      on_sync => sub { write_temp_file($temp_file) },
+      on_commit => sub { rename $temp_file, $permanent_name }
+      on_sync_fail => sub { log_message("Commit failed, left temp file $temp_file") }
+  );
+
+  # Later on...
+  UR::Context->commit(); # on_commit sub runs here, when data sources are committed
+
+=head1 DESCRIPTION
+
+This class provides a mechanism to schedule some code to run later when
+changed data is being saved to the database.  The callbacks are only when
+the base, Process context is being committed, not when a software transaction
+is committed.  Callbacks are only run once, even if the Process context is
+committed multiple times.
+
+There are two phases to committing saved data.  First, all changed data is
+saved to the appropriate data source (colloquially called sync_database).
+After all data is saved, each data soruce is asked to commit the changes.
+If any data fails to save during sync_database, all data sources are asked
+to rollback.
+
+For these CommitAction objects, their C<on_sync> callback is run during
+sync_database, C<on_commit> is run during commit.
+
+The C<on_sync_fail> callback is only run when a subsequent C<on_sync> callback
+throws an exception.  CommitActions are then considered live again, and
+all their C<con_sync> callbacks may run again, if the original Context commit
+exception is caught and it tries to commit again.  Note that C<on_sync_fail>
+callbacks are _not_ run when the context is rolled back with
+UR::Context->rollback
+
+=head1 SEE ALSO
+
+L<UR::Context>
+
+=cut

--- a/lib/perl/Genome/Sys/CommitAction.pm
+++ b/lib/perl/Genome/Sys/CommitAction.pm
@@ -84,13 +84,13 @@ Genome::Sys::CommitAction - Schedule code to run at commit time
 
 This class provides a mechanism to schedule some code to run later when
 changed data is being saved to the database.  The callbacks are run only when
-the base, Process context is being committed or rolled-back, not when a
+the base Process context is being committed or rolled-back, not when a
 software transaction is committed/rolled-back.  Callbacks are only run once,
 even if the Process context is committed or rolled-back multiple times.
 
 There are two phases to committing saved data.  First, all changed data is
 saved to the appropriate data source (colloquially called sync_database).
-After all data is saved, each data soruce is asked to commit the changes.
+After all data is saved, each data source is asked to commit the changes.
 If any data fails to save during sync_database, all data sources are asked
 to rollback.
 
@@ -117,6 +117,9 @@ callbacks will have happened too late to make it into this list.  In
 particular, this behavior differs from a C<precommit> callback on the Context
 in that precommit callbacks run before the list of changes is collected.
 
+Finally, these actions are implemented by creating ordinary UR Objects.  That
+means if a CommitAction is created within a software transaction, it will
+be deleted without running its callbacks if that transaction is rolled back.
 
 =head1 SEE ALSO
 

--- a/lib/perl/Genome/Sys/CommitAction.t
+++ b/lib/perl/Genome/Sys/CommitAction.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use above 'Genome';
-use Test::More tests => 2;
+use Test::More tests => 3;
 use Test::Exception;
 
 subtest basic => sub {
@@ -37,20 +37,24 @@ subtest basic => sub {
     is(scalar(@actions), 0, 'No CommitActions left in memory');
 };
 
-subtest rollback => sub {
-    plan tests => 8;
+subtest 'lifecycle' => sub {
+    plan tests => 15;
 
-    my($sync_called, $commit_called, $sync_failed_called) = (0,0,0);
+    my($sync_called, $commit_called, $sync_failed_called, $rollback_called) = (0,0,0,0);
 
     my $action1 = Genome::Sys::CommitAction->create(
                     on_sync => sub { $sync_called++; die "in on_sync\n"; },
                     on_commit => sub { $commit_called++ },
                     on_sync_fail => sub { $sync_failed_called++ },
+                    on_rollback => sub { $rollback_called++ },
                 );
     ok($action1, 'Created Genome::Sys::CommitAction');
 
     my $action2 = Genome::Sys::CommitAction->create(
-                    on_sync => sub { 1 },
+                    on_sync => sub { $sync_called++ },
+                    on_commit => sub { $commit_called++ },
+                    on_sync_fail => sub { $sync_failed_called++ },
+                    on_rollback => sub { $rollback_called++ },
                   );
     ok($action2, 'Created second CommitAction');
 
@@ -58,10 +62,36 @@ subtest rollback => sub {
               qr/in on_sync/,
               'exception in on_sync';
 
-    is($sync_called, 1, 'on_sync callback not run');
     is($commit_called, 0, 'on_commit callback not run');
-    is($sync_failed_called, 1, 'on_sync_fail callback was run');
+    ok($sync_failed_called > 1, 'on_sync_fail callback was run');
+    is($rollback_called, 0, 'on_rollback was not run');
 
-    isa_ok($action1, 'Genome::Sys::CommitAction', 'First action is a Genome::Sys::CommitAction');
-    isa_ok($action2, 'Genome::Sys::CommitAction', 'Second action is a Genome::Sys::CommitAction');
+    isa_ok($action1, 'Genome::Sys::CommitAction', 'First action');
+    isa_ok($action2, 'Genome::Sys::CommitAction', 'Second action');
+
+
+    ($sync_called, $commit_called, $sync_failed_called, $rollback_called) = (0,0,0,0);
+    $action1->on_sync( sub { $sync_called++ });
+    ok(UR::Context->commit(), 'commit');
+    is($sync_called, 2, 'on_sync called twice');
+    is($commit_called, 2, 'on_commit called twice');
+    is($sync_failed_called, 0, 'on_sync_failed was not run');
+    is($rollback_called, 0, 'on_rollback was not run');
+    isa_ok($action1, 'UR::DeletedRef', 'First action');
+    isa_ok($action2, 'UR::DeletedRef', 'Second action');
+};
+
+subtest 'rollback' => sub {
+    plan tests => 4;
+
+    my($sync_fail, $rollback) = (0,0);
+    my $action = Genome::Sys::CommitAction->create(
+                    on_sync_fail => sub { $sync_fail++ },
+                    on_rollback  => sub { $rollback++ },
+                );
+
+    ok(UR::Context->rollback, 'rollback');
+    is($rollback, 1, 'on_rollback called');
+    is($sync_fail, 0, 'on_sync_fail not called');
+    isa_ok($action, 'UR::DeletedRef');
 };

--- a/lib/perl/Genome/Sys/CommitAction.t
+++ b/lib/perl/Genome/Sys/CommitAction.t
@@ -8,13 +8,15 @@ use Test::More tests => 2;
 use Test::Exception;
 
 subtest basic => sub {
-    plan tests => 9;
+    plan tests => 11;
 
-    my($sync_called, $commit_called) = (0, 0);
+    my($sync_called, $commit_called, $sync_received_data, $commit_received_data) = (0, 0, undef);
+    my $passed_data = 'hi there';
 
     my $action = Genome::Sys::CommitAction->create(
-                    on_sync => sub { $sync_called++ },
-                    on_commit => sub { $commit_called++ },
+                    on_sync => sub { $sync_called++; $sync_received_data = shift; },
+                    on_commit => sub { $commit_called++; $commit_received_data = shift; },
+                    data => $passed_data,
                 );
     ok($action, 'Created Genome::Sys::CommitAction');
 
@@ -22,6 +24,8 @@ subtest basic => sub {
 
     is($sync_called, 1, 'on_sync callback run');
     is($commit_called, 1, 'on_commit_callback run');
+    is($sync_received_data, $passed_data, 'callback got data');
+    is($commit_received_data, $passed_data, 'callback got data');
 
     ok(UR::Context->commit(), 'commit again');
 

--- a/lib/perl/Genome/Sys/CommitAction.t
+++ b/lib/perl/Genome/Sys/CommitAction.t
@@ -8,7 +8,7 @@ use Test::More tests => 2;
 use Test::Exception;
 
 subtest basic => sub {
-    plan tests => 7;
+    plan tests => 9;
 
     my($sync_called, $commit_called) = (0, 0);
 
@@ -27,19 +27,28 @@ subtest basic => sub {
 
     is($sync_called, 1, 'on_sync callback was not run again');
     is($commit_called, 1, 'on_commit_callback was not run again');
+
+    isa_ok($action, 'UR::DeletedRef', 'CommitAction is deleted');
+    my @actions = Genome::Sys::CommitAction->is_loaded();
+    is(scalar(@actions), 0, 'No CommitActions left in memory');
 };
 
 subtest rollback => sub {
-    plan tests => 5;
+    plan tests => 8;
 
     my($sync_called, $commit_called, $sync_failed_called) = (0,0,0);
 
-    my $action = Genome::Sys::CommitAction->create(
+    my $action1 = Genome::Sys::CommitAction->create(
                     on_sync => sub { $sync_called++; die "in on_sync\n"; },
                     on_commit => sub { $commit_called++ },
                     on_sync_fail => sub { $sync_failed_called++ },
                 );
-    ok($action, 'Created Genome::Sys::CommitAction');
+    ok($action1, 'Created Genome::Sys::CommitAction');
+
+    my $action2 = Genome::Sys::CommitAction->create(
+                    on_sync => sub { 1 },
+                  );
+    ok($action2, 'Created second CommitAction');
 
     throws_ok { UR::Context->commit() }
               qr/in on_sync/,
@@ -48,4 +57,7 @@ subtest rollback => sub {
     is($sync_called, 1, 'on_sync callback not run');
     is($commit_called, 0, 'on_commit callback not run');
     is($sync_failed_called, 1, 'on_sync_fail callback was run');
+
+    isa_ok($action1, 'Genome::Sys::CommitAction', 'First action is a Genome::Sys::CommitAction');
+    isa_ok($action2, 'Genome::Sys::CommitAction', 'Second action is a Genome::Sys::CommitAction');
 };

--- a/lib/perl/Genome/Sys/CommitAction.t
+++ b/lib/perl/Genome/Sys/CommitAction.t
@@ -1,0 +1,51 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+use above 'Genome';
+use Test::More tests => 2;
+use Test::Exception;
+
+subtest basic => sub {
+    plan tests => 7;
+
+    my($sync_called, $commit_called) = (0, 0);
+
+    my $action = Genome::Sys::CommitAction->create(
+                    on_sync => sub { $sync_called++ },
+                    on_commit => sub { $commit_called++ },
+                );
+    ok($action, 'Created Genome::Sys::CommitAction');
+
+    ok(UR::Context->commit(), 'commit');
+
+    is($sync_called, 1, 'on_sync callback run');
+    is($commit_called, 1, 'on_commit_callback run');
+
+    ok(UR::Context->commit(), 'commit again');
+
+    is($sync_called, 1, 'on_sync callback was not run again');
+    is($commit_called, 1, 'on_commit_callback was not run again');
+};
+
+subtest rollback => sub {
+    plan tests => 5;
+
+    my($sync_called, $commit_called, $sync_failed_called) = (0,0,0);
+
+    my $action = Genome::Sys::CommitAction->create(
+                    on_sync => sub { $sync_called++; die "in on_sync\n"; },
+                    on_commit => sub { $commit_called++ },
+                    on_sync_fail => sub { $sync_failed_called++ },
+                );
+    ok($action, 'Created Genome::Sys::CommitAction');
+
+    throws_ok { UR::Context->commit() }
+              qr/in on_sync/,
+              'exception in on_sync';
+
+    is($sync_called, 1, 'on_sync callback not run');
+    is($commit_called, 0, 'on_commit callback not run');
+    is($sync_failed_called, 1, 'on_sync_fail callback was run');
+};

--- a/lib/perl/Genome/Utility/ObjectWithAllocations.pm
+++ b/lib/perl/Genome/Utility/ObjectWithAllocations.pm
@@ -31,16 +31,10 @@ sub _create_deallocate_disk_allocations_observer {
     my @disk_allocations = $self->disk_allocations;
     return 1 if not @disk_allocations;
 
-    my $deallocator;
-    $deallocator = sub {
-        _deallocate_disk_allocations(@disk_allocations);
-        UR::Context->cancel_change_subscription(
-            'commit', $deallocator
-        );
-    };
-    UR::Context->add_observer(
-        aspect => 'commit',
-        callback => $deallocator
+    Genome::Sys::CommitAction->create(
+        on_commit => sub {
+            _deallocate_disk_allocations(@disk_allocations);
+        },
     );
 
     return 1;

--- a/lib/perl/Genome/Utility/ObjectWithLockedConstruction.pm
+++ b/lib/perl/Genome/Utility/ObjectWithLockedConstruction.pm
@@ -42,9 +42,8 @@ sub create_with_lock {
         return $obj;
     } else {
        $obj = $class->SUPER::create(@_);
-       UR::Context->current->add_observer(
-           aspect => 'commit',
-           callback => sub {
+       Genome::Sys::CommitAction->create(
+           on_commit => sub {
                $lock->unlock();
            }
        );


### PR DESCRIPTION
This branch implements an alternative API for registering callbacks to run then the base Context commits or rolls-back intended to have fewer gotchas than using Context observers:
* They only ever fire when the base Process context is saving to data sources, never for software transactions
* They only ever fire once (except during a failure in sync_database - discussed in the docs)
* commit/rollback callbacks may by grouped together and only one of them will fire