### PR TITLE
A superseding alignment's samples must match the samples of the alignment it supersedes.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -756,6 +756,10 @@ sub get_superseding_results {
         next if $merged_result_id eq $self->id;
 
         my $superseding_result = __PACKAGE__->get($merged_result_id);
+
+        my @samples = uniq map { $_->sample_id } $superseding_result->instrument_data;
+        next if @samples > 1;
+
         my $superseding_per_lane_results = Set::Scalar->new($superseding_result->collect_individual_alignments);
         
         if ($superseding_per_lane_results->is_proper_superset($per_lane_results)) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -290,7 +290,6 @@ sub _remove_per_lane_bam_post_commit {
     return 1;
 }
 
-    
 sub collect_individual_alignments {
     my $self = shift;
     my $result_users = shift || $self->_user_data_for_nested_results;
@@ -743,7 +742,7 @@ sub get_superseding_results {
 
     my @per_lane_results = $self->collect_individual_alignments;
     my $per_lane_results = Set::Scalar->new(@per_lane_results);
-    
+
     my %count;
     my @superseding_results = ();
 
@@ -765,7 +764,7 @@ sub get_superseding_results {
         next unless $sample_set->is_equal($superseding_sample_set);
 
         my $superseding_per_lane_results = Set::Scalar->new($superseding_result->collect_individual_alignments);
-        
+
         if ($superseding_per_lane_results->is_proper_superset($per_lane_results)) {
             push @superseding_results, $superseding_result;
         }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.pm
@@ -751,14 +751,18 @@ sub get_superseding_results {
         map{$count{$_->id}++}$per_lane_result->get_merged_alignment_results;
     }
 
+    my @sample_ids = uniq map { $_->sample_id } $self->instrument_data;
+    my $sample_set = Set::Scalar->new(@sample_ids);
+
     for my $merged_result_id (keys %count) {
         next unless $count{$merged_result_id} == $per_lane_results->size;
         next if $merged_result_id eq $self->id;
 
         my $superseding_result = __PACKAGE__->get($merged_result_id);
 
-        my @samples = uniq map { $_->sample_id } $superseding_result->instrument_data;
-        next if @samples > 1;
+        my @superseding_sample_ids = uniq map { $_->sample_id } $superseding_result->instrument_data;
+        my $superseding_sample_set = Set::Scalar->new(@superseding_sample_ids);
+        next unless $sample_set->is_equal($superseding_sample_set);
 
         my $superseding_per_lane_results = Set::Scalar->new($superseding_result->collect_individual_alignments);
         


### PR DESCRIPTION
We encountered a situation wherein a BAM was superseded by another that was a combination of data for 16 samples.  This led to the per-sample BAMs being removed.