### PR TITLE
evaluate-vcf takes a file rather than a build

### DIFF
--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.pm
@@ -16,8 +16,8 @@ class Genome::Model::Tools::Vcf::EvaluateVcf {
     is => "Command::V2",
     has_input => [
         reference => {
-            is => 'Genome::Model::Build::ReferenceSequence',
-            doc => 'a reference sequence of interest.',
+            is => 'Path',
+            doc => 'a reference sequence of interest (fasta).',
         },
 
         bedtools_version => {
@@ -233,12 +233,6 @@ sub vcflib_tool {
     return $path;
 }
 
-sub reference_path {
-    my $self = shift;
-    my $path = $self->reference->full_consensus_path('fa');
-    return $path;
-}
-
 sub _process_input_file {
     my ($self, $input_file, $output_file) = @_;
     my @cmds = (
@@ -246,7 +240,7 @@ sub _process_input_file {
         $self->restrict_to_sample_commands("/dev/stdin", $self->old_sample),
         $self->pass_only_commands("/dev/stdin", $self->pass_only_expression),
         $self->allelic_primitives_commands("/dev/stdin"),
-        $self->normalize_vcf_commands("/dev/stdin", $self->reference_path),
+        $self->normalize_vcf_commands("/dev/stdin", $self->reference),
         $self->sort_commands("/dev/stdin"),
         $self->restrict_commands("stdin", $self->roi),
         "bgzip -c",

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcf.t
@@ -113,5 +113,5 @@ sub setup_evaluate_vcf_params {
 
     my $ref = Genome::Model::Build::ReferenceSequence->get(106942997);
 
-    return ($vcf, $gold_vcf, $roi, $true_negative_bed, $output_dir, $ref);
+    return ($vcf, $gold_vcf, $roi, $true_negative_bed, $output_dir, $ref->full_consensus_path('fa'));
 }

--- a/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcfs.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/EvaluateVcfs.pm
@@ -241,13 +241,19 @@ sub parse_config_file {
             vcf => Path::Class::File->new($path)->absolute,
             gold_vcf => Path::Class::File->new($gold_vcf)->absolute,
             sample => $sample,
-            reference => $reference,
+            reference => reference_path($reference),
             clean_indels => $clean_indels,
         };
         push(@inputs, $i);
     }
 
     return \@inputs;
+}
+
+sub reference_path {
+    my $reference = shift;
+    my $path = $reference->full_consensus_path('fa');
+    return $path;
 }
 
 sub _run_evaluate_vcf {


### PR DESCRIPTION
This will make it easier to use the evaluation script outside of model/build paradigm