### PR TITLE
New method get_superseding_results added to Merged.pm

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -744,28 +744,28 @@ sub estimated_gtmp_for_instrument_data  {
 sub get_superseding_results {
     my $self = shift;
 
-    my @ars  = $self->collect_individual_alignments;
-    my $ars  = Set::Scalar->new(@ars);
+    my @per_lane_results = $self->collect_individual_alignments;
+    my $per_lane_results = Set::Scalar->new(@per_lane_results);
     
-    my %ct;
-    my @founds = ();
+    my %count;
+    my @superseding_results = ();
 
-    for my $ar (@ars) {
-        map{$ct{$_->id}++}$ar->get_merged_alignment_results;
+    for my $per_lane_result (@per_lane_results) {
+        map{$count{$_->id}++}$per_lane_result->get_merged_alignment_results;
     }
 
-    for my $supmr_id (keys %ct) {
-        next unless $ct{$supmr_id} == $ars->size;
-        next if $supmr_id eq $self->id;
+    for my $merged_result_id (keys %count) {
+        next unless $count{$merged_result_id} == $per_lane_results->size;
+        next if $merged_result_id eq $self->id;
 
-        my $supmr  = __PACKAGE__->get($supmr_id);
-        my $supars = Set::Scalar->new($supmr->collect_individual_alignments);
+        my $superseding_result = __PACKAGE__->get($merged_result_id);
+        my $superseding_per_lane_results = Set::Scalar->new($superseding_result->collect_individual_alignments);
         
-        if ($supars->is_proper_superset($ars)) {
-            push @founds, $supmr;
+        if ($superseding_per_lane_results->is_proper_superset($per_lane_results)) {
+            push @superseding_results, $superseding_result;
         }
     }
-    return @founds;
+    return @superseding_results;
 }
 
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -9,6 +9,7 @@ use File::Path 'rmtree';
 use List::MoreUtils qw{ uniq };
 use List::Util qw(shuffle);
 use Try::Tiny qw(try catch finally);
+use Set::Scalar;
 
 use Genome;
 use Genome::Utility::Text; #quiet warning about deprecated use of autoload
@@ -738,5 +739,42 @@ sub estimated_gtmp_for_instrument_data  {
         $class
     );
 }
+
+
+sub get_superseding_results {
+    my $self = shift;
+
+    my @ars  = $self->collect_individual_alignments;
+    my $ars  = Set::Scalar->new(@ars);
+    
+    my %ct;
+    my @founds = ();
+
+    for my $ar (@ars) {
+        my @sup_mrs = $ar->get_merged_alignment_results;
+        for my $sup_mr (@sup_mrs) {
+            if ($ct{$sup_mr->id}) {
+                $ct{$sup_mr->id}++;
+            }
+            else {
+                $ct{$sup_mr->id} = 1;
+            }
+        }
+    }
+
+    for my $supmr_id (keys %ct) {
+        next unless $ct{$supmr_id} == $ars->size;
+        next if $supmr_id eq $self->id;
+
+        my $supmr  = __PACKAGE__->get($supmr_id);
+        my $supars = Set::Scalar->new($supmr->collect_individual_alignments);
+        
+        if ($supars->is_proper_superset($ars)) {
+            push @founds, $supmr;
+        }
+    }
+    return @founds;
+}
+
 
 1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -751,15 +751,7 @@ sub get_superseding_results {
     my @founds = ();
 
     for my $ar (@ars) {
-        my @sup_mrs = $ar->get_merged_alignment_results;
-        for my $sup_mr (@sup_mrs) {
-            if ($ct{$sup_mr->id}) {
-                $ct{$sup_mr->id}++;
-            }
-            else {
-                $ct{$sup_mr->id} = 1;
-            }
-        }
+        map{$ct{$_->id}++}$ar->get_merged_alignment_results;
     }
 
     for my $supmr_id (keys %ct) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.t
@@ -70,7 +70,7 @@ ok(dircopy($expected_shortcut_path, $tmp_shortcut_path2), 'Copied expected dir t
 my @instrument_data    = generate_fake_instrument_data();
 my @individual_results = generate_individual_alignment_results(@instrument_data);
 
-my @params = (
+my %parameters = (
      aligner_name                => $aligner_name,
      aligner_version             => $aligner_version,
      samtools_version            => $samtools_version,
@@ -85,8 +85,10 @@ my @params = (
      instrument_data_segment     => [map {$_->id . ':A:2:read_group'} @instrument_data],
 );
 
-my $merged_alignment_result = $pkg->create(@params, _user_data_for_nested_results => $result_users);
+my $merged_alignment_result = $pkg->create(%parameters, _user_data_for_nested_results => $result_users);
 isa_ok($merged_alignment_result, $pkg, 'produced merged alignment result');
+
+
 
 subtest 'testing merge without filter_name' => sub {
     compare_ok($merged_alignment_result->bam_file, File::Spec->join($expected_dir, '-120573001.bam'),
@@ -118,17 +120,17 @@ subtest 'testing merge without filter_name' => sub {
         }
     }
 
-    my $existing_alignment_result = $pkg->get_or_create(@params, users => $result_users);
+    my $existing_alignment_result = $pkg->get_or_create(%parameters, users => $result_users);
     is($existing_alignment_result, $merged_alignment_result, 'got back the previously created result');
 };
 
 subtest 'testing merge with filter_name' => sub {
     my @filtered_params = (
-        @params,
+        %parameters,
         filter_name => [$instrument_data[0]->id . ':forward-only', $instrument_data[1]->id . ':forward-only'],
     );
 
-    my $existing_alignment_result = $pkg->get_or_create(@params, users => $result_users);
+    my $existing_alignment_result = $pkg->get_or_create(%parameters, users => $result_users);
     is($existing_alignment_result, $merged_alignment_result, 'got back the previously created result');
 
 
@@ -153,13 +155,13 @@ subtest 'testing merge with filter_name' => sub {
 
     is($existing_filtered_alignment_result, $filtered_alignment_result, 'got back the previously created filtered result');
 
-    my $gotten_alignment_result = $pkg->get_with_lock(@params, users => $result_users);
+    my $gotten_alignment_result = $pkg->get_with_lock(%parameters, users => $result_users);
     is($gotten_alignment_result, $existing_alignment_result, 'using get returns same result as get_or_create');
 };
 
 subtest 'testing invalid merged alignment' => sub {
     my @segmented_params = (
-        @params,
+        %parameters,
         instrument_data_segment => [$instrument_data[0]->id . ':test:read_group', $instrument_data[0]->id . ':test2:read_group'],
     );
 
@@ -170,7 +172,27 @@ subtest 'testing invalid merged alignment' => sub {
     like($error, qr/Failed to find individual alignments for all instrument_data/, 'failed for expected reason');
 };
 
+
+subtest 'testing supersede merged alignment' => sub {
+    #need recopy bam back to ar output dir since it was removed after merge
+    for my $type ('', '.bai') {
+        my $ar_base = 'all_sequences.bam'.$type;
+        my $ar_file = File::Spec->join($tmp_shortcut_path1, 0, $ar_base);
+        Genome::Sys->copy_file(File::Spec->join($expected_shortcut_path, 0, $ar_base), $ar_file);
+        ok(-s $ar_file, "$ar_base copied over ok");
+    }
+
+    $parameters{instrument_data_id} = [$instrument_data[0]->id];
+    my $small_merged_alignment_result = $pkg->create(%parameters, _user_data_for_nested_results => $result_users);
+    isa_ok($small_merged_alignment_result, $pkg, 'produced small merged alignment result');
+
+    # We need to override this because get_merged_alignment_results only returns objects in the database. 
+    Sub::Install::install_sub({code => sub { my $self = shift; return @_; }, into => 'Genome::InstrumentData::AlignmentResult', as => 'filter_non_database_objects'});
+    is_deeply([$small_merged_alignment_result->get_superseding_results], [$merged_alignment_result], 'Got supersede merged alignment for small merged alignment');
+};
+
 done_testing();
+
 
 sub generate_individual_alignment_results {
     my @instrument_data = @_;


### PR DESCRIPTION
This new method will get superseding results for a given merged result. Refer to https://jira.gsc.wustl.edu/browse/APIPE-3231.