### PR TITLE
Inst Data Import: use read group id as instdata id

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_archive.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_archive.t
@@ -17,8 +17,9 @@ use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::Basic') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
+Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class('Genome::InstrumentData::Command::Import::WorkFlow::FastqsToBam');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v3');
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1');
 my $source_file = $test_dir.'/input.fastq.tgz';
 ok($source_file, 'source archive exists');
 
@@ -60,8 +61,8 @@ my $bam_path = $instrument_data->bam_path;
 ok(-s $bam_path, 'bam path exists');
 is($bam_path, $instrument_data->data_directory.'/all_sequences.bam', 'bam path correctly named');
 is(eval{$instrument_data->attributes(attribute_label => 'bam_path')->attribute_value}, $bam_path, 'set attributes bam path');
-is(File::Compare::compare($bam_path, $test_dir.'/all_sequences.bam'), 0, 'bam matches');
-is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/all_sequences.bam.flagstat'), 0, 'flagstat matches');
+is(File::Compare::compare($bam_path, $test_dir.'/all_sequences.basic-fastq-t.bam'), 0, 'bam matches');
+is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/all_sequences.basic-fastq-t.bam.flagstat'), 0, 'flagstat matches');
 
 my $allocation = $instrument_data->disk_allocation;
 ok($allocation, 'got allocation');

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
@@ -27,8 +27,8 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'bam/v4');
-my $source_bam = $test_dir.'/test.bam';
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1');
+my $source_bam = $test_dir.'/input.bam';
 ok(-s $source_bam, 'source bam exists') or die;
 
 my $cmd = Genome::InstrumentData::Command::Import::Basic->create(
@@ -57,7 +57,7 @@ is($instrument_data->description, 'We took some DNA and sheared it and sequenced
 is($instrument_data->is_paired_end, 1, 'is_paired_end correctly set');
 is($instrument_data->read_count, 252, 'read_count correctly set');
 is($instrument_data->read_length, 100, 'read_length correctly set');
-is(eval{$instrument_data->attributes(attribute_label => 'segment_id')->attribute_value;}, 2883581797, 'segment_id correctly set');
+is(eval{$instrument_data->attributes(attribute_label => 'segment_id')->attribute_value;}, '33333333333333333333333333333333', 'segment_id correctly set');
 is(eval{$instrument_data->attributes(attribute_label => 'original_data_path_md5')->attribute_value;}, 'f81fbc3d3a6b57d11e60b016bb2c950c', 'original_data_path_md5 correctly set');
 is($instrument_data->analysis_projects, $analysis_project, 'set analysis project');
 
@@ -65,8 +65,8 @@ my $bam_path = $instrument_data->bam_path;
 ok(-s $bam_path, 'bam path exists');
 is($bam_path, $instrument_data->data_directory.'/all_sequences.bam', 'bam path correctly named');
 is(eval{$instrument_data->attributes(attribute_label => 'bam_path')->attribute_value}, $bam_path, 'set attributes bam path');
-is(File::Compare::compare($bam_path, $test_dir.'/test.clean.sorted.bam'), 0, 'bam matches');
-is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/test.clean.sorted.bam.flagstat'), 0, 'flagstat matches');
+is(File::Compare::compare($bam_path, $test_dir.'/all_sequences.basic-bam-t.bam'), 0, 'bam matches');
+is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/all_sequences.basic-bam-t.bam.flagstat'), 0, 'flagstat matches');
 
 my $allocation = $instrument_data->disk_allocation;
 ok($allocation, 'got allocation');

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
@@ -17,6 +17,7 @@ use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::Basic') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
+Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class('Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup');
 
 my $analysis_project = Genome::Config::AnalysisProject->create(name => '__TEST_AP__');
 ok($analysis_project, 'create analysis project');

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
@@ -57,7 +57,7 @@ is($instrument_data->description, 'We took some DNA and sheared it and sequenced
 is($instrument_data->is_paired_end, 1, 'is_paired_end correctly set');
 is($instrument_data->read_count, 252, 'read_count correctly set');
 is($instrument_data->read_length, 100, 'read_length correctly set');
-is(eval{$instrument_data->attributes(attribute_label => 'segment_id')->attribute_value;}, '33333333333333333333333333333333', 'segment_id correctly set');
+is(eval{$instrument_data->attributes(attribute_label => 'segment_id')->attribute_value;}, '11111111111111111111111111111111', 'segment_id correctly set');
 is(eval{$instrument_data->attributes(attribute_label => 'original_data_path_md5')->attribute_value;}, 'f81fbc3d3a6b57d11e60b016bb2c950c', 'original_data_path_md5 correctly set');
 is($instrument_data->analysis_projects, $analysis_project, 'set analysis project');
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_downsample.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_downsample.t
@@ -17,6 +17,7 @@ use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::Basic') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
+Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class('Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup');
 
 my $analysis_project = Genome::Config::AnalysisProject->create(name => '__TEST_AP__');
 ok($analysis_project, 'create analysis project');
@@ -26,8 +27,8 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'bam/v4');
-my $source_bam = $test_dir.'/test.bam';
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1');
+my $source_bam = $test_dir.'/input.bam';
 ok(-s $source_bam, 'source bam exists') or die;
 
 my $cmd = Genome::InstrumentData::Command::Import::Basic->create(
@@ -56,7 +57,7 @@ is($instrument_data->is_paired_end, 1, 'is_paired_end correctly set');
 is($instrument_data->read_count, 68, 'read_count correctly set');
 is($instrument_data->read_length, 100, 'read_length correctly set');
 cmp_ok(eval{$instrument_data->attributes(attribute_label => 'downsample_ratio')->attribute_value;}, '==', 0.25, 'downsample_ratio correctly set');
-is(eval{$instrument_data->attributes(attribute_label => 'segment_id')->attribute_value;}, 2883581797, 'segment_id correctly set');
+is(eval{$instrument_data->attributes(attribute_label => 'segment_id')->attribute_value;}, '33333333333333333333333333333333', 'segment_id correctly set');
 is(eval{$instrument_data->attributes(attribute_label => 'original_data_path_md5')->attribute_value;}, 'f81fbc3d3a6b57d11e60b016bb2c950c', 'original_data_path_md5 correctly set');
 is($instrument_data->analysis_projects, $analysis_project, 'set analysis project');
 
@@ -65,11 +66,11 @@ ok(-s $bam_path, 'bam path exists');
 is($bam_path, File::Spec->catfile($instrument_data->data_directory, 'all_sequences.bam'), 'bam path correctly named');
 is(eval{$instrument_data->attributes(attribute_label => 'bam_path')->attribute_value}, $bam_path, 'set attributes bam path');
 is(# compare to the split version b/c just the downsampled bam header has attrs sorted differently
-    File::Compare::compare($bam_path, File::Spec->catfile($test_dir, 'test.clean.sorted.downsampled.split-by-rg.bam')),
+    File::Compare::compare($bam_path, File::Spec->catfile($test_dir, 'all_sequences.basic-bam-downsample-t.bam')),
     0, 'bam matches',
 );
 is(# compare to the downsampled flagstat
-    File::Compare::compare($bam_path.'.flagstat', File::Spec->catfile($test_dir, 'test.clean.sorted.downsampled.bam.flagstat')),
+    File::Compare::compare($bam_path.'.flagstat', File::Spec->catfile($test_dir, 'all_sequences.basic-bam-downsample-t.bam.flagstat')),
     0, 'flagstat matches',
 );
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_downsample.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_downsample.t
@@ -57,7 +57,7 @@ is($instrument_data->is_paired_end, 1, 'is_paired_end correctly set');
 is($instrument_data->read_count, 68, 'read_count correctly set');
 is($instrument_data->read_length, 100, 'read_length correctly set');
 cmp_ok(eval{$instrument_data->attributes(attribute_label => 'downsample_ratio')->attribute_value;}, '==', 0.25, 'downsample_ratio correctly set');
-is(eval{$instrument_data->attributes(attribute_label => 'segment_id')->attribute_value;}, '33333333333333333333333333333333', 'segment_id correctly set');
+is(eval{$instrument_data->attributes(attribute_label => 'segment_id')->attribute_value;}, '11111111111111111111111111111111', 'segment_id correctly set');
 is(eval{$instrument_data->attributes(attribute_label => 'original_data_path_md5')->attribute_value;}, 'f81fbc3d3a6b57d11e60b016bb2c950c', 'original_data_path_md5 correctly set');
 is($instrument_data->analysis_projects, $analysis_project, 'set analysis project');
 
@@ -78,4 +78,5 @@ my $allocation = $instrument_data->disk_allocation;
 ok($allocation, 'got allocation');
 ok($allocation->kilobytes_requested > 0, 'allocation kb was set');
 
+#print $instrument_data->bam_path."\n"; <STDIN>;
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_fails.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_fails.t
@@ -25,7 +25,7 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
-my $data_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', File::Spec->join('bam', 'v5'));
+my $data_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1') or die;
 my $source_file = File::Spec->join($data_dir, 'input.bam');
 
 throws_ok(

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_fastq.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_fastq.t
@@ -17,8 +17,9 @@ use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::Basic') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
+Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class('Genome::InstrumentData::Command::Import::WorkFlow::FastqsToBam');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v3');
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v5');
 my @source_files = (
     $test_dir.'/input.1.fastq.gz', 
     $test_dir.'/input.2.fastq',

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_fastq.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_fastq.t
@@ -19,7 +19,7 @@ use_ok('Genome::InstrumentData::Command::Import::Basic') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
 Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class('Genome::InstrumentData::Command::Import::WorkFlow::FastqsToBam');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v5');
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1');
 my @source_files = (
     $test_dir.'/input.1.fastq.gz', 
     $test_dir.'/input.2.fastq',
@@ -71,8 +71,8 @@ my $bam_path = $instrument_data->bam_path;
 ok(-s $bam_path, 'bam path exists');
 is($bam_path, $instrument_data->data_directory.'/all_sequences.bam', 'bam path correctly named');
 is(eval{$instrument_data->attributes(attribute_label => 'bam_path')->attribute_value}, $bam_path, 'set attributes bam path');
-is(File::Compare::compare($bam_path, $test_dir.'/all_sequences.bam'), 0, 'bam matches');
-is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/all_sequences.bam.flagstat'), 0, 'flagstat matches');
+is(File::Compare::compare($bam_path, $test_dir.'/all_sequences.basic-fastq-t.bam'), 0, 'bam matches');
+is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/all_sequences.basic-fastq-t.bam.flagstat'), 0, 'flagstat matches');
 
 my $allocation = $instrument_data->disk_allocation;
 ok($allocation, 'got allocation');

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_sra.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_sra.t
@@ -17,8 +17,9 @@ use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::Basic') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
+Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class('Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'sra/v4');
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1');
 my $source_sra = $test_dir.'/input.sra';
 ok(-s $source_sra, 'source sra exists') or die;
 
@@ -64,8 +65,8 @@ my $bam_path = $instrument_data->bam_path;
 ok(-s $bam_path, 'bam path exists');
 is($bam_path, $instrument_data->data_directory.'/all_sequences.bam', 'bam path correctly named');
 is(eval{$instrument_data->attributes(attribute_label => 'bam_path')->attribute_value}, $bam_path, 'set attributes bam path');
-is(File::Compare::compare($bam_path, $test_dir.'/input.sra.bam'), 0, 'sra dumped and sorted bam matches');
-is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/input.sra.bam.flagstat'), 0, 'flagstat matches');
+is(File::Compare::compare($bam_path, $test_dir.'/all_sequences.basic-sra-t.bam'), 0, 'bam matches');
+is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/all_sequences.basic-sra-t.bam.flagstat'), 0, 'flagstat matches');
 
 #print $instrument_data->data_directory."\n"; <STDIN>;
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/ArchiveToFastqs.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/ArchiveToFastqs.t
@@ -13,7 +13,7 @@ use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::ArchiveToFastqs') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::SourceFile') or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v1') or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1') or die;
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
 
 my $source_base_name = 'input.fastq.tgz';
@@ -46,7 +46,7 @@ ok(!-e $cmd->extract_directory, 'removed extract directory after extracting');
 # FAIL - no fastqs in archive
 $cmd = Genome::InstrumentData::Command::Import::WorkFlow::ArchiveToFastqs->execute(
     working_directory => $tmp_dir,
-    archive_path => File::Spec->join($test_dir, 'input.fail.no-fastqs.tar'),
+    archive_path => File::Spec->join($test_dir, 'archive-to-fastq.no-fastqs.tar'),
 );
 ok(!$cmd->result, 'execute failed');
 is($cmd->error_message, 'No fastqs found in archive!', 'correct error');

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/CreateInstrumentDataAndCopyBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/CreateInstrumentDataAndCopyBam.pm
@@ -144,24 +144,21 @@ sub _create_instrument_data_for_bam_path {
     $self->debug_message('Bam path: '.$bam_path);
 
     my $read_group_ids_from_bam = $self->helpers->load_read_groups_from_bam($bam_path);
-    return if not $read_group_ids_from_bam; # should only be one or 0
+    return if not $read_group_ids_from_bam;
+    if ( not @$read_group_ids_from_bam ) {
+        die $self->error_message('No read groups in bam!');
+    }
+    $self->debug_message("Read groups in bam: @$read_group_ids_from_bam");
     if ( @$read_group_ids_from_bam > 1 ) {
         $self->error_message('More than one read group in bam! '.$bam_path);
         return;
     }
 
     my $properties = $self->instrument_data_properties;
-
-    if ( @$read_group_ids_from_bam ) {
-        $self->debug_message("Read groups in bam: @$read_group_ids_from_bam");
-        if ( @$read_group_ids_from_bam > 1 ) {
-            $self->error_message('Multiple read groups in bam! '.$bam_path);
-            return;
-        }
-        $properties->{segment_id} = $read_group_ids_from_bam->[0];
-    }
+    $properties->{segment_id} = $read_group_ids_from_bam->[0];
 
     my $instrument_data = Genome::InstrumentData::Imported->create(
+        id => $read_group_ids_from_bam->[0],
         library => $self->library,
         subset_name => $self->instrument_data_subset_name,
         sequencing_platform => 'solexa',

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/CreateInstrumentDataAndCopyBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/CreateInstrumentDataAndCopyBam.t
@@ -30,8 +30,8 @@ ok($library, 'Create library');
 my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1');
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
 my @bams_info = (
-    [qw/ split-by-rg.2883581797.paired.bam    1 34 100 55555555555555555555555555555555 /],
-    [qw/ split-by-rg.2883581797.singleton.bam 0 94 100 66666666666666666666666666666666 /],
+    [qw/ split-by-rg.2883581797.paired.bam    1 34 100 11111111111111111111111111111111 /],
+    [qw/ split-by-rg.2883581797.singleton.bam 0 94 100 22222222222222222222222222222222 /],
 );
 my @bam_paths;
 for ( my $i = 0; $i < @bams_info; $i++ ) {

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/CreateInstrumentDataAndCopyBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/CreateInstrumentDataAndCopyBam.t
@@ -85,10 +85,10 @@ is(@instrument_data_ids, 2, "found instrument data for md5 $source_md5");
 for my $bam_data ( @bams_info ) {
     my ($bam_base_name, $is_paired_end, $read_count, $read_length, $rg_id) = @$bam_data;
     my $instrument_data = Genome::InstrumentData::Imported->get(
-        id => \@instrument_data_ids,
+        id => $rg_id,
         is_paired_end => $is_paired_end,
     );
-    ok($instrument_data, "found instrument data for is_paired_end $is_paired_end") or die 'cannot continue without instrument data';
+    ok($instrument_data, "found instrument data with rg_id for id $rg_id is_paired_end $is_paired_end") or die 'cannot continue without instrument data';
     is($instrument_data->subset_name, 'unknown', 'subset_name correctly set');
     is($instrument_data->sequencing_platform, 'solexa', 'sequencing_platform correctly set');
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/CreateInstrumentDataAndCopyBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/CreateInstrumentDataAndCopyBam.t
@@ -27,7 +27,7 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', File::Spec->join('bam-rg-multi', 'v5'));
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1');
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
 my @bams_info = (
     [qw/ split-by-rg.2883581797.paired.bam    1 34 100 55555555555555555555555555555555 /],

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.pm
@@ -113,7 +113,7 @@ sub _fastqs_to_bam {
         quality_format => 'Standard',
         sample_name => $self->sample_name,
         library_name => $self->library_name,
-        read_group_name => $self->library_name,
+        read_group_name => UR::Object::Type->autogenerate_new_object_id_uuid,
         use_version => '1.113',
     );
     if ( $fastqs[1] ) {

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.t
@@ -20,25 +20,10 @@ use Test::More;
 
 my $class = 'Genome::InstrumentData::Command::Import::WorkFlow::FastqsToBam';
 use_ok($class) or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v4') or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v5') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
 my $helpers = Genome::InstrumentData::Command::Import::WorkFlow::Helpers->get;
-
-my $autogenerate_new_object_id_uuid_sub = UR::Object::Type->can('autogenerate_new_object_id_uuid');
-Sub::Install::reinstall_sub({ # to set the RG ID in the bam
-        into => 'UR::Object::Type',
-        as => 'autogenerate_new_object_id_uuid',
-        code => sub{
-            my @caller = caller;
-            if ( $caller[0] eq $class ) {
-                return 'a' x 32;
-            }
-            else {
-                return $autogenerate_new_object_id_uuid_sub->();
-            }
-        },
-    });
-
+$helpers->overload_uuid_generator_for_class($class);
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
 
 my @source_fastq_base_names = (qw/ input.1.fastq.gz input.2.fastq /);

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.t
@@ -20,7 +20,7 @@ use Test::More;
 
 my $class = 'Genome::InstrumentData::Command::Import::WorkFlow::FastqsToBam';
 use_ok($class) or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v5') or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
 my $helpers = Genome::InstrumentData::Command::Import::WorkFlow::Helpers->get;
 $helpers->overload_uuid_generator_for_class($class);

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.t
@@ -15,12 +15,29 @@ require Genome::Utility::Test;
 require File::Compare;
 require File::Spec;
 require File::Temp;
+require Sub::Install;
 use Test::More;
 
-use_ok('Genome::InstrumentData::Command::Import::WorkFlow::FastqsToBam') or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v3') or die;
+my $class = 'Genome::InstrumentData::Command::Import::WorkFlow::FastqsToBam';
+use_ok($class) or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'fastq/v4') or die;
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::Helpers') or die;
 my $helpers = Genome::InstrumentData::Command::Import::WorkFlow::Helpers->get;
+
+my $autogenerate_new_object_id_uuid_sub = UR::Object::Type->can('autogenerate_new_object_id_uuid');
+Sub::Install::reinstall_sub({ # to set the RG ID in the bam
+        into => 'UR::Object::Type',
+        as => 'autogenerate_new_object_id_uuid',
+        code => sub{
+            my @caller = caller;
+            if ( $caller[0] eq $class ) {
+                return 'a' x 32;
+            }
+            else {
+                return $autogenerate_new_object_id_uuid_sub->();
+            }
+        },
+    });
 
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.pm
@@ -613,10 +613,10 @@ sub determine_read_length_in_bam {
 }
 #<>#
 
+my $autogenerate_new_object_id_uuid_sub = UR::Object::Type->can('autogenerate_new_object_id_uuid');
 sub overload_uuid_generator_for_class {
     my ($self, $class) = Params::Validate::validate_pos(@_, {isa => __PACKAGE__}, {type => SCALAR});
 
-    my $autogenerate_new_object_id_uuid_sub = UR::Object::Type->can('autogenerate_new_object_id_uuid');
     my $n = 0;
     Sub::Install::reinstall_sub({ # to set the RG ID in the bam
             into => 'UR::Object::Type',

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.pm
@@ -613,5 +613,25 @@ sub determine_read_length_in_bam {
 }
 #<>#
 
+sub overload_uuid_generator_for_class {
+    my ($self, $class) = Params::Validate::validate_pos(@_, {isa => __PACKAGE__}, {type => SCALAR});
+
+    my $autogenerate_new_object_id_uuid_sub = UR::Object::Type->can('autogenerate_new_object_id_uuid');
+    my $n = 0;
+    Sub::Install::reinstall_sub({ # to set the RG ID in the bam
+            into => 'UR::Object::Type',
+            as => 'autogenerate_new_object_id_uuid',
+            code => sub{
+                my @caller = caller;
+                if ( $caller[0] eq $class ) {
+                    return ++$n x 32;
+                }
+                else {
+                    return $autogenerate_new_object_id_uuid_sub->();
+            }
+        },
+    });
+}
+
 1;
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.t
@@ -54,14 +54,14 @@ is_deeply(
     'headers',
 );
 
-throws_ok(sub{ $helpers->read_groups_from_headers; }, qr//, 'failed to get read groups from headers w/o headers');
-my $read_groups_from_headers = $helpers->read_groups_from_headers($headers->{'@RG'});
+throws_ok(sub{ $helpers->read_groups_and_tags_from_headers; }, qr//, 'failed to get read groups from headers w/o headers');
+my $read_groups_and_tags = $helpers->read_groups_and_tags_from_headers($headers->{'@RG'});
 is_deeply(
-    $read_groups_from_headers, 
+    $read_groups_and_tags,
     {
-        2883581797 => 'CN:WUGSC	DS:paired end	DT:2012-12-17T13:15:46-0600	LB:TEST-patient1-somval_normal1-extlibs	PI:165	PL:illumina	PU:2883581797.	SM:TEST-patient1-somval_normal1',
-        2883581798 => 'CN:WUGSC	DS:paired end	DT:2012-12-17T13:15:46-0600	LB:TEST-patient1-somval_normal1-extlibs	PI:165	PL:illumina	PU:2883581798.	SM:TEST-patient1-somval_normal1',
-        2883581799 => 'CN:WUGSC	DS:paired end	DT:2012-12-17T13:15:46-0600	LB:TEST-patient1-somval_normal1-extlibs	PI:165	PL:illumina	PU:2883581799.	SM:TEST-patient1-somval_normal1',
+        2883581797 => { ID => 2883581797, CN => 'WUGSC', DS => 'paired end', DT => '2012-12-17T13:15:46-0600', LB => 'TEST-patient1-somval_normal1-extlibs', PI => '165', PL => 'illumina', PU => '2883581797.', SM => 'TEST-patient1-somval_normal1', },
+        2883581798 => { ID => 2883581798, CN => 'WUGSC', DS => 'paired end', DT => '2012-12-17T13:15:46-0600', LB => 'TEST-patient1-somval_normal1-extlibs', PI => '165', PL => 'illumina', PU => '2883581798.', SM => 'TEST-patient1-somval_normal1', },
+        2883581799 => { ID => 2883581799, CN => 'WUGSC', DS => 'paired end', DT => '2012-12-17T13:15:46-0600', LB => 'TEST-patient1-somval_normal1-extlibs', PI => '165', PL => 'illumina', PU => '2883581799.', SM => 'TEST-patient1-somval_normal1' , },
     },
     'read groups from headers',
 );

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.t
@@ -54,7 +54,7 @@ is_deeply(
     'headers',
 );
 
-ok(!eval{$helpers->read_groups_from_headers;}, 'failed to get read groups from headers w/o headers');
+throws_ok(sub{ $helpers->read_groups_from_headers; }, qr//, 'failed to get read groups from headers w/o headers');
 my $read_groups_from_headers = $helpers->read_groups_from_headers($headers->{'@RG'});
 is_deeply(
     $read_groups_from_headers, 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Helpers.t
@@ -228,4 +228,10 @@ for my $attr (qw/ bam_path is_paired_end read_count read_length /) {
     is($instdata->attributes(attribute_label => $attr)->attribute_value, $expected_attrs{$attr}, "$attr set")
 }
 
+# overload uuid generator for class
+isnt(UR::Object::Type->autogenerate_new_object_id_uuid, 1 x 32, 'uuid');
+throws_ok(sub{ $helpers->overload_uuid_generator_for_class; }, qr//, 'fail to overload uuid generator w/o class');
+ok($helpers->overload_uuid_generator_for_class('main'), 'overload uuid generator');
+is(UR::Object::Type->autogenerate_new_object_id_uuid, 1 x 32, 'overloaded uuid');
+
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/RetrieveSourcePath.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/RetrieveSourcePath.t
@@ -10,7 +10,7 @@ require File::Spec;
 use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::RetrieveSourcePath') or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'bam/v1') or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1') or die;
 
 # Minimal base class testing
 class Genome::InstrumentData::Command::Import::WorkFlow::RetrieveSourcePathTest {

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/RetrieveSourcePathFromLocalDisk.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/RetrieveSourcePathFromLocalDisk.t
@@ -11,7 +11,7 @@ require File::Temp;
 use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::RetrieveSourcePathFromLocalDisk') or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'bam/v5') or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1') or die;
 my $source_basename = 'input.bam';
 my $source_path =File::Spec->join($test_dir, $source_basename);
 my $source_md5_path = $source_path.'.md5';

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/RetrieveSourcePathFromRemoteUrl.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/RetrieveSourcePathFromRemoteUrl.t
@@ -11,7 +11,7 @@ use File::Temp;
 use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::RetrieveSourcePathFromRemoteUrl') or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'bam/v5') or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1') or die;
 my $source_basename = 'input.bam';
 my $source_path = 'file:/'.$test_dir.'/'.$source_basename;
 my $source_md5_path = $source_path.'.md5';

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -91,7 +91,7 @@ sub _process_reads {
         }
 
         if($tokens[0] eq $previous_tokens->[0] and $previous_read_group_id eq $read_group_id) {
-            my $fh = $self->_write_reads_based_on_read_group_and_pairedness(
+            $self->_write_reads_based_on_read_group_and_pairedness(
                 rg_id => $read_group_id,
                 pairedness => 'paired',
                 reads => [ $previous_tokens, \@tokens ],
@@ -99,7 +99,7 @@ sub _process_reads {
             undef $previous_tokens;
             undef $previous_read_group_id;
         } else {
-            my $fh = $self->_write_reads_based_on_read_group_and_pairedness(
+            $self->_write_reads_based_on_read_group_and_pairedness(
                 rg_id => $previous_read_group_id,
                 pairedness => 'singleton',
                 reads => [ $previous_tokens, ],
@@ -110,7 +110,7 @@ sub _process_reads {
     }
 
     if($previous_tokens) {
-        my $fh = $self->_write_reads_based_on_read_group_and_pairedness(
+        $self->_write_reads_based_on_read_group_and_pairedness(
             rg_id => $previous_read_group_id,
             pairedness => 'singleton',
             reads => [ $previous_tokens, ],

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -79,8 +79,8 @@ sub _process_reads {
     my $previous_tokens;
     my $previous_read_group_id;
     while ( my $line = $bam_fh->getline ) {
+        chomp $line;
         my @tokens = split(/\t/, $line);
-        chomp $tokens[$#tokens];
         my $read_group_id = $self->_get_rg_id_from_sam_tokens(\@tokens);
 
         unless($previous_tokens) {

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -73,8 +73,7 @@ sub _process_reads {
     $self->debug_message("Bam path: $bam_path");
     my $bam_fh = IO::File->new("samtools view $bam_path |");
     if ( not $bam_fh ) {
-        $self->error_message('Failed to open file handle to samtools command!');
-        return;
+        die $self->error_message('Failed to open file handle to samtools command!');
     }
 
     my $previous_tokens;
@@ -156,8 +155,7 @@ sub _verify_read_count {
     }
 
     if ( not @validated_output_bam_paths ) {
-        $self->error_message('No read group bams passed validation!');
-        return;
+        die $self->error_message('No read group bams passed validation!');
     }
 
     $self->output_bam_paths(\@validated_output_bam_paths);
@@ -169,8 +167,7 @@ sub _verify_read_count {
     $self->debug_message('Read group bams read count: '.$read_count);
 
     if ( $original_flagstat->{total_reads} != $read_count ) {
-        $self->error_message('Original and split by read group bam read counts do not match!');
-        return;
+        die $self->error_message('Original and split by read group bam read counts do not match!');
     }
 
     $self->debug_message('Verify read count...done');
@@ -226,8 +223,7 @@ sub _open_fh_for_read_group_and_pairedness {
     $self->debug_message("Opening fh for $read_group_bam_path $pairedness with:\n$samtools_cmd");
     my $fh = IO::File->new($samtools_cmd);
     if ( not $fh ) {
-        $self->error_message('Failed to open file handle to samtools command!');
-        return;
+        die $self->error_message('Failed to open file handle to samtools command!');
     }
 
     $self->_write_headers_for_read_group($fh, $read_group_id, $pairedness);

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -67,7 +67,7 @@ sub _set_headers_and_read_groups {
 
 sub _process_reads {
     my ($self) = @_;
-    $self->debug_message('Write reads...');
+    $self->debug_message('Processing reads...');
 
     my $bam_path = $self->bam_path;
     $self->debug_message("Bam path: $bam_path");
@@ -120,7 +120,7 @@ sub _process_reads {
         $fh->close;
     }
 
-    $self->debug_message('Write reads...done');
+    $self->debug_message('Processing reads...done');
     return 1;
 }
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -66,6 +66,9 @@ sub _set_headers_and_read_groups {
     my $read_groups_and_tags = $helpers->read_groups_and_tags_from_headers($read_group_headers);
     return if not $read_groups_and_tags;
 
+    # Add unknown rg
+    $read_groups_and_tags->{unknown} = { ID => 'unkown', CN => 'NA', };
+
     $self->headers($headers);
     $self->read_groups_and_tags($read_groups_and_tags);
 
@@ -213,10 +216,6 @@ sub _write_headers_for_read_group {
     $fh->print( $headers_as_string );
 
     my $read_groups_and_tags = $self->read_groups_and_tags;
-    unless(exists $read_groups_and_tags->{$read_group_id}) {
-        $read_groups_and_tags->{$read_group_id} = { ID => 'unknown', CN => 'NA', };
-    }
-
     my %rg_tags = %{$read_groups_and_tags->{$read_group_id}};
     my @tag_names = sort keys %rg_tags;
     splice(@tag_names, (List::MoreUtils::firstidx { $_ eq 'ID' } @tag_names), 1);

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -30,12 +30,6 @@ class Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup {
         old_and_new_read_group_ids => { is => 'HASH', default => {}, },
         _read_group_fhs => { is => 'HASH', default => {} },
     ],
-    has_optional_calculated => [
-        read_group_ids => {
-            calculate_from => [qw/ read_groups_and_tags /],
-            calculate => q( return keys %$read_groups_and_tags ), 
-        },
-    ],
 };
 
 sub execute {
@@ -44,8 +38,6 @@ sub execute {
 
     my $set_headers_and_read_groups = $self->_set_headers_and_read_groups;
     return if not $set_headers_and_read_groups;
-
-    my @read_group_ids = $self->read_group_ids;
 
     my $write_reads_ok = $self->_write_reads();
     return if not $write_reads_ok;

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -26,7 +26,6 @@ class Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup {
     has_optional_transient => [
         headers => { is => 'Array', },
         read_groups_and_headers => { is => 'Hash', default => {} },
-        removed_reads_cnt => { is => 'Number', },
         _read_group_fhs => { is => 'HASH', default => {} },
     ],
     has_optional_calculated => [
@@ -89,7 +88,6 @@ sub _write_reads {
         return;
     }
 
-    my $removed_reads_cnt = 0;
     my $previous_line;
     my $previous_id;
     my $previous_read_group_id;
@@ -133,9 +131,6 @@ sub _write_reads {
         $fh->close;
     }
 
-    $self->debug_message('Removed reads count: '.$removed_reads_cnt);
-    $self->removed_reads_cnt($removed_reads_cnt);
-
     $self->debug_message('Write reads...done');
     return 1;
 }
@@ -168,11 +163,10 @@ sub _verify_read_count {
     return if not $original_flagstat;
 
     $self->debug_message('Original bam read count: '.$original_flagstat->{total_reads});
-    $self->debug_message('Removed reads count: '.$self->removed_reads_cnt);
     $self->debug_message('Read group bams read count: '.$read_count);
 
-    if ( $original_flagstat->{total_reads} - $self->removed_reads_cnt != $read_count ) {
-        $self->error_message('Original and read group bam read counts do not match!');
+    if ( $original_flagstat->{total_reads} != $read_count ) {
+        $self->error_message('Original and split by read group bam read counts do not match!');
         return;
     }
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -39,7 +39,7 @@ sub execute {
     my $set_headers_and_read_groups = $self->_set_headers_and_read_groups;
     return if not $set_headers_and_read_groups;
 
-    my $write_reads_ok = $self->_write_reads();
+    my $write_reads_ok = $self->_process_reads;
     return if not $write_reads_ok;
 
     my $verify_read_count_ok = $self->_verify_read_count;
@@ -81,8 +81,7 @@ sub _set_headers_and_read_groups {
     return 1;
 }
 
-
-sub _write_reads {
+sub _process_reads {
     my ($self) = @_;
     $self->debug_message('Write reads...');
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -69,9 +69,8 @@ sub _set_headers_and_read_groups {
         my $rg_id = delete $rg_tags->{ID};
         $old_and_new_read_group_ids{$rg_id} = {
             paired => UR::Object::Type->autogenerate_new_object_id_uuid,
-            #singleton => UR::Object::Type->autogenerate_new_object_id_uuid,
+            singleton => UR::Object::Type->autogenerate_new_object_id_uuid,
         };
-        $old_and_new_read_group_ids{$rg_id}->{singleton} = $old_and_new_read_group_ids{$rg_id}->{paired};
     }
     $self->old_and_new_read_group_ids(\%old_and_new_read_group_ids);
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.pm
@@ -37,7 +37,6 @@ sub execute {
     $self->debug_message('Spilt bam by read group...');
 
     my $set_headers_and_read_groups = $self->_set_headers_and_read_groups;
-    return if not $set_headers_and_read_groups;
 
     my $write_reads_ok = $self->_process_reads;
     return if not $write_reads_ok;
@@ -54,12 +53,12 @@ sub _set_headers_and_read_groups {
 
     my $helpers = Genome::InstrumentData::Command::Import::WorkFlow::Helpers->get;
     my $headers = $helpers->load_headers_from_bam($self->bam_path);
-    return if not $headers;
+    die $self->error_message('Failed to get headers!') if not $headers;
     $self->headers($headers);
     
     my $read_group_headers = delete $headers->{'@RG'} || [];
     my $read_groups_and_tags = $helpers->read_groups_and_tags_from_headers($read_group_headers);
-    return if not $read_groups_and_tags;
+    die $self->error_message('Failed to get read groups and tags from headers!') if not $read_groups_and_tags;
     $self->read_groups_and_tags($read_groups_and_tags);
 
     return 1;

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
@@ -10,10 +10,28 @@ require File::Compare;
 require File::Spec;
 require File::Temp;
 require List::MoreUtils;
+require Sub::Install;
 use Test::More;
 
-use_ok('Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup') or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', File::Spec->join('bam-rg-multi', 'v4')) or die;
+my $class = 'Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup';
+use_ok($class) or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', File::Spec->join('bam-rg-multi', 'v5')) or die;
+
+my $autogenerate_new_object_id_uuid_sub = UR::Object::Type->can('autogenerate_new_object_id_uuid');
+my $n = 0;
+Sub::Install::reinstall_sub({ # to set the RG ID in the bam
+        into => 'UR::Object::Type',
+        as => 'autogenerate_new_object_id_uuid',
+        code => sub{
+            my @caller = caller;
+            if ( $caller[0] eq $class ) {
+                return ++$n x 32;
+            }
+            else {
+                return $autogenerate_new_object_id_uuid_sub->();
+            }
+        },
+    });
 
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
 my $multi_rg_base_name = 'input.rg-multi.bam';

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
@@ -6,26 +6,33 @@ use warnings;
 use above 'Genome';
 
 require Genome::Utility::Test;
+require File::Compare;
+require File::Spec;
 require File::Temp;
+require List::MoreUtils;
 use Test::More;
 
 use_ok('Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup') or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import') or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', File::Spec->join('bam-rg-multi', 'v4')) or die;
 
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
-my $multi_rg_base_name = 'input.rg-multi';
-my $multi_rg_bam_path = $tmp_dir.'/'.$multi_rg_base_name.'.bam';
-Genome::Sys->create_symlink($test_dir.'/bam-rg-multi/v3/'.$multi_rg_base_name.'.bam', $multi_rg_bam_path);
+my $multi_rg_base_name = 'input.rg-multi.bam';
+my $multi_rg_bam_path = File::Spec->join($tmp_dir, $multi_rg_base_name);
+Genome::Sys->create_symlink(File::Spec->join($test_dir, $multi_rg_base_name), $multi_rg_bam_path);
 ok(-s $multi_rg_bam_path, 'linked two read groups bam');
 my $cmd = Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup->execute(bam_path => $multi_rg_bam_path);
 ok($cmd->result, 'execute');
+
 my @output_bam_paths = $cmd->output_bam_paths;
-is(@output_bam_paths, 4, '4 read group bam paths');
-is_deeply(
-    [sort @output_bam_paths], 
-    [sort map { $tmp_dir.'/'.$multi_rg_base_name.'.'.$_.'.bam' } (qw/ 2883581797.paired 2883581797.singleton 2883581798.paired 2883581798.singleton /)],
-    '4 read groups bams paths');
-is(grep({ -s } @output_bam_paths), 4, 'read group bam paths exist');
+my @bam_basenames = (qw/ 2883581797.paired 2883581797.singleton 2883581798.paired 2883581798.singleton /);
+is(@output_bam_paths, @bam_basenames, '4 read group bam paths');
+for my $basename ( @bam_basenames ) {
+    my $output_bam_path = File::Spec::->join($tmp_dir, 'input.rg-multi.'.$basename.'.bam');
+    ok((List::MoreUtils::any { $_ eq $output_bam_path } @output_bam_paths), 'expected bam in output bams');
+    ok(-s $output_bam_path, 'expectred bam path exists');
+    my $expected_bam_path = File::Spec->join($test_dir, 'split-by-rg.'.$basename.'.bam');
+    is(File::Compare::compare($output_bam_path, $expected_bam_path), 0, "expected $basename bam path matches");
+}
 
 #print "$tmp_dir\n"; <STDIN>;
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
@@ -16,22 +16,7 @@ use Test::More;
 my $class = 'Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup';
 use_ok($class) or die;
 my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', File::Spec->join('bam-rg-multi', 'v5')) or die;
-
-my $autogenerate_new_object_id_uuid_sub = UR::Object::Type->can('autogenerate_new_object_id_uuid');
-my $n = 0;
-Sub::Install::reinstall_sub({ # to set the RG ID in the bam
-        into => 'UR::Object::Type',
-        as => 'autogenerate_new_object_id_uuid',
-        code => sub{
-            my @caller = caller;
-            if ( $caller[0] eq $class ) {
-                return ++$n x 32;
-            }
-            else {
-                return $autogenerate_new_object_id_uuid_sub->();
-            }
-        },
-    });
+Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class($class);
 
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
 my $multi_rg_base_name = 'input.rg-multi.bam';

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
@@ -47,7 +47,7 @@ is(@output_bam_paths, @bam_basenames, '4 read group bam paths');
 for my $basename ( @bam_basenames ) {
     my $output_bam_path = File::Spec::->join($tmp_dir, 'input.rg-multi.'.$basename.'.bam');
     ok((List::MoreUtils::any { $_ eq $output_bam_path } @output_bam_paths), 'expected bam in output bams');
-    ok(-s $output_bam_path, 'expectred bam path exists');
+    ok(-s $output_bam_path, 'expected bam path exists');
     my $expected_bam_path = File::Spec->join($test_dir, 'split-by-rg.'.$basename.'.bam');
     is(File::Compare::compare($output_bam_path, $expected_bam_path), 0, "expected $basename bam path matches");
 }

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SplitBamByReadGroup.t
@@ -15,7 +15,7 @@ use Test::More;
 
 my $class = 'Genome::InstrumentData::Command::Import::WorkFlow::SplitBamByReadGroup';
 use_ok($class) or die;
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', File::Spec->join('bam-rg-multi', 'v5')) or die;
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v1') or die;
 Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class($class);
 
 my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);


### PR DESCRIPTION
When processing files for import, generate a uuid for each read group and type (paired, singleton). Then use that red group id as the instrument data id.