### PR TITLE
Make the volume lister work

### DIFF
--- a/lib/perl/Genome/Disk/Command/Volume/List.pm
+++ b/lib/perl/Genome/Disk/Command/Volume/List.pm
@@ -19,5 +19,34 @@ class Genome::Disk::Command::Volume::List {
     doc => 'Lists Genome::Disk::Volume objects',
 };
 
+sub execute {
+    my $self = shift;
+
+    require Genome::Disk::Group;
+    require Genome::Disk::Volume;
+    no warnings 'redefine';
+    local *Genome::Disk::Group::validate = sub { 1 };  # For just listing, don't validate them
+    local *Genome::Disk::Volume::used_kb = make_is_mounted_wrapper(\&Genome::Disk::Volume::used_kb);
+    local *Genome::Disk::Volume::percent_used = make_is_mounted_wrapper(\&Genome::Disk::Volume::percent_used);
+
+    my $super_execute = $self->super_can('_execute_body');
+    return $self->$super_execute(@_);
+}
+
+my %cached_is_mounted;
+sub make_is_mounted_wrapper {
+    my $original_sub = shift;
+
+    return sub {
+        my $volume = shift;
+
+        if ($cached_is_mounted{$volume->id} //= $volume->is_mounted) {
+            return $volume->$original_sub(@_);
+        } else {
+            return '<unmounted>';
+        }
+    };
+}
+
 1;
 

--- a/lib/perl/Genome/Disk/Command/Volume/List.pm
+++ b/lib/perl/Genome/Disk/Command/Volume/List.pm
@@ -16,6 +16,11 @@ class Genome::Disk::Command::Volume::List {
         show => { 
             default_value => 'mount_path,disk_group_names,total_kb,percent_used,percent_allocated', 
         },
+        accurate_size => {
+            is => 'Boolean',
+            default_value => 0,
+            doc => 'Mount each displayed volume to display used/free sizes accurately',
+        },
     ],
     doc => 'Lists Genome::Disk::Volume objects',
 };
@@ -27,20 +32,20 @@ sub execute {
     require Genome::Disk::Volume;
     no warnings 'redefine';
     local *Genome::Disk::Group::validate = sub { 1 };  # For just listing, don't validate them
-    local *Genome::Disk::Volume::used_kb = make_is_mounted_wrapper(\&Genome::Disk::Volume::used_kb);
-    local *Genome::Disk::Volume::percent_used = make_is_mounted_wrapper(\&Genome::Disk::Volume::percent_used);
+    local *Genome::Disk::Volume::used_kb = $self->make_is_mounted_wrapper(\&Genome::Disk::Volume::used_kb);
+    local *Genome::Disk::Volume::percent_used = $self->make_is_mounted_wrapper(\&Genome::Disk::Volume::percent_used);
 
     my $super_execute = $self->super_can('_execute_body');
     return $self->$super_execute(@_);
 }
 
 sub make_is_mounted_wrapper {
-    my $original_sub = shift;
+    my($self, $original_sub) = @_;
 
     return sub {
         my $volume = shift;
 
-        if (is_volume_mounted($volume)) {
+        if ($self->is_volume_mounted($volume)) {
             return $volume->$original_sub(@_);
         } else {
             return '<unmounted>';
@@ -50,17 +55,30 @@ sub make_is_mounted_wrapper {
 
 my %cached_is_mounted;
 sub is_volume_mounted {
-    my $volume = shift;
+    my($self, $volume) = @_;
 
     unless (%cached_is_mounted) {
-        my $mounts = IO::File->new('/proc/mounts');
-        while(my $line = $mounts->getline) {
-            my(undef, $mount_path) = split(/\s/, $line);
-            $cached_is_mounted{$mount_path} = 1;
-        }
+        _populate_cached_is_mounted();
     }
 
-    return $cached_is_mounted{$volume->mount_path};
+    my $mount_path = $volume->mount_path;
+
+    if (! exists($cached_is_mounted{$mount_path}) && $self->accurate_size) {
+        my $dir = IO::Dir->new($mount_path);
+        $dir->read if $dir;
+        _populate_cached_is_mounted();
+        $cached_is_mounted{$mount_path} //= 0;
+    }
+
+    return $cached_is_mounted{$volume->mount_path}
+}
+
+sub _populate_cached_is_mounted {
+    my $mounts = IO::File->new('/proc/mounts');
+    while(my $line = $mounts->getline) {
+        my(undef, $mount_path) = split(/\s/, $line);
+        $cached_is_mounted{$mount_path} = 1;
+    }
 }
 
 1;


### PR DESCRIPTION
Disk Groups validate that their disk_group_name belongs to a short list
and dies otherwise to ensure Genome stuff only messes with analysis
allocations.  For a basic lister, we don't want want this safety net.

Getting the free space of an unmounted volume also throws an exception
if the volume is unmounted to avoid mounting tons of volumes.  For this
simple lister, we just print out "<unmounted>" for such volumes instead of
dying.