### PR TITLE
Disable index creation in `gmt mutect`.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Mutect.pm
+++ b/lib/perl/Genome/Model/Tools/Mutect.pm
@@ -165,6 +165,7 @@ sub execute {
     $cmd .= " --only_passing_calls" if $self->only_passing_calls;
     $cmd .= " --vcf " . $self->vcf if $self->vcf;
     $cmd .= " --coverage_file " . $self->coverage_file if $self->coverage_file;
+    $cmd .= " --disable_auto_index_creation_and_locking_when_reading_rods"; #prevent lock contention when run in parallel
 
     my @intervals = $self->intervals;
     s/'/'\\''/g for @intervals; # escape strings for shell


### PR DESCRIPTION
When run in the pipeline it uses a hardcoded ROD that should already be indexed.  (See also
[this GATK forum thread](http://gatkforums.broadinstitute.org/discussion/1252/unifiedgenotyper-gets-hung-waiting-for-file-lock).)