### PR TITLE
Exclude index results from CLE verification.

### DIFF
--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -9,7 +9,7 @@ use Data::Dump qw(pp);
 use Scalar::Util qw();
 use Try::Tiny qw(try catch);
 use JSON qw(to_json);
-use List::MoreUtils qw(uniq);
+use List::MoreUtils qw(uniq any);
 use Genome::Disk::Group::Validate::GenomeDiskGroups;
 use Genome::Utility::Inputs qw(encode);
 use Cwd qw(abs_path);
@@ -657,7 +657,7 @@ sub is_cle_verified {
     my $self = shift;
 
     for my $result ($self->unique_results) {
-        unless ($self->result_is_on_cle_disk_group($result)) {
+        unless ($self->result_is_index_result($result) or $self->result_is_on_cle_disk_group($result)) {
             return 0;
         }
     }
@@ -672,6 +672,13 @@ sub result_is_on_cle_disk_group {
     my $disk_group_name = $allocation->disk_group_name;
 
     return Genome::Disk::Group::Validate::GenomeDiskGroups::is_cle_disk_group_name($disk_group_name);
+}
+
+sub result_is_index_result {
+    my $self = shift;
+    my $result = shift;
+
+    return any { $result->isa($_) } (qw(Genome::Db::Ensembl::Api Genome::Db::Ensembl::VepCache));
 }
 
 sub compare_output {


### PR DESCRIPTION
These results do not depend on any of the data being analyzed, and as such are not CLE-specific.