### PR TITLE
Make read group accumulation level not the default at this time

### DIFF
--- a/lib/perl/Genome/Qc/Config.pm
+++ b/lib/perl/Genome/Qc/Config.pm
@@ -42,7 +42,7 @@ sub get_commands_for_alignment_result {
                 input_file => 'bam_file',
                 refseq_file => 'reference_sequence',
                 use_version => 1.123,
-                metric_accumulation_level => ['SAMPLE', 'READ_GROUP'],
+                metric_accumulation_level => ['SAMPLE'],
             }
         },
         picard_collect_insert_size_metrics => {

--- a/lib/perl/Genome/Qc/Config.pm
+++ b/lib/perl/Genome/Qc/Config.pm
@@ -42,7 +42,6 @@ sub get_commands_for_alignment_result {
                 input_file => 'bam_file',
                 refseq_file => 'reference_sequence',
                 use_version => 1.123,
-                metric_accumulation_level => ['SAMPLE'],
             }
         },
         picard_collect_insert_size_metrics => {
@@ -51,7 +50,6 @@ sub get_commands_for_alignment_result {
                 input_file => 'bam_file',
                 histogram_file => 'histogram_file',
                 use_version => 1.123,
-                metric_accumulation_level => ['SAMPLE'],
             }
         },
     );
@@ -64,7 +62,6 @@ sub get_commands_for_alignment_result {
                 bait_intervals => 'bait_intervals', #region_of_interest_set
                 target_intervals => 'target_intervals', #target_region_set
                 use_version => 1.123,
-                metric_accumulation_level => ['SAMPLE'],
             },
         };
     }


### PR DESCRIPTION
- Adding the read group accumulation level drastically increases runtime
- Picard uses the RG PU field as the read group value which in our BAMs is not unique and, thus, not useful
- It's not needed for CCDG at this time

Once we have the config management system deployed this option can be turned on as needed.