### PR TITLE
Fixes to Metric Parsing in ClinSeq SummarizeBuilds

### DIFF
--- a/lib/perl/Genome/Model/Tools/BamQc/SummarizeAsText.pm
+++ b/lib/perl/Genome/Model/Tools/BamQc/SummarizeAsText.pm
@@ -388,12 +388,12 @@ sub execute {
         my $as_metrics = $self->_load_alignment_summary_metrics($label_dir);
         my $is_paired_end;
         my $as_category;
-        if ($as_metrics->{'CATEGORY-PAIR'}) {
+        if ($as_metrics->{'PAIR'}) {
             $is_paired_end = 1;
-            $as_category = 'CATEGORY-PAIR';
-        } elsif ($as_metrics->{'CATEGORY-UNPAIRED'}) {
+            $as_category = 'PAIR';
+        } elsif ($as_metrics->{'UNPAIRED'}) {
             $is_paired_end = 0;
-            $as_category = 'CATEGORY-UNPAIRED';
+            $as_category = 'UNPAIRED';
         } else {
             die('Failed to identify the read type!');
         }

--- a/lib/perl/Genome/Model/Tools/Picard/CollectGcBiasMetrics.pm
+++ b/lib/perl/Genome/Model/Tools/Picard/CollectGcBiasMetrics.pm
@@ -95,4 +95,8 @@ sub _java_class {
     return qw(picard analysis CollectGcBiasMetrics);
 }
 
+sub _metric_header_as_key {
+    return 'GC';
+}
+
 1;


### PR DESCRIPTION
This is a follow-up to changes in #998 to update a few cases that aren't covered by unit tests but were caught by the `ClinSeq` model test.