### PR TITLE
Add formatters to ResourceParser

### DIFF
--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -68,11 +68,11 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
-                     "numProcessors" : "1",
+                     "numProcessors" : 1,
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
                   "rLimits" : {
-                     "RSS" : "3000000"
+                     "RSS" : 3000000
                   },
                   "user" : "dmorton"
                },
@@ -164,11 +164,11 @@
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
                                                 "options" : {
-                                                   "numProcessors" : "1",
+                                                   "numProcessors" : 1,
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "rLimits" : {
-                                                   "RSS" : "3000000"
+                                                   "RSS" : 3000000
                                                 },
                                                 "user" : "dmorton"
                                              },

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -112,11 +112,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
-                                    "numProcessors" : "1",
+                                    "numProcessors" : 1,
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "rLimits" : {
-                                    "RSS" : "3000000"
+                                    "RSS" : 3000000
                                  },
                                  "user" : "dmorton"
                               },
@@ -210,11 +210,11 @@
                                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                                },
                                                                "options" : {
-                                                                  "numProcessors" : "1",
+                                                                  "numProcessors" : 1,
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
                                                                "rLimits" : {
-                                                                  "RSS" : "3000000"
+                                                                  "RSS" : 3000000
                                                                },
                                                                "user" : "dmorton"
                                                             },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -115,13 +115,13 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
-                     "numProcessors" : "4",
+                     "numProcessors" : 4,
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
                   "rLimits" : {
-                     "RSS" : "200000",
-                     "cpuTime" : "10"
+                     "RSS" : 200000,
+                     "cpuTime" : 10
                   },
                   "user" : "dmorton"
                },
@@ -166,13 +166,13 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
-                     "numProcessors" : "4",
+                     "numProcessors" : 4,
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
                   "rLimits" : {
-                     "RSS" : "200000",
-                     "cpuTime" : "10"
+                     "RSS" : 200000,
+                     "cpuTime" : 10
                   },
                   "user" : "dmorton"
                },
@@ -217,13 +217,13 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
-                     "numProcessors" : "4",
+                     "numProcessors" : 4,
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
                   "rLimits" : {
-                     "RSS" : "200000",
-                     "cpuTime" : "10"
+                     "RSS" : 200000,
+                     "cpuTime" : 10
                   },
                   "user" : "dmorton"
                },
@@ -268,13 +268,13 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
-                     "numProcessors" : "4",
+                     "numProcessors" : 4,
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
                   "rLimits" : {
-                     "RSS" : "200000",
-                     "cpuTime" : "10"
+                     "RSS" : 200000,
+                     "cpuTime" : 10
                   },
                   "user" : "dmorton"
                },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -161,13 +161,13 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
-                                    "numProcessors" : "4",
+                                    "numProcessors" : 4,
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
                                  "rLimits" : {
-                                    "RSS" : "200000",
-                                    "cpuTime" : "10"
+                                    "RSS" : 200000,
+                                    "cpuTime" : 10
                                  },
                                  "user" : "dmorton"
                               },
@@ -214,13 +214,13 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
-                                    "numProcessors" : "4",
+                                    "numProcessors" : 4,
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
                                  "rLimits" : {
-                                    "RSS" : "200000",
-                                    "cpuTime" : "10"
+                                    "RSS" : 200000,
+                                    "cpuTime" : 10
                                  },
                                  "user" : "dmorton"
                               },
@@ -267,13 +267,13 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
-                                    "numProcessors" : "4",
+                                    "numProcessors" : 4,
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
                                  "rLimits" : {
-                                    "RSS" : "200000",
-                                    "cpuTime" : "10"
+                                    "RSS" : 200000,
+                                    "cpuTime" : 10
                                  },
                                  "user" : "dmorton"
                               },
@@ -320,13 +320,13 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
-                                    "numProcessors" : "4",
+                                    "numProcessors" : 4,
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
                                  "rLimits" : {
-                                    "RSS" : "200000",
-                                    "cpuTime" : "10"
+                                    "RSS" : 200000,
+                                    "cpuTime" : 10
                                  },
                                  "user" : "dmorton"
                               },

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -99,11 +99,11 @@
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
                                                 "options" : {
-                                                   "numProcessors" : "1",
+                                                   "numProcessors" : 1,
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "rLimits" : {
-                                                   "RSS" : "3000000"
+                                                   "RSS" : 3000000
                                                 },
                                                 "user" : "dmorton"
                                              },

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -140,11 +140,11 @@
                                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                                },
                                                                "options" : {
-                                                                  "numProcessors" : "1",
+                                                                  "numProcessors" : 1,
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
                                                                "rLimits" : {
-                                                                  "RSS" : "3000000"
+                                                                  "RSS" : 3000000
                                                                },
                                                                "user" : "dmorton"
                                                             },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -53,11 +53,11 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
-                     "numProcessors" : "1",
+                     "numProcessors" : 1,
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
                   "rLimits" : {
-                     "RSS" : "3000000"
+                     "RSS" : 3000000
                   },
                   "user" : "dmorton"
                },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -94,11 +94,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
