### PR TITLE
Add reagent info of new target_region_set_name to TCGA Sdrf.pm

### DIFF
--- a/lib/perl/Genome/Model/Tools/Tcga/Sdrf.pm
+++ b/lib/perl/Genome/Model/Tools/Tcga/Sdrf.pm
@@ -641,6 +641,14 @@ sub capture_reagents {
                 target_file    => 'https://earray.chem.agilent.com/earray/',
             },
         ],
+        'agilent_sureselect_exome_version_2_broad_refseq_cds_only_hs37' => [
+            {
+                reagent_vendor => 'Agilent',
+                reagent_name   => 'SureSelect Human All Exon 38 Mb v2',
+                catalog_number => 'S0293689',
+                target_file    => 'https://earray.chem.agilent.com/earray/',
+            },
+        ],
         'hg18 nimblegen exome version 2' => [
             {
                 reagent_vendor => 'Nimblegen',


### PR DESCRIPTION
The reagent info of new target_region_set_name: agilent_sureselect_exome_version_2_broad_refseq_cds_only_hs37 is added to make create-submission-archive working on models with that target_region_set_name. Refer to https://rt.gsc.wustl.edu/Ticket/Display.html?id=108635