### PR TITLE
Qc build metrics

### DIFF
--- a/lib/perl/Genome/Qc/Command/BuildMetrics.pm
+++ b/lib/perl/Genome/Qc/Command/BuildMetrics.pm
@@ -5,7 +5,6 @@ use warnings;
 
 use Genome;
 use YAML::Syck;
-use Test::More qw/no_plan/;
 
 class Genome::Qc::Command::BuildMetrics {
     is => 'Command::V2',

--- a/lib/perl/Genome/Qc/Command/BuildMetrics.pm
+++ b/lib/perl/Genome/Qc/Command/BuildMetrics.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Genome;
-use YAML::Syck;
+use YAML::Syck qw(DumpFile);
 
 class Genome::Qc::Command::BuildMetrics {
     is => 'Command::V2',

--- a/lib/perl/Genome/Qc/Command/BuildMetrics.t
+++ b/lib/perl/Genome/Qc/Command/BuildMetrics.t
@@ -12,7 +12,7 @@ use warnings;
 use above "Genome";
 
 use Test::More;
-use YAML::Syck;
+use YAML::Syck qw(LoadFile);
 
 use Genome::Utility::Test qw(compare_ok);
 
@@ -52,16 +52,11 @@ my $test_dir = __FILE__.'.d';
 my $expected_output_file = $test_dir .'/expected_build_metrics.yml';
 my $test_output_file = Genome::Sys->create_temp_file_path();
 
-# TSV expected output IDs
-#my $expected_instrument_data_id = '5dacb1b2284a4b71afdf9680d4ef3691';
-#my $expected_build_id = 'c10605dbabfc49229838cc02fbd87e98';
-
 # Get expected IDs from YAML file.
 my @expected_metrics = LoadFile($expected_output_file);
 my $expected_metrics_hash = $expected_metrics[0];
 my $expected_build_id = $expected_metrics_hash->{'build_id'};
 my $expected_instrument_data_id = $expected_metrics_hash->{'instrument_data_ids'};
-
 
 my $test_model = Genome::Test::Factory::Model::SomaticValidation->setup_object();
 my $test_build = Genome::Test::Factory::Build->setup_object(

--- a/lib/perl/Genome/Qc/Command/BuildMetrics.t.d/expected_build_metrics.yml
+++ b/lib/perl/Genome/Qc/Command/BuildMetrics.t.d/expected_build_metrics.yml
@@ -1,0 +1,11 @@
+--- 
+build_id: a3dbe478702c4f3aa9f4c1c68bbcdebf
+instrument_data_count: 1
+instrument_data_ids: d0eef0c4ee574f70a61a95bae0fdc93a
+label_1: 
+  metric_E: 5
+  metric_F: 6
+metric_A: 1
+metric_B: 2
+metric_C: 3
+metric_D: 4


### PR DESCRIPTION
Updates include:
Support merged QC results rather than per-lane
Use YAML output format to handle nested data structures (unflattened metrics hash).