### PR TITLE
Make Java 1.7 the default for running GATK tools.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Gatk/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Gatk/Base.pm
@@ -33,7 +33,7 @@ class Genome::Model::Tools::Gatk::Base {
         java_interpreter => {
             is => 'Text',
             doc => 'The java interpreter to use',
-            default_value => 'java',
+            default_value => Genome::Sys->java_executable_path('1.7'),
         },
     ],
     has_optional => [

--- a/lib/perl/Genome/Model/Tools/Gatk/Base.t
+++ b/lib/perl/Genome/Model/Tools/Gatk/Base.t
@@ -76,8 +76,10 @@ subtest 'optional parameters not specified' => sub {
 
     isa_ok($cmd, $pkg, 'created a dummy test command');
 
+    my $java_path = Genome::Model::Tools::Gatk::Base->__meta__->property(property_name => 'java_interpreter')->default_value;
+
     my @cmdline = $cmd->gatk_command;
-    is_deeply(\@cmdline,[qw(java -Xmx1g -Djava.io.tmpdir=/tmp/testing -jar), $cmd->gatk_path($gatk_version), qw(-et NO_ET -T Magic)], 'generated the expected command line');
+    is_deeply(\@cmdline,[$java_path, qw(-Xmx1g -Djava.io.tmpdir=/tmp/testing -jar), $cmd->gatk_path($gatk_version), qw(-et NO_ET -T Magic)], 'generated the expected command line');
 };
 
 done_testing();

--- a/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.t
+++ b/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.t
@@ -32,7 +32,6 @@ my $expected_output_vcf = File::Spec->join($test_data_dir, $output_filename);
 
 my $gatk_cmd = $pkg->create(
     version => '3.4',
-    java_interpreter => Genome::Sys->java_executable_path('1.7'),
     max_memory => 2,
     input_bam => $input_bam,
     reference_fasta => $input_reference,


### PR DESCRIPTION
The system default is currently at 1.6, but various tools in the "refine-reads" step have been segfaulting on 1.6, and using 1.7 resolves this.  Additionally newer versions of GATK require 1.7 or higher (such as for the `HaplotypeCaller`).