### PR TITLE
CQID processes data batched by sample

### DIFF
--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -346,50 +346,22 @@ sub _get_items_to_process {
 sub _ordered_sample_id_iterator {
     my $self = shift;
 
-    if(!defined UR::Context->query_underlying_context or UR::Context->query_underlying_context) {
-        my $dbh = Genome::Sample->__meta__->data_source->get_default_handle;
-        my $sth = $dbh->prepare(q{
-            SELECT sample.subject_id
-            FROM subject.subject sample
-            INNER JOIN instrument.fragment_library library ON library.sample_id = sample.subject_id
-            INNER JOIN instrument.data id ON id.library_id = library.library_id
-            INNER JOIN config.instrument_data_analysis_project_bridge bridge ON bridge.instrument_data_id = id.id
-            INNER JOIN config.analysis_project anp ON bridge.analysis_project_id = anp.id
-            WHERE anp.status = 'In Progress'
-            AND bridge.status IN ('new', 'failed')
-            GROUP BY sample.subject_id
-            ORDER BY SUM(bridge.fail_count) ASC;
-        });
+    my $it = Genome::Config::AnalysisProject::InstrumentDataBridge->create_iterator(
+        status => ['new', 'failed'],
+        'analysis_project.status' => 'In Progress',
+        -order => ['fail_count'],
+        -hint => ['analysis_project', 'instrument_data', 'instrument_data.sample'],
+    );
 
-        $sth->execute;
-        return sub {
-            my $next_value = $sth->fetchrow_arrayref;
-            unless($next_value) {
-                if(my $error = $sth->err) {
-                    die $self->error_message('Error loading samples: %s', $error);
-                } else {
-                    return;
-                }
-            }
-
-            return $next_value->[0];
-        };
-    } else {
-        my @all_bridges = Genome::Config::AnalysisProject::InstrumentDataBridge->get(
-            status => ['new', 'failed'],
-            'analysis_project.status' => 'In Progress',
-            -hint => ['analysis_project', 'instrument_data', 'instrument_data.sample'],
-        );
-        my %sample_fail_counts;
-        for my $bridge (@all_bridges) {
-            $sample_fail_counts{$bridge->instrument_data->sample_id} += $bridge->fail_count;
+    my %subjects_seen;
+    return sub {
+        while(my $bridge = $it->next) {
+            my $subject_id = $bridge->instrument_data->sample_id;
+            next if $subjects_seen{$subject_id}++;
+            return $subject_id;
         }
-
-        my @ordered_sample_ids = sort { $sample_fail_counts{$a} <=> $sample_fail_counts{$b} } keys %sample_fail_counts;
-        return sub {
-            return shift @ordered_sample_ids;
-        };
-    }
+        return;
+    };
 }
 
 sub _assign_model_to_analysis_project {

--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.t
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.t
@@ -331,7 +331,7 @@ sub _rna_seq_config_hash {
 
 my $som_val_project;
 sub _generate_som_val_instrument_data {
-    $som_val_project ||= Genome::Project->create(name => sprintf('test %s %s',  __FILE__));
+    $som_val_project ||= Genome::Project->create(name => sprintf('test %s %s', $$, __FILE__));
 
     my $sample_1 = Genome::Test::Factory::Sample->setup_object(
         extraction_type => 'genomic_dna',

--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.t
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.t
@@ -26,6 +26,42 @@ use warnings;
 my $class = 'Genome::Config::Command::ConfigureQueuedInstrumentData';
 use_ok($class);
 
+subtest '_get_items_to_process respects limits' => sub {
+    #this test must be first before other in-memory objects have been created!
+
+    my (undef, undef, undef, $anp) = _generate_som_val_instrument_data();
+    my @bridges = $anp->analysis_project_bridges;
+    is(scalar(@bridges), 2, 'created expected bridges');
+    $bridges[1]->fail_count(1);
+
+    my @sample_ids = map $_->instrument_data->sample_id, @bridges;
+
+    my $cmd = $class->create(limit => 1);
+    isa_ok($cmd, $class, 'created CQID command');
+
+    #avoid finding production objects
+    my $original_quc = UR::Context->query_underlying_context();
+    UR::Context->query_underlying_context(0);
+
+    my @items = $cmd->_get_items_to_process();
+    is(scalar(@items), 1, 'found one item');
+    is($items[0], $bridges[0], 'found the item with the lowest fail count');
+
+    $bridges[0]->fail_count(2);
+
+    @items = $cmd->_get_items_to_process();
+    is(scalar(@items), 1, 'found one item again');
+    is($items[0], $bridges[1], 'still found the item with the lowest fail count');
+
+    $cmd->limit(5);
+    @items = $cmd->_get_items_to_process();
+    is(scalar(@items), 2, 'found both items');
+
+    done_testing();
+    UR::Context->query_underlying_context($original_quc);
+    map $_->delete, @bridges; #reset for future tests
+};
+
 #new model
 my ($rna_instrument_data, $model_types) = generate_rna_seq_instrument_data();
 build_and_run_cmd($rna_instrument_data);


### PR DESCRIPTION
In order to reduce the creation of builds that are nearly immediately superseded, this processes all available data for a sample in a single CQID run.

* This may run over the `limit` parameter, since otherwise it's possible to have a sample that will never be processed.  This version is pretty tolerant of going over, but it could be made more strict (e.g. only accepting a larger sample batch if nothing else is going to be processed) if that seems better.
* There's SQL added that is not covered by the `.t`.  It looked like it was working when I tried it manually, but it probably warrants extra attention in review!