-                                    "numProcessors" : "1",
+                                    "numProcessors" : 1,
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "rLimits" : {
-                                    "RSS" : "3000000"
+                                    "RSS" : 3000000
                                  },
                                  "user" : "dmorton"
                               },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -76,11 +76,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
-                                    "numProcessors" : "1",
+                                    "numProcessors" : 1,
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "rLimits" : {
-                                    "RSS" : "3000000"
+                                    "RSS" : 3000000
                                  },
                                  "user" : "dmorton"
                               },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -117,11 +117,11 @@
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
                                                 "options" : {
-                                                   "numProcessors" : "1",
+                                                   "numProcessors" : 1,
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "rLimits" : {
-                                                   "RSS" : "3000000"
+                                                   "RSS" : 3000000
                                                 },
                                                 "user" : "dmorton"
                                              },

--- a/lib/perl/Genome/Sys/LSF/ResourceParser.pm
+++ b/lib/perl/Genome/Sys/LSF/ResourceParser.pm
@@ -81,9 +81,9 @@ sub _create_option_spec {
     return ("$option=s" => sub { my ($option_name, $value, )});
 }
 
-sub null_formatter {
+sub string_formatter {
     my $value = shift;
-    return $value;
+    return "$value";
 }
 
 sub number_formatter {
@@ -92,20 +92,20 @@ sub number_formatter {
 }
 
 my %formatters = (
-    'b' => \&null_formatter,
-    'e' => \&null_formatter,
-    'g' => \&null_formatter,
-    'i' => \&null_formatter,
-    'J' => \&null_formatter,
-    'u' => \&null_formatter,
+    'b' => \&string_formatter,
+    'e' => \&string_formatter,
+    'g' => \&string_formatter,
+    'i' => \&string_formatter,
+    'J' => \&string_formatter,
+    'u' => \&string_formatter,
     'n' => \&number_formatter,
-    'o' => \&null_formatter,
-    'E' => \&null_formatter,
-    'Ep' => \&null_formatter,
-    'P' => \&null_formatter,
-    'q' => \&null_formatter,
-    'R' => \&null_formatter,
-    't' => \&null_formatter,
+    'o' => \&string_formatter,
+    'E' => \&string_formatter,
+    'Ep' => \&string_formatter,
+    'P' => \&string_formatter,
+    'q' => \&string_formatter,
+    'R' => \&string_formatter,
+    't' => \&string_formatter,
 
     'c' => \&number_formatter,
     'M' => \&number_formatter,

--- a/lib/perl/Genome/Sys/LSF/ResourceParser.pm
+++ b/lib/perl/Genome/Sys/LSF/ResourceParser.pm
@@ -58,18 +58,20 @@ sub _create_getopt_specs {
 
 sub _lookup_spec_for_bsub_option {
     my ($bsub_option, $submit_field, $destination) = @_;
+    my $formatter = _formatters($bsub_option);
     if ($bsub_option eq 'n') {
         return("$bsub_option=s" => sub {
                 my ($option_name, $option_value) = @_;
                 my ($num, $max_num) = split q{,}, $option_value;
-                $destination->{numProcessors} = $num;
-                $destination->{maxNumProcessors} = $max_num if defined $max_num;
+                $destination->{numProcessors} = $formatter->($num);
+                $destination->{maxNumProcessors} = $formatter->($max_num)
+                    if defined $max_num;
             });
     }
     else {
         return("$bsub_option=s" => sub {
                 my ($option_name, $option_value) = @_;
-                $destination->{$submit_field} = $option_value;
+                $destination->{$submit_field} = $formatter->($option_value);
             });
     }
 }
@@ -77,6 +79,42 @@ sub _lookup_spec_for_bsub_option {
 sub _create_option_spec {
     my ($option, $dictionary) = @_;
     return ("$option=s" => sub { my ($option_name, $value, )});
+}
+
+sub null_formatter {
+    my $value = shift;
+    return $value;
+}
+
+sub number_formatter {
+    my $value = shift;
+    return $value + 0;
+}
+
+my %formatters = (
+    'b' => \&null_formatter,
+    'e' => \&null_formatter,
+    'g' => \&null_formatter,
+    'i' => \&null_formatter,
+    'J' => \&null_formatter,
+    'u' => \&null_formatter,
+    'n' => \&number_formatter,
+    'o' => \&null_formatter,
+    'E' => \&null_formatter,
+    'Ep' => \&null_formatter,
+    'P' => \&null_formatter,
+    'q' => \&null_formatter,
+    'R' => \&null_formatter,
+    't' => \&null_formatter,
+
+    'c' => \&number_formatter,
+    'M' => \&number_formatter,
+    'F' => \&number_formatter,
+    'S' => \&number_formatter,
+);
+sub _formatters {
+    my $key = shift;
+    return $formatters{$key};
 }
 
 my %valid_options = (


### PR DESCRIPTION
This ensures that later, when we prepare to submit a workflow to PTero, that the JSON formatter treats some values as numbers instead of strings.