### PR TITLE
Remove old db_skip_postgres configuration variable.

### DIFF
--- a/etc/genome/spec/db_skip_postgres.yaml
+++ b/etc/genome/spec/db_skip_postgres.yaml
@@ -1,3 +1,0 @@
---- 
-env: XGENOME_DB_SKIP_POSTGRES
-default_value: ""


### PR DESCRIPTION
This variable could be used to skip writing to postgres.  Since support for writing to multiple databases is long gone, this is not useful.