### PR TITLE
Remove newly created disk allocations when exiting genome-env

### DIFF
--- a/bin/genome-env
+++ b/bin/genome-env
@@ -148,7 +148,7 @@ function main {
 
     if test -z "$DISABLE_DB" -a -z "$PERSIST_DB"
     then
-        test-db delete database $TESTDBSERVER_DB_NAME > /dev/null
+        cleanup_test_db
     fi
     exit $EXIT
 }
@@ -488,6 +488,14 @@ function setup_test_db {
             fi
         )
     fi
+}
+
+# cleanup_test_db reverses setup_test_db by deleting any new disk allocations
+# from the test database, then deletes the test database
+function cleanup_test_db {
+    echo "=> Removing disk allocations created during $THIS..."
+    genome model admin remove-disk-allocations-from-testdb
+    test-db delete database $TESTDBSERVER_DB_NAME > /dev/null
 }
 
 # assert_module_missing only works with single word module names, e.g. UR, Workflow, and Genome.


### PR DESCRIPTION
Before the test database is deleted, remove any allocations created during
this invocation of genome-env