### PR TITLE
Ncallers fix

### DIFF
--- a/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/interpreters/variant-callers
+++ b/lib/perl/Genome/VariantReporting/Command/ShowDocs.t.expected-output/interpreters/variant-callers
@@ -8,6 +8,7 @@ Output a list of variant callers that called this position for the specified sam
     This is a translated property.
   [1mvalid_callers[0m   String
     List of variant callers to include in determination for filtering
+    Default value ["VarscanSomatic", "Sniper", "Strelka"] if not specified
 
 [4mAVAILABLE FIELDS[0m
   [1mvariant_caller_count[0m

--- a/lib/perl/Genome/VariantReporting/Generic/NCallersBase.pm
+++ b/lib/perl/Genome/VariantReporting/Generic/NCallersBase.pm
@@ -1,0 +1,45 @@
+package Genome::VariantReporting::Generic::NCallersBase;
+
+use strict;
+use warnings;
+use Genome;
+use List::MoreUtils qw/uniq/;
+
+class Genome::VariantReporting::Generic::NCallersBase {
+    is => 'Genome::VariantReporting::Framework::Component::WithSampleName',
+    has => [
+        valid_callers => {
+            is => 'String',
+            is_many => 1,
+            default_value => [qw(VarscanSomatic Sniper Strelka)],
+            doc => 'List of variant callers to include in determination for filtering',
+        },
+    ],
+};
+
+sub get_callers {
+    my ($self, $entry, $alts) = @_;
+    my %callers;
+    for my $alt (@$alts) {
+        $callers{$alt} = [];
+    }
+    for my $caller_name (sort $self->valid_callers) {
+        my $sample_name = $self->sample_name_with_suffix($caller_name);
+        my $sample_index = eval{ $entry->{header}->index_for_sample_name($sample_name) };
+        my $error = $@;
+        if ($error =~ /^\QSample name $sample_name not found in header\E/) {
+            next;
+        }
+        my $caller_filtered = $entry->sample_field($sample_index, "FT");
+        if (defined $caller_filtered and $caller_filtered ne ".") {
+            next;
+        }
+        my @sample_alt_alleles = $entry->alt_bases_for_sample($sample_index);
+        for my $sample_alt_allele (uniq @sample_alt_alleles) {
+            push(@{$callers{$sample_alt_allele}}, $caller_name);
+        }
+    }
+    return %callers;
+}
+1;
+

--- a/lib/perl/Genome/VariantReporting/Generic/NCallersBase.pm
+++ b/lib/perl/Genome/VariantReporting/Generic/NCallersBase.pm
@@ -31,7 +31,7 @@ sub get_callers {
             next;
         }
         my $caller_filtered = $entry->sample_field($sample_index, "FT");
-        if (defined $caller_filtered and $caller_filtered ne ".") {
+        if (defined $caller_filtered and $caller_filtered ne "." and $caller_filtered ne "PASS") {
             next;
         }
         my @sample_alt_alleles = $entry->alt_bases_for_sample($sample_index);

--- a/lib/perl/Genome/VariantReporting/Generic/NCallersFilter.pm
+++ b/lib/perl/Genome/VariantReporting/Generic/NCallersFilter.pm
@@ -47,6 +47,10 @@ sub filter_entry {
         if ($error =~ /^\QSample name $sample_name not found in header\E/) {
             next;
         }
+        my $caller_filtered = $entry->sample_field($sample_index, "FT");
+        if (defined $caller_filtered and $caller_filtered ne ".") {
+            next;
+        }
         my @sample_alt_alleles = $entry->alt_bases_for_sample($sample_index);
         for my $sample_alt_allele (@sample_alt_alleles) {
             $caller_counts{$sample_alt_allele}++;

--- a/lib/perl/Genome/VariantReporting/Generic/NCallersFilter.pm
+++ b/lib/perl/Genome/VariantReporting/Generic/NCallersFilter.pm
@@ -5,17 +5,11 @@ use warnings;
 use Genome;
 
 class Genome::VariantReporting::Generic::NCallersFilter {
-    is => ['Genome::VariantReporting::Framework::Component::Filter', 'Genome::VariantReporting::Framework::Component::WithSampleName'],
+    is => ['Genome::VariantReporting::Framework::Component::Filter', 'Genome::VariantReporting::Generic::NCallersBase'],
     has => [
         min_callers => {
             is => 'Integer',
             doc => 'Variant must be called by at least this many callers',
-        },
-        valid_callers => {
-            is => 'String',
-            is_many => 1,
-            default_value => [qw(VarscanSomatic Sniper Strelka)],
-            doc => 'List of variant callers to include in determination for filtering',
         },
     ],
     doc => q{Filter out variants that weren't called by the minimum number of the specified callers},
@@ -34,30 +28,12 @@ sub filter_entry {
     my $entry = shift;
 
     my %return_values;
-    my %caller_counts;
     for my $alt_allele (@{$entry->{alternate_alleles}}) {
         $return_values{$alt_allele} = 0;
-        $caller_counts{$alt_allele} = 0;
     }
-
-    for my $caller_name ($self->valid_callers) {
-        my $sample_name = $self->sample_name_with_suffix($caller_name);
-        my $sample_index = eval{ $entry->{header}->index_for_sample_name($sample_name) };
-        my $error = $@;
-        if ($error =~ /^\QSample name $sample_name not found in header\E/) {
-            next;
-        }
-        my $caller_filtered = $entry->sample_field($sample_index, "FT");
-        if (defined $caller_filtered and $caller_filtered ne ".") {
-            next;
-        }
-        my @sample_alt_alleles = $entry->alt_bases_for_sample($sample_index);
-        for my $sample_alt_allele (@sample_alt_alleles) {
-            $caller_counts{$sample_alt_allele}++;
-        }
-    }
+    my %callers = $self->get_callers($entry, $entry->{alternate_alleles});
     for my $alt_allele (keys %return_values) {
-        if ($caller_counts{$alt_allele} >= $self->min_callers) {
+        if (@{$callers{$alt_allele}} >= $self->min_callers) {
             $return_values{$alt_allele} = 1;
         }
     }

--- a/lib/perl/Genome/VariantReporting/Generic/NCallersFilter.t
+++ b/lib/perl/Genome/VariantReporting/Generic/NCallersFilter.t
@@ -50,6 +50,22 @@ subtest "sample 2" => sub {
     is_deeply({$filter->filter_entry($entry)}, \%expected_return_values, "Sample 1 return values as expected");
 };
 
+subtest "sample 3 individual callers filtered" => sub {
+    my $filter = $pkg->create(
+        sample_name => "S3",
+        min_callers => 2,
+    );
+    lives_ok(sub {$filter->validate}, "Filter validates ok");
+
+    my $entry = create_entry();
+
+    my %expected_return_values = (
+        C => 0,
+        G => 0,
+    );
+    is_deeply({$filter->filter_entry($entry)}, \%expected_return_values, "Sample 3 return values as expected");
+};
+
 subtest "Nonexistent Caller" => sub {
     my $filter = $pkg->create(
         sample_name => "S1",
@@ -80,7 +96,7 @@ sub create_vcf_header {
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
 ##FORMAT=<ID=FT,Number=.,Type=String,Description="Filter">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S1-[VarscanSomatic]	S1-[Sniper]	S1-[Strelka]	S2	S2-[VarscanSomatic]	S2-[Sniper]	S2-[Strelka]
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S1-[VarscanSomatic]	S1-[Sniper]	S1-[Strelka]	S2	S2-[VarscanSomatic]	S2-[Sniper]	S2-[Strelka]	S3	S3-[VarscanSomatic]	S3-[Sniper]	S3-[Strelka]
 EOS
     my @lines = split("\n", $header_txt);
     my $header = Genome::File::Vcf::Header->create(lines => \@lines);
@@ -97,7 +113,7 @@ sub create_entry {
         '10.3',         # QUAL
         'PASS',         # FILTER
         'A=B;C=8,9;E',  # INFO
-        'GT:DP',     # FORMAT
+        'GT:DP:FT',     # FORMAT
         "0/1:12",   # FIRST_SAMPLE
         "0/0:12",   # FIRST_SAMPLE_Varscan
         "1/1:12",   # First_SAMPLE_Sniper
@@ -106,6 +122,10 @@ sub create_entry {
         ".",   # SECOND_SAMPLE_Varscan
         ".",   # SECOND_SAMPLE_Sniper
         "1/2:12",   # Second_SAMPLE_Strelka
+        "0/0:12",   # THIRD_SAMPLE
+        "1/2",   # THIRD_SAMPLE_Varscan
+        "1/2:.:NOT",   # THIRD_SAMPLE_Sniper
+        "1/2:12:NOT",   # THIRD_SAMPLE_Strelka
     );
 
     my $entry_txt = join("\t", @fields);

--- a/lib/perl/Genome/VariantReporting/Generic/VariantCallersInterpreter.pm
+++ b/lib/perl/Genome/VariantReporting/Generic/VariantCallersInterpreter.pm
@@ -3,18 +3,10 @@ package Genome::VariantReporting::Generic::VariantCallersInterpreter;
 use strict;
 use warnings;
 use Genome;
-use List::MoreUtils qw/uniq/;
 
 class Genome::VariantReporting::Generic::VariantCallersInterpreter {
-    is => ['Genome::VariantReporting::Framework::Component::Interpreter', 'Genome::VariantReporting::Framework::Component::WithSampleName'],
+    is => ['Genome::VariantReporting::Framework::Component::Interpreter', 'Genome::VariantReporting::Generic::NCallersBase'],
     doc => 'Output a list of variant callers that called this position for the specified sample, as well as the number of callers',
-    has => [
-        valid_callers => {
-            is => 'String',
-            is_many => 1,
-            doc => 'List of variant callers to include in determination for filtering',
-        },
-    ],
 };
 
 sub name {
@@ -39,26 +31,11 @@ sub _interpret_entry {
     my $passed_alt_alleles = shift;
 
     my %return_values;
-    my %callers;
     for my $alt_allele (@$passed_alt_alleles) {
         $return_values{$alt_allele} = { variant_callers => [] };
-        $callers{$alt_allele} = [];
     }
 
-    for my $caller_name ($self->valid_callers) {
-        my $sample_name = $self->sample_name_with_suffix($caller_name);
-        my $sample_index = eval{ $entry->{header}->index_for_sample_name($sample_name) };
-        my $error = $@;
-        if (defined($error) &&
-            $error =~ /^\QSample name $sample_name not found in header\E/) {
-            next;
-        }
-        my @sample_alt_alleles = $entry->alt_bases_for_sample($sample_index);
-        for my $sample_alt_allele (uniq @sample_alt_alleles) {
-            push(@{$callers{$sample_alt_allele}}, $caller_name);
-        }
-    }
-
+    my %callers = $self->get_callers($entry, $passed_alt_alleles);
     for my $alt_allele (keys %return_values) {
         $return_values{$alt_allele} = {
             variant_callers => $callers{$alt_allele},

--- a/lib/perl/Genome/VariantReporting/Generic/VariantCallersInterpreter.t
+++ b/lib/perl/Genome/VariantReporting/Generic/VariantCallersInterpreter.t
@@ -101,6 +101,20 @@ subtest "sample with non-valid caller" => sub {
     run_test($sample_name, %expected_return_values);
 };
 
+subtest "sample with filtered callers" => sub {
+    my $sample_name = "S5";
+    my %expected_return_values = (
+        C => {
+            variant_callers => [qw/Sniper/],
+            variant_caller_count => 1,
+        },
+        G => {
+            variant_callers => [],
+            variant_caller_count => 0,
+        },
+    );
+    run_test($sample_name, %expected_return_values);
+};
 done_testing;
 
 sub run_test {
@@ -130,7 +144,7 @@ sub create_vcf_header {
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
 ##FORMAT=<ID=FT,Number=.,Type=String,Description="Filter">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S1-[VarscanSomatic]	S1-[Sniper]	S1-[Strelka]	S2	S2-[VarscanSomatic]	S2-[Sniper]	S2-[Strelka]	S3	S3-[VarscanSomatic]	S3-[Sniper]	S3-[Strelka]	S4	S4-[VarscanSomatic]	S4-[Sniper]	S4-[Strelka]	S4-[Samtools]
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S1-[VarscanSomatic]	S1-[Sniper]	S1-[Strelka]	S2	S2-[VarscanSomatic]	S2-[Sniper]	S2-[Strelka]	S3	S3-[VarscanSomatic]	S3-[Sniper]	S3-[Strelka]	S4	S4-[VarscanSomatic]	S4-[Sniper]	S4-[Strelka]	S4-[Samtools]	S5	S5-[VarscanSomatic]	S5-[Sniper]	S5-[Strelka]
 
 EOS
     my @lines = split("\n", $header_txt);
@@ -148,7 +162,7 @@ sub create_entry {
         '10.3',         # QUAL
         'PASS',         # FILTER
         'A=B;C=8,9;E',  # INFO
-        'GT:DP',     # FORMAT
+        'GT:DP:FT',     # FORMAT
         "0/1:12",   # FIRST_SAMPLE
         "0/0:12",   # FIRST_SAMPLE_Varscan
         "1/1:12",   # First_SAMPLE_Sniper
@@ -166,6 +180,10 @@ sub create_entry {
         "1/1:12",   # FOURTH_SAMPLE_Sniper
         "1/2:12",   # FOURTH_SAMPLE_Strelka
         "0/1:12",   # FOURTH_SAMPLE_Samtools
+        "0/1:12",   # FIFTH_SAMPLE
+        "0/0:12:.",   # FIFTH_SAMPLE_Varscan
+        "1/1:12:.",   # FIFTH_SAMPLE_Sniper
+        "1/2:12:BAD",   # FIFTH_SAMPLE_Strelka
     );
 
     my $entry_txt = join("\t", @fields);


### PR DESCRIPTION
The reports were including variants that were filtered out upstream by one or more of the individual callers, but those callers were being counted toward the 'n-callers' filter cutoff, which is not desirable.  I also did a small refactor so that the n-callers filter and variant-callers interpreter now use the same bit of code to decide which filters to count/include