### PR TITLE
Add intervals parameter for GATK HaplotypeCaller

### DIFF
--- a/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.pm
+++ b/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.pm
@@ -59,6 +59,13 @@ class Genome::Model::Tools::Gatk::HaplotypeCaller {
             is_many => 1,
             is_optional => 1,
         },
+        read_filters => {
+            is => 'Text',
+            is_many => 1,
+            is_optional => 1,
+            doc => 'Filters to apply to reads before analysis.',
+            gatk_param_name => '-rf',
+        },
     ],
 };
 

--- a/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.pm
+++ b/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.pm
@@ -51,6 +51,14 @@ class Genome::Model::Tools::Gatk::HaplotypeCaller {
             doc => 'GQ thresholds for reference confidence bands',
             is_optional => 1,
         },
+        intervals => {
+            is_input => 1,
+            is => 'Text',
+            gatk_param_name => '-L',
+            doc => 'restrict run to these regions (either a file or explicit intervals)',
+            is_many => 1,
+            is_optional => 1,
+        },
     ],
 };
 


### PR DESCRIPTION
Once the HaplotypeCaller is added to the pipeline, we'll be using the buckets from #1044 to fill in the `intervals` parameter added here.