### PR TITLE
Disk Allocation Archive command accepts paths

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -973,6 +973,19 @@ sub get_allocation_for_path {
     return $allocation;
 }
 
+sub _resolve_param_value_from_text_by_name_or_id {
+    my ($class, $param_arg) = @_;
+
+    my @results = Command::V2->_resolve_param_value_from_text_by_name_or_id($class, $param_arg);
+
+    if(!@results) {
+        my $allocation = $class->get_allocation_for_path($param_arg);
+        push @results, $allocation if $allocation;
+    }
+
+    return @results;
+}
+
 sub archive_after_time {
     my $self = shift;
 

--- a/lib/perl/Genome/Disk/Command/Allocation/Archive.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/Archive.pm
@@ -7,17 +7,12 @@ use Carp;
 
 class Genome::Disk::Command::Allocation::Archive {
     is => 'Command::V2',
-    has_optional => [
+    has => [
         allocations => {
             is => 'Genome::Disk::Allocation',
             is_many => 1,
             shell_args_position => 1,
             doc => 'allocations to be archived',
-        },
-        paths => {
-            is => 'Text',
-            is_many => 1,
-            doc => 'paths for which to look up the corresponding allocations to be archived',
         },
     ],
     doc => 'archives the given allocations',
@@ -35,20 +30,7 @@ sub execute {
     my $self = shift;
     $self->status_message("Starting archive command...");
 
-    my @allocations = $self->allocations;
-    if ($self->paths) {
-        for my $path ($self->paths) {
-            my $allocation = Genome::Disk::Allocation->get_allocation_for_path($path);
-            if ($allocation) {
-                $self->debug_message('Found allocation %s for path: %s', $allocation->id, $path);
-                push @allocations, $allocation;
-            } else {
-                die $self->error_message('No allocation found for path: %s', $path);
-            }
-        }
-    }
-
-    for my $allocation (@allocations) {
+    for my $allocation ($self->allocations) {
         $self->status_message("Archiving allocation " . $allocation->id);
         if ($allocation->archivable == 0) {
             $self->status_message("Skipping allocation " . $allocation->id . ", not set to archivable");

--- a/lib/perl/Genome/Disk/Command/Allocation/Archive.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Archive.t
@@ -76,7 +76,7 @@ my $archive_assignment = Genome::Disk::Assignment->create(
     group => $group,
     volume => $archive_volume
 );
-ok($archive_assignment, 'added archiev volume to test group successfully');
+ok($archive_assignment, 'added archive volume to test group successfully');
 Genome::Sys->create_directory(join('/', $archive_volume->mount_path, $group->subdirectory));
 
 my $allocation_creator = sub {

--- a/lib/perl/Genome/Disk/Command/Allocation/Archive.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Archive.t
@@ -20,14 +20,6 @@ use Genome::Disk::Allocation;
 $Genome::Disk::Allocation::CREATE_DUMMY_VOLUMES_FOR_TESTING = 0;
 #$Genome::Disk::Allocation::TESTING_DISK_ALLOCATION = 1;
 
-# Temp testing directory, used as mount path for test volumes and allocations
-my $test_dir = tempdir(
-    'allocation_testing_XXXXXX',
-    TMPDIR => 1,
-    UNLINK => 1,
-    CLEANUP => 1,
-);
-
 # Create test group
 my $group = Genome::Disk::Group->create(
     disk_group_name => 'test',
@@ -42,7 +34,7 @@ ok($group, 'created test disk group');
 # Create temp archive volume
 my $archive_volume_path = tempdir(
     "test_volume_XXXXXXX",
-    DIR => $test_dir,
+    TMPDIR => 1,
     CLEANUP => 1,
     UNLINK => 1,
 );
@@ -59,7 +51,7 @@ ok($archive_volume, 'created test volume');
 # Create temp active volume
 my $volume_path = tempdir(
     "test_volume_XXXXXXX",
-    DIR => $test_dir,
+    TMPDIR => 1,
     CLEANUP => 1,
     UNLINK => 1,
 );

--- a/lib/perl/Genome/Disk/Command/Allocation/Archive.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Archive.t
@@ -128,6 +128,18 @@ subtest 'call archive command with allocation from command line' => sub {
     is($allocation->volume->id, $archive_volume->id, 'allocation updated as expected after archive');
 };
 
+subtest 'call archive command with path' => sub {
+    my $allocation = $allocation_creator->();
+
+    my $cmd = Genome::Disk::Command::Allocation::Archive->create(
+        paths => [$allocation->absolute_path . '/a.out'],
+    );
+    ok($cmd, 'created archive command');
+    ok($cmd->execute, 'successfully executed archive command');
+    is($allocation->volume->id, $archive_volume->id, 'allocation moved to archive volume');
+    ok($allocation->is_archived, 'allocation is now archived');
+};
+
 done_testing();
 
 

--- a/lib/perl/Genome/Disk/Command/Allocation/Archive.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Archive.t
@@ -128,14 +128,13 @@ subtest 'call archive command with allocation from command line' => sub {
     is($allocation->volume->id, $archive_volume->id, 'allocation updated as expected after archive');
 };
 
-subtest 'call archive command with path' => sub {
+subtest 'call archive command with path from command line' => sub {
     my $allocation = $allocation_creator->();
 
-    my $cmd = Genome::Disk::Command::Allocation::Archive->create(
-        paths => [$allocation->absolute_path . '/a.out'],
+    my $rv = Genome::Disk::Command::Allocation::Archive->_execute_with_shell_params_and_return_exit_code(
+        $allocation->absolute_path . '/a.out',
     );
-    ok($cmd, 'created archive command');
-    ok($cmd->execute, 'successfully executed archive command');
+    is($rv, 0, 'successfully executed command using path command line argument');
     is($allocation->volume->id, $archive_volume->id, 'allocation moved to archive volume');
     ok($allocation->is_archived, 'allocation is now archived');
 };

--- a/lib/perl/Genome/Disk/Command/Allocation/Archive.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Archive.t
@@ -106,7 +106,7 @@ ok($allocation, 'created test allocation');
 system("touch " . $allocation->absolute_path . "/a.out");
 
 # Override these methods so archive/active volume linking works for our test volumes
-no warnings 'redefine';
+no warnings 'redefine', 'once';
 *Genome::Disk::Volume::archive_volume_prefix = sub { return $archive_volume->mount_path };
 *Genome::Disk::Volume::active_volume_prefix = sub { return $volume->mount_path };
 use warnings;

--- a/lib/perl/Genome/Disk/Command/Allocation/ArchiveExpired.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/ArchiveExpired.t
@@ -83,7 +83,7 @@ my $archive_assignment = Genome::Disk::Assignment->create(
     group => $group,
     volume => $archive_volume
 );
-ok($archive_assignment, 'added archiev volume to test group successfully');
+ok($archive_assignment, 'added archive volume to test group successfully');
 Genome::Sys->create_directory(join('/', $archive_volume->mount_path, $group->subdirectory));
 
 # Make test allocation

--- a/lib/perl/Genome/Disk/Command/Allocation/DelayArchiving.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/DelayArchiving.pm
@@ -7,15 +7,11 @@ use DateTime;
 
 class Genome::Disk::Command::Allocation::DelayArchiving {
     is => 'Command::V2',
-    has_optional => [
+    has => [
         allocations => {
             is => 'Genome::Disk::Allocation',
             is_many => 1,
             doc => 'allocations that are not to be archived, resolved via Command::V2',
-        },
-        paths => {
-            is => 'Text',
-            doc => 'comma delimited list of paths, an attempt will be made to resolve them to allocations',
         },
         _duration_property_for_commands(),
     ],
@@ -25,46 +21,15 @@ sub help_detail {
     return 'Archiving of the given allocations and paths is delayed by 3 months (or the value you specified). Any paths that are given are resolved ' .
         'to allocations if possible, otherwise a warning is emitted.';
 }
-sub help_brief { return 'given allocations and paths are marked so they cannot be archived' };
+sub help_brief { return 'given allocations are marked so they cannot be archived' };
 sub help_synopsis { return help_brief() . "\n" };
 
 sub execute {
     my $self = shift;
-    for my $allocation ($self->_resolve_allocations_from_paths, $self->allocations) {
-        next unless $allocation;
+    for my $allocation ($self->allocations) {
         $allocation->archive_after_time($self->_resolve_date_from_months($self->duration));
     }
     return 1;
-}
-
-# TODO Move this logic into a special get method on Genome::Disk::Allocation?
-sub _resolve_allocations_from_paths {
-    my $self = shift;
-    return unless $self->paths;
-
-    my @allocations;
-    for my $path (split(/,/, $self->paths)) {
-        my $allocation_path = Genome::Disk::Allocation->_allocation_path_from_full_path($path);
-        unless ($allocation_path) {
-            $self->warning_message("No allocation found for path $path");
-            next;
-        }
-
-        my $allocation = Genome::Disk::Allocation->get_parent_allocation($allocation_path);
-        if ($allocation) {
-            push @allocations, $allocation;
-            next;
-        }
-
-        my @allocations_for_path = Genome::Disk::Allocation->get_child_allocations($allocation_path);
-        if (@allocations_for_path) {
-            push @allocations, @allocations_for_path;
-            next;
-        }
-
-        $self->warning_message("No allocation found for path $path");
-    }
-    return @allocations;
 }
 
 sub _resolve_date_from_months {

--- a/lib/perl/Genome/Disk/Command/Allocation/Unarchive.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/Unarchive.pm
@@ -6,17 +6,12 @@ use Genome;
 
 class Genome::Disk::Command::Allocation::Unarchive {
     is => 'Genome::Disk::Command::Allocation::UnarchiveBase',
-    has_optional => [
+    has => [
         allocations => {
             is => 'Genome::Disk::Allocation',
             is_many => 1,
             shell_args_position => 1,
             doc => 'allocations to be unarchived',
-        },
-        paths => {
-            is => 'Text',
-            is_many => 1,
-            doc => 'pass a path instead of allocations and allocation will be looked up'
         },
     ],
     doc => 'unarchives the given allocations',
@@ -32,23 +27,6 @@ sub help_brief {
 
 sub _execute {
     my $self = shift;
-
-    if (!$self->allocations) {
-        if ($self->paths) {
-            my @allocs;
-            for my $path ($self->paths) {
-                my $alloc = Genome::Disk::Allocation->get_allocation_for_path($path);
-                if ($alloc) { push @allocs, $alloc; }
-            }
-            $self->allocations(\@allocs);
-        }
-
-        if ($self->allocations) {
-            $self->status_message('found allocation(s): ' . join("\n",map {$_->id} $self->allocations));
-        } else {
-            die 'You must provide either allocation id or the path you are trying to unarchive.';
-        }
-    }
 
     $self->status_message("Starting unarchive command...");
 


### PR DESCRIPTION
The unarchive command already accepts paths; this makes them more symmetric.