### PR TITLE
Don't really start builds in this test.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Start.t
+++ b/lib/perl/Genome/Model/Build/Command/Start.t
@@ -8,6 +8,8 @@ use Sys::Hostname;
 require File::Temp;
 use Test::More;
 
+use Sub::Install qw(reinstall_sub);
+
 Genome::Report::Email->silent();
 
 # use
@@ -41,6 +43,14 @@ my $model_id = $m->id;
 # tmpdir
 my $tmpdir = File::Temp::tempdir(CLEANUP => 1);
 ok(-d $tmpdir, 'Created temp dir');
+
+reinstall_sub({
+    into => 'Genome::Model::Command::Services::Build::Run',
+    as => 'execute',
+    code => sub {
+        return 1;
+    },
+});
 
 # ok
 my $rv = eval { 


### PR DESCRIPTION
The integration (model) tests will try running a build all the way through.  This just needs to make sure Start works.  (This was testing the "inline" build process, anyway, which is not how builds are usually run in production.)