### PR TITLE
ModelSummary: "abandon" action should not be overridden by "rebuild" action

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
+++ b/lib/perl/Genome/Model/Command/Admin/ModelSummary.pm
@@ -179,7 +179,7 @@ sub generate_model_summary {
     if ($latest_build_status eq 'Disabled') {
         $action = 'abandon';
     }
-    if (!$latest_build && $model->build_requested){
+    elsif (!$latest_build && $model->build_requested){
         $action = 'none';
     }
     elsif (!$latest_build) {


### PR DESCRIPTION
(The rebuilds would fail to queue, anyway, since the models are disabled.)