### PR TITLE
Return analysis ID but join on seq ID.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/InstrumentDataAnalysisProjectBridge.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/InstrumentDataAnalysisProjectBridge.pm
@@ -14,15 +14,15 @@ class Genome::Site::TGI::Synchronize::Classes::InstrumentDataAnalysisProjectBrid
         swo.analysis_project_id
     FROM
     (
-        SELECT to_char(i.analysis_id) instrument_data_id FROM index_illumina i
+        SELECT to_char(i.seq_id) seq_id, to_char(i.analysis_id) instrument_data_id FROM index_illumina i
         UNION ALL
-        SELECT to_char(ri454.seq_id) instrument_data_id FROM region_index_454 ri454
+        SELECT to_char(ri454.seq_id) seq_id, to_char(ri454.seq_id) instrument_data_id FROM region_index_454 ri454
         UNION ALL
-        SELECT to_char(g.seq_id) instrument_data_id FROM external_genotyping g
+        SELECT to_char(g.seq_id) seq_id, to_char(g.seq_id) instrument_data_id FROM external_genotyping g
         UNION ALL
-        SELECT to_char(g.seq_id) instrument_data_id FROM illumina_genotyping g
+        SELECT to_char(g.seq_id) seq_id, to_char(g.seq_id) instrument_data_id FROM illumina_genotyping g
     ) x
-    LEFT JOIN GSC.woi_sequence_product wsp ON wsp.seq_id = x.instrument_data_id
+    LEFT JOIN GSC.woi_sequence_product wsp ON wsp.seq_id = x.seq_id
     LEFT JOIN work_order_item@oltp woi ON wsp.woi_id = woi.woi_id
     LEFT JOIN setup_work_order@oltp swo ON swo.setup_wo_id = woi.setup_wo_id
     WHERE swo.analysis_project_id IS NOT NULL


### PR DESCRIPTION
The "analysis ID" is only used to map to the Genome object for Illumina data.  Everywhere else the "seq ID" is used to refer to the object within the LIMS schema.