### PR TITLE
Build with results from https://github.com/genome/genome/pull/1012

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
@@ -1,7 +1,7 @@
 ---
 apipe-test-amplicon-assembly: 133133151
 apipe-test-clinseq-v1: 133114501
-apipe-test-clinseq-wer: d64a5bb2f808434fa30f252c418c1d2c
+apipe-test-clinseq-wer: ae64b2da21034268b1a16cc5f1ecff72
 apipe-test-de-novo-soap: 137388725
 apipe-test-de-novo-velvet: 79a406fcf18c46e090dec62342b2c4ae
 apipe-test-gene-prediction-bacterial: 4ddaecaa52364dd09b3a4d7709ddfc3b


### PR DESCRIPTION
#1012 switched to separatedvaluereader from an incorrect regex.
The updated blessed-build has the correct results.