### PR TITLE
Use should_skip_run from Loh.pm to decide whether loh runs or not

### DIFF
--- a/lib/perl/Genome/Model/SomaticVariation/Command/IdentifyPreviouslyDiscoveredVariations.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/IdentifyPreviouslyDiscoveredVariations.pm
@@ -101,7 +101,7 @@ sub execute {
             $self->link_result_to_build($result);
         } elsif($snv_result) {
 
-            my $detected_snv_path = defined($build->loh_version) ? $build->data_set_path("loh/snvs.somatic",$version,'bed') : $build->data_set_path("variants/snvs.hq",$version,"bed"); 
+            my $detected_snv_path = Genome::Model::SomaticVariation::Command::Loh->should_skip_run($build) ? $build->data_set_path("variants/snvs.hq",$version,"bed") : $build->data_set_path("loh/snvs.somatic",$version,'bed'); 
             my $novel_detected_snv_path = $build->data_set_path("novel/snvs.hq.novel",$version,'bed');
             my $previously_detected_snv_path = $build->data_set_path("novel/snvs.hq.previously_detected",$version,'bed');
 
@@ -259,7 +259,7 @@ sub skip_run {
         $detected_path = $r->path($variant_type . '.hq.bed');
     } else {
         my $version = '2';
-        $detected_path = ($variant_type eq 'snv' && defined($build->loh_version)) ? $build->data_set_path("loh/snvs.somatic",$version,'bed') : $build->data_set_path("variants/" . $variant_type . "s.hq",$version,"bed");
+        $detected_path = ($variant_type eq 'snv' && !Genome::Model::SomaticVariation::Command::Loh->should_skip_run($build)) ? $build->data_set_path("loh/snvs.somatic",$version,'bed') : $build->data_set_path("variants/" . $variant_type . "s.hq",$version,"bed");
     }
     File::Copy::copy($detected_path, $novel);
     system("touch $previously_detected");
@@ -274,7 +274,7 @@ sub params_for_result {
     my $build = $self->build;
 
     my $prior_result;
-    if($variant_type eq 'snv' and $build->loh_version) {
+    if($variant_type eq 'snv' and !Genome::Model::SomaticVariation::Command::Loh->should_skip_run($build)) {
         my @results = $build->results;
         for my $r (@results) {
             if($r->class eq 'Genome::Model::Tools::DetectVariants2::Classify::Loh') {

--- a/lib/perl/Genome/Model/SomaticVariation/Command/Loh.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/Loh.pm
@@ -113,26 +113,26 @@ sub execute {
 }
 
 sub should_skip_run {
-    my $self = shift;
-    my $build = $self->build;
+    my ($class, $build) = @_;
+    $build = $class->build unless $build;
 
     unless ($build){
-        die $self->error_message("no build provided!");
+        die $class->error_message("no build provided!");
     }
 
     unless(defined($build->loh_version)){
-        $self->debug_message("No LOH version was found, skipping LOH detection!");
+        $class->debug_message("No LOH version was found, skipping LOH detection!");
         return 1;
     }
 
     unless(defined($build->model->snv_detection_strategy)){
-        $self->debug_message("No SNV Detection Strategy, skipping LOH.");
+        $class->debug_message("No SNV Detection Strategy, skipping LOH.");
         return 1;
     }
 
     my $normal_model = $build->normal_model;
     unless($normal_model->can('snv_detection_strategy') and $normal_model->snv_detection_strategy) {
-        $self->debug_message("No SNV Detection Strategy on normal model, skipping LOH.");
+        $class->debug_message("No SNV Detection Strategy on normal model, skipping LOH.");
         return 1;
     }
 

--- a/lib/perl/Genome/Model/SomaticVariation/Command/Loh.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/Loh.pm
@@ -45,7 +45,7 @@ class Genome::Model::SomaticVariation::Command::Loh {
 sub shortcut {
     my $self = shift;
 
-    return 1 if $self->should_skip_run;
+    return 1 if $self->should_skip_run($self->build);
 
     my @params = $self->_params_for_result;
     return unless @params;
@@ -62,7 +62,7 @@ sub execute {
     my $self = shift;
     my $build = $self->build;
 
-    return 1 if $self->should_skip_run;
+    return 1 if $self->should_skip_run($build);
 
     my $normal_build = $build->normal_build;
     unless ($normal_build){
@@ -114,7 +114,6 @@ sub execute {
 
 sub should_skip_run {
     my ($class, $build) = @_;
-    $build = $class->build unless $build;
 
     unless ($build){
         die $class->error_message("no build provided!");


### PR DESCRIPTION
Currently $build->loh_version is used to decide whether loh runs or not, which is not accurate. This PR is to fix the bug.