### PR TITLE
In the UsageLog, don't call getpwuid.

### DIFF
--- a/lib/perl/Genome/Site/TGI/UsageLog.pm
+++ b/lib/perl/Genome/Site/TGI/UsageLog.pm
@@ -27,7 +27,7 @@ sub import {
             record_usage(
                 recorded_at  => 'now',
                 hostname     => $hostname,
-                username     => (getpwuid($<))[0],
+                username     => $<,
                 genome_path  => genome_path(),
                 perl_path    => abs_path($^X),
                 command      => $command,


### PR DESCRIPTION
In my tests it reduces the runtime of "use Genome;" by about half a second–from ~1.2s to ~0.7s).

This potentially trades accuracy for speed, but, If we're using this as an audit log, we're going about it all wrong!