### PR TITLE
Use generic config variable for alignment queue.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -98,7 +98,7 @@ sub _format_lsf_resource_string {
 
     my $cpus = 8;
     my $mem_gb = 60;
-    my $queue = Genome::Config::get('lsf_queue_alignment_prod');
+    my $queue = Genome::Config::get('lsf_queue_alignment_default');
 
     my $gtmp_kb = ceil($gtmp_bytes / 1024);
     my $gtmp_mb = ceil($gtmp_kb / 1024);


### PR DESCRIPTION
This is the only place left referring to this config instead of the regular one.  After this change is in all active snapshots we can remove the other variable from our deployed `config.yaml` and then from config altogether.
