### PR TITLE
add option to run on non-succeeded build

### DIFF
--- a/lib/perl/Genome/Model/Tools/Somatic/ProcessSomaticVariation.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/ProcessSomaticVariation.pm
@@ -159,7 +159,13 @@ class Genome::Model::Tools::Somatic::ProcessSomaticVariation {
           default => "4",
       },
 
-
+      force_use_latest_build => {
+          is => 'Boolean',
+          is_optional => 1,
+          doc => "Use the latest build on this model, even if it's unsuccessful or still running",
+          default => 0,
+      },
+      
       ],
 };
 
@@ -634,7 +640,16 @@ sub execute {
   my $build = $model->last_succeeded_build;
   unless( defined($build) ){
       $self->error_message("Model %s has no succeeded builds",$model->id);
-      return undef;
+      if($self->force_use_latest_build){
+          $self->warning_message("--force-use-latest-build was set, so attempting to use build %s",$model->latest_build->id);
+          $build = $model->latest_build;
+          unless(defined($build)){
+              $self->error_message("Model %s has no latest build",$model->id);
+              return undef;
+          }
+      } else {
+          return undef;
+      }
   }
 
   my $tumor_build = $build->tumor_build;

--- a/lib/perl/Genome/Model/Tools/Somatic/ProcessSomaticVariation.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/ProcessSomaticVariation.pm
@@ -159,7 +159,7 @@ class Genome::Model::Tools::Somatic::ProcessSomaticVariation {
           default => "4",
       },
 
-      force_use_latest_build => {
+      fallback_to_latest_build => {
           is => 'Boolean',
           is_optional => 1,
           doc => "Use the latest build on this model, even if it's unsuccessful or still running",
@@ -640,8 +640,8 @@ sub execute {
   my $build = $model->last_succeeded_build;
   unless( defined($build) ){
       $self->error_message("Model %s has no succeeded builds",$model->id);
-      if($self->force_use_latest_build){
-          $self->warning_message("--force-use-latest-build was set, so attempting to use build %s",$model->latest_build->id);
+      if($self->fallback_to_latest_build){
+          $self->warning_message("--fallback-to-latest-build was set, so attempting to use build %s",$model->latest_build->id);
           $build = $model->latest_build;
           unless(defined($build)){
               $self->error_message("Model %s has no latest build",$model->id);


### PR DESCRIPTION
This is useful when a build crashes in the late stages, preventing create reports from running. Gives us an easy way to at least pull out SNVs and indels without waiting for a rebuild.