### PR TITLE
Add run_as to test factory model.

### DIFF
--- a/lib/perl/Genome/Model/Build/MetagenomicComposition16s/TestBuildFactory.pm
+++ b/lib/perl/Genome/Model/Build/MetagenomicComposition16s/TestBuildFactory.pm
@@ -68,7 +68,8 @@ sub build_with_example_build {
         name => '__TEST_MC16S_MODEL__',
         processing_profile => $pp,
         subject_name => $sample->name,
-        subject_type => 'sample_name'
+        subject_type => 'sample_name',
+        run_as => Genome::Sys->username,
     );
     die 'Failed to create MC16s model!' if not $model;
 


### PR DESCRIPTION
This way `Genome::SoftwareResult::User->user_hash_for_build` can find a sponsor.

(I don't understand how `Genome/Model/Build/MetagenomicComposition16s/ProcessAndMergeInstrumentData.t` has been passing before, but it currently fails for me even on the deployed snapshot.  This change fixes it.)