### PR TITLE
Better User Handling with IntermediateAlignmentResults

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/WithIntermediateResults.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/WithIntermediateResults.pm
@@ -84,8 +84,8 @@ sub remove_intemediate_results {
         $iar_user->active(0);
 
         if($result_users) {
-            for my $value (values %$result_users) {
-                my @using = $iar->users(user => $value, label => ['created', 'shortcut', 'sponsor']);
+            while(my ($label, $user) = each %$result_users) {
+                my @using = $iar->users(user => $user, label => $label);
                 map $_->active(0), @using;
             }
         }

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
@@ -484,21 +484,6 @@ sub _process_and_link_alignments_to_build {
         return 0;
     }
 
-    for my $alignment (@alignments) {
-        my $link = $alignment->user(user => $build, label => 'uses');
-        if ($link) {
-            $self->debug_message("Linked alignment " . $alignment->id . " to the build");
-        }
-        else {
-            $self->error_message(
-                "Failed to link the build to the alignment " 
-                . $alignment->__display_name__ 
-                . "!"
-            );
-            # TODO: die, but not for now
-        }
-    }
-
     $self->debug_message("Generating alignments...");
     $self->generate_metric($self->metrics_for_class);
 

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AlignReads.pm
@@ -484,7 +484,7 @@ sub _process_and_link_alignments_to_build {
         return 0;
     }
 
-    $self->debug_message("Generating alignments...");
+    $self->debug_message("Generating alignment metrics...");
     $self->generate_metric($self->metrics_for_class);
 
     $self->debug_message("Verifying...");


### PR DESCRIPTION
This fixes an issue where the IAR could not be deleted when custom users were supplied in the result user hash.  It also removes a spurious error about linking alignments to the build in ReferenceAlignment.