### PR TITLE
More efficient unarchive wait for lsf jobs

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Unarchive.pm
+++ b/lib/perl/Genome/Model/Build/Command/Unarchive.pm
@@ -65,7 +65,7 @@ sub _execute {
             $self->status_message("Found $num_allocations archived allocations related to this build, " .
                 "starting unarchive process now.");
             # Schedule unarchive of all allocations related to build via LSF
-            my %jobs_to_allocations = $self->_bsub_unarchives($dir, @allocations);
+            my %jobs_to_allocations = $self->_bsub_unarchives_and_wait_completion($dir, @allocations);
             %job_to_allocation_mapping = %jobs_to_allocations;
             my @job_ids = keys %job_to_allocation_mapping;
             $self->debug_message("Unarchives scheduled, waiting for completion");
@@ -83,7 +83,7 @@ sub _execute {
         if ( @symlinked_allocations_that_need_unarchiving ) {
             $num_allocations += @symlinked_allocations_that_need_unarchiving;
             $self->status_message("Found ".@symlinked_allocations_that_need_unarchiving." archived symlinked allocations. Unarchiving...");
-            my %jobs_to_allocations = $self->_bsub_unarchives($dir, @symlinked_allocations_that_need_unarchiving);
+            my %jobs_to_allocations = $self->_bsub_unarchives_and_wait_completion($dir, @symlinked_allocations_that_need_unarchiving);
             %job_to_allocation_mapping = %jobs_to_allocations;
             my @symlinked_allocation_job_ids = keys %jobs_to_allocations;
             $self->debug_message("Unarchives for symlinked allocations scheduled, waiting for completion");
@@ -158,7 +158,7 @@ sub _execute {
     return 1;
 }
 
-sub _bsub_unarchives {
+sub _bsub_unarchives_and_wait_completion {
     my $self = shift;
     my $log_file_dir = shift;
     my @allocations = @_;
@@ -166,23 +166,34 @@ sub _bsub_unarchives {
     my $lab = $self->lab;
     my $requestor = $self->requestor->id;
 
-    my %job_to_allocation_mapping;
+    my @allocation_ids = map { $_->id } @allocations;
+    my @unarchive_commands;
     for my $allocation (@allocations) {
         my $allocation_id = $allocation->id;
         my @cmd = ('genome', 'disk', 'allocation', 'unarchive', $allocation_id,
             '--lab', $lab, '--requestor', $requestor,
         );
-        my $job_id = Genome::Sys->bsub(
-            queue => Genome::Config::get('lsf_queue_build_worker'),
-            cmd => \@cmd,
-            log_file => "$log_file_dir/$allocation_id.out",
-            err_file => "$log_file_dir/$allocation_id.err",
-            job_group => '/apipe/build-unarchive',
-        );
-        $job_to_allocation_mapping{$job_id} = $allocation_id;
-        $self->debug_message("Scheduled unarchive of allocation $allocation_id  " .
-            "via LSF job $job_id");
+        push @unarchive_commands,
+                { cmd => \@cmd,
+                  log_file => "$log_file_dir/$allocation_id.out",
+                  err_file => "$log_file_dir/$allocation_id.err",
+                };
     }
+
+    my %job_to_allocation_mapping;
+    my $on_submit = sub {
+        my($idx, $job_id) = @_;
+        my $allocation_id = $allocation_ids[$idx];
+        $self->debug_message("Scheduled unarchive of allocation $allocation_id  via LSF job $job_id");
+        $job_to_allocation_mapping{$job_id} = $allocation_ids[$idx];
+    };
+
+    my @statuses = Genome::Sys->bsub_and_wait_completion(
+                    queue => Genome::Config::get('lsf_queue_build_worker'),
+                    job_group => '/apipe/build-unarchive',
+                    cmds => \@unarchive_commands,
+                    on_submit => $on_submit,
+                  );
     return %job_to_allocation_mapping;
 }
 

--- a/lib/perl/Genome/Site/TGI/Extension/Sys-lsf_api.t
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys-lsf_api.t
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use above "Genome";
-use Test::More tests => 4;
+use Test::More tests => 5;
 
 use constant SUCCESSFUL_JOB => 'DONE';
 use constant FAILED_JOB => 'EXIT';
@@ -56,3 +56,17 @@ subtest 'get job statuses' => sub {
     is_deeply(\%job_statuses, \%expected_job_statuses, 'Job statuses are as expected');
 };
 
+subtest 'bsub_and_wait_for_completion' => sub {
+    plan tests => 1;
+
+    my @cmds = (['ls', '~'],
+                'exit 1',
+               );
+    my @statuses = Genome::Sys->bsub_and_wait_for_completion(
+                        queue => Genome::Config::get('lsf_queue_short'),
+                        cmds => \@cmds,
+                    );
+    is_deeply(\@statuses,
+              [SUCCESSFUL_JOB, FAILED_JOB],
+              'statuses are correct');
+};

--- a/lib/perl/Genome/Site/TGI/Extension/Sys-lsf_api.t
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys-lsf_api.t
@@ -57,10 +57,11 @@ subtest 'get job statuses' => sub {
 };
 
 subtest 'bsub_and_wait_for_completion' => sub {
-    plan tests => 5;
+    plan tests => 7;
 
     my @cmds = (['ls', '~'],
                 'exit 1',
+                { cmd => ['cat', '/dev/null'] },
                );
     my(%submitted, %completed);
     my @statuses = Genome::Sys->bsub_and_wait_for_completion(
@@ -70,7 +71,7 @@ subtest 'bsub_and_wait_for_completion' => sub {
                         on_complete => sub { my($idx, $job_id) = @_; $completed{$idx} = $job_id },
                     );
     is_deeply(\@statuses,
-              [SUCCESSFUL_JOB, FAILED_JOB],
+              [SUCCESSFUL_JOB, FAILED_JOB, SUCCESSFUL_JOB],
               'statuses are correct');
 
     for (my $i = 0; $i < @cmds; $i++) {

--- a/lib/perl/Genome/Site/TGI/Extension/Sys-lsf_api.t
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys-lsf_api.t
@@ -9,46 +9,50 @@ use strict;
 use warnings;
 
 use above "Genome";
-use Test::More;
+use Test::More tests => 4;
+
+use constant SUCCESSFUL_JOB => 'DONE';
+use constant FAILED_JOB => 'EXIT';
 
 use_ok('Genome::Sys') or die;
 
-# Submit job that should work
-my @job_ids;
-my $cmd = 'ls ~';
-my $job_id = Genome::Sys->bsub(
-    queue => Genome::Config::get('lsf_queue_short'),
-    cmd => $cmd,
-);
-ok($job_id, "bsubbed $cmd, got job id back");
-push @job_ids, $job_id;
 
-# Submit job that should fail
-$cmd = 'exit 1';
-$job_id = Genome::Sys->bsub(
-    queue => Genome::Config::get('lsf_queue_short'),
-    cmd => $cmd
-);
-ok($job_id, "bsubbed $cmd, got job id back");
-push @job_ids, $job_id;
-my $job_that_should_fail = $job_id;
+my %expected_job_statuses;
 
-# Wait for jobs to come back
-my %job_statuses = Genome::Sys->wait_for_lsf_jobs(@job_ids);
-ok(%job_statuses, 'got job status hash back from wait_for_lsf_jobs method');
+subtest 'submit job' => sub {
+    plan tests => 1;
 
-my @keys = keys %job_statuses;
-ok(@keys == @job_ids, 'job status hash has same number of keys as submitted jobs');
+    my $cmd = 'ls ~';
+    my $job_id = Genome::Sys->bsub(
+        queue => Genome::Config::get('lsf_queue_short'),
+        cmd => $cmd,
+    );
+    ok($job_id, "bsubbed $cmd, got job id back");
+    $expected_job_statuses{$job_id} = SUCCESSFUL_JOB;
+};
 
-for my $job_id (@job_ids) {
-    my $status = $job_statuses{$job_id};
-    ok($status, "got status for job $job_id, $status");
-    if ($job_id eq $job_that_should_fail) {
-        is($status, 'EXIT', "job $job_id failed as expected");
-    }
-    else {
-        is($status, 'DONE', "job $job_id succeeded as expected");
-    }
-}
+subtest 'submit failing job' => sub {
+    plan tests => 1;
 
-done_testing;
+    my $cmd = 'exit 1';
+    my $job_id = Genome::Sys->bsub(
+        queue => Genome::Config::get('lsf_queue_short'),
+        cmd => $cmd
+    );
+    ok($job_id, "bsubbed $cmd, got job id back");
+    $expected_job_statuses{$job_id} = FAILED_JOB;
+};
+
+subtest 'get job statuses' => sub {
+    plan tests => 3;
+
+    my %job_statuses = Genome::Sys->wait_for_lsf_jobs(keys %expected_job_statuses);
+    ok(%job_statuses, 'got job status hash back from wait_for_lsf_jobs method');
+
+    is(scalar(keys %job_statuses),
+       scalar(keys %expected_job_statuses),
+       'job status hash has same number of keys as submitted jobs');
+
+    is_deeply(\%job_statuses, \%expected_job_statuses, 'Job statuses are as expected');
+};
+

--- a/lib/perl/Genome/Site/TGI/Extension/Sys.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys.pm
@@ -85,9 +85,16 @@ sub bsub_and_wait_for_completion {
     my %seq_to_job_id;
     for(my $seq = 0; $seq < @$commands; $seq++) {
         my $cmd = $commands->[$seq];
+        my %this_cmd_bsub_args;
+        if (ref($cmd) and ref($cmd) eq 'HASH') {
+            %this_cmd_bsub_args = %$cmd;
+        } else {
+            %this_cmd_bsub_args = ( cmd => $cmd );
+        }
+
         my $job_id = $class->bsub(post_exec_cmd => qq(echo $seq | netcat $hostname $port),
                                   %bsub_args,
-                                  cmd => $cmd,
+                                  %this_cmd_bsub_args,
                                 );
         $on_submit_cb->($seq, $job_id) if $on_submit_cb;
         $seq_to_job_id{$seq} = $job_id;

--- a/lib/perl/Genome/Site/TGI/Extension/Sys.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys.pm
@@ -20,6 +20,8 @@ require Genome::Utility::Text; #TODO remove, unused
 use Sys::Hostname;
 use File::Find;
 use Params::Validate qw(:types);
+use IO::Socket;
+use Sys::Hostname qw(hostname);
 #use Archive::Extract;
 
 require MIME::Lite;
@@ -67,6 +69,69 @@ sub get_lsf_job_status {
         die "Could not get status for job $job_id";
     }
     return $status;
+}
+
+sub bsub_and_wait_for_completion {
+    my($class, %bsub_args) = @_;
+
+    my $commands;
+    ($commands, %bsub_args) = _bsub_and_wait_for_completion__validate_args(%bsub_args);
+
+    my $hostname = hostname;
+    my $waiting_socket = IO::Socket::INET->new(Listen => 5, Proto => 'tcp', LocalHost => $hostname);
+    my $port = $waiting_socket->sockport;
+
+    my %seq_to_job_id;
+    for(my $seq = 0; $seq < @$commands; $seq++) {
+        my $cmd = $commands->[$seq];
+        my $job_id = $class->bsub(post_exec_cmd => qq(echo $seq | netcat $hostname $port),
+                                  %bsub_args,
+                                  cmd => $cmd,
+                                );
+        $seq_to_job_id{$seq} = $job_id;
+    }
+
+    $class->_bsub_and_wait_for_completion__wait_on_jobs($waiting_socket, %seq_to_job_id);
+
+    # immediately after being reaped in _bsub_and_wait_for_completion_wait_on_jobs(), bjobs
+    # reports their status as still "RUN".  Instead, we go into the traditional polling until
+    # LSF updates their status to EXIT or DONE
+    my %job_statuses = $class->wait_for_lsf_jobs(values %seq_to_job_id);
+    my @statuses = map { $job_statuses{$_} }
+                   map { $seq_to_job_id{$_} }
+                   ( 0 .. $#$commands );
+    return @statuses;
+}
+
+sub _bsub_and_wait_for_completion__validate_args {
+    my %bsub_args = @_;
+
+    my $commands = delete $bsub_args{cmds};
+    unless ($commands and ref($commands) and ref($commands) eq 'ARRAY') {
+        Carp::croak(q(arg 'commands' is required and must be an arrayref of commands'));
+    }
+    if (exists $bsub_args{cmd}) {
+        Carp::croak(q(arg 'cmd' is not allowed, use 'cmds' instead, an arrayref of commands));
+    }
+    return($commands, %bsub_args);
+}
+
+sub _bsub_and_wait_for_completion__wait_on_jobs {
+    my($class, $waiting_socket, %seq_to_job_id) = @_;
+
+    while (%seq_to_job_id) {
+        my $fh = $waiting_socket->accept();
+        my $seq = $fh->getline;
+        $fh->close;
+        $seq =~ s/\r|\n//g;
+
+        my $job_id = delete $seq_to_job_id{$seq};
+        unless ($job_id) {
+            Carp::croak("Got unexpected response '$seq' while waiting for these jobs:\n",
+                join("\n", map { join(' => ', $_, $seq_to_job_id{$_}) } keys %seq_to_job_id));
+        }
+    }
+    return 1;
 }
 
 sub wait_for_lsf_job {

--- a/lib/perl/Genome/Site/TGI/Extension/Sys.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys.pm
@@ -170,7 +170,6 @@ sub wait_for_lsf_jobs {
 
     my %job_statuses;
     my $all_jobs_complete = 1;
-    $DB::single = 1;
     do {
         $all_jobs_complete = 1;
         JOB_ID: for my $job_id (@job_ids) {

--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -127,6 +127,11 @@ sub _args_spec {
             option_flag => '-g',
             type => SCALAR,
         },
+        post_exec_cmd => {
+            optional => 1,
+            option_flag => '-Ep',
+            type => SCALAR,
+        },
         cmd => {
             type => SCALAR | ARRAYREF,
         },


### PR DESCRIPTION
Adds a new method to Genome::Sys called bsub_and_wait_completion() that can schedule multiple LSF jobs in parallel, and wait on them without running bjobs over and over.  It sets a post-exec command for each job to send a message back to the waiter over a TCP socket.  The waiter knows all the jobs are done when it gets the message from all the jobs it's waiting on.

Then, Genome::Model::Build::Command::Unarchive is changed to use this new method.