### PR TITLE
Use submit_url option when submitting PTero workflows

### DIFF
--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -136,7 +136,6 @@ sub run {
         return $self->_execute_process($transaction);
     } else {
         if (Genome::Config::get('workflow_builder_backend') eq 'ptero') {
-            local $ENV{PTERO_WORKFLOW_SUBMIT_URL} = Genome::Config::get('ptero_workflow_submit_url');
             $self->_submit_process($transaction);
         } else {
             local $ENV{WF_USE_FLOW} = 1 unless

--- a/lib/perl/Genome/WorkflowBuilder/DAG.pm
+++ b/lib/perl/Genome/WorkflowBuilder/DAG.pm
@@ -123,7 +123,11 @@ sub submit {
     if ($backend eq 'ptero') {
         my $wf_builder = $self->get_ptero_builder_for_process($process);
 
-        my $wf_proxy = $wf_builder->submit(inputs => encode($inputs), name => $process->workflow_name);
+        my $wf_proxy = $wf_builder->submit(
+            inputs => encode($inputs),
+            submit_url => Genome::Config::get('ptero_workflow_submit_url'),
+            name => $process->workflow_name
+        );
         $self->status_message("Submitted workflow to petri service: %s",
             $wf_proxy->url);
         return $wf_proxy;
@@ -159,7 +163,10 @@ sub _execute_with_ptero {
 
     my $wf_builder = $self->get_ptero_builder($self->name);
 
-    my $wf_proxy = $wf_builder->submit( inputs => encode($used_inputs) );
+    my $wf_proxy = $wf_builder->submit(
+        inputs => encode($used_inputs),
+        submit_url => Genome::Config::get('ptero_workflow_submit_url'),
+    );
     $self->status_message("Waiting on PTero workflow (%s) to complete",
         $wf_proxy->url);
     Genome::Sys->disconnect_default_handles;


### PR DESCRIPTION
Instead of setting the PTERO_WORKFLOW_SUBMIT_URL env variable.  This uses features made available here: https://github.com/genome/ptero-perl-sdk/pull/96