### PR TITLE
Create Gtf::Cat command before executing.

### DIFF
--- a/lib/perl/Genome/Model/Build/ImportedAnnotation.pm
+++ b/lib/perl/Genome/Model/Build/ImportedAnnotation.pm
@@ -850,7 +850,7 @@ sub generate_rRNA_MT_file {
         if ($squashed) {
             die('Support for squashed representations of GTF files is not supported!');
         }
-        my $cat = Genome::Model::Tools::Gtf::Cat->execute(
+        my $cat = Genome::Model::Tools::Gtf::Cat->create(
             input_files => \@input_files,
             output_file => $file_name,
             remove_originals => 0,


### PR DESCRIPTION
First create command before executing.  Calling execute twice results fatal error.