### PR TITLE
Run the HaplotypeCaller serially on each contig in a bucket.

### DIFF
--- a/lib/perl/Genome/Model/SingleSampleGenotype.pm.xml
+++ b/lib/perl/Genome/Model/SingleSampleGenotype.pm.xml
@@ -15,7 +15,7 @@
       <operationtype commandClass="Genome::Model::SingleSampleGenotype::Command::QualityControl" typeClass="Workflow::OperationType::Command"/>
   </operation>
   <operation name="HaplotypeCaller" parallelBy="bucket">
-      <operationtype commandClass="Genome::Model::SingleSampleGenotype::Command::HaplotypeCaller" typeClass="Workflow::OperationType::Command"/>
+      <operationtype commandClass="Genome::Model::SingleSampleGenotype::Command::HaplotypeCaller::BucketIterator" typeClass="Workflow::OperationType::Command"/>
   </operation>
 
   <operationtype typeClass="Workflow::OperationType::Model">

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller.pm
@@ -9,9 +9,10 @@ class Genome::Model::SingleSampleGenotype::Command::HaplotypeCaller {
     is => 'Genome::Model::SingleSampleGenotype::Command::Base',
     doc => 'Runs the Haplotype Caller on the alignments',
     has_optional_input => [
-        bucket => {
+        intervals => {
             is => 'Text',
-            doc => 'bucket of chromosomes to restrict this run of the haplotype caller',
+            doc => 'intervals to restrict this run of the haplotype caller',
+            is_many => 1,
         },
     ],
 };
@@ -46,16 +47,6 @@ sub _params_for_command {
 
 sub _label_for_result {
     return 'haplotype_caller_result';
-}
-
-sub intervals {
-    my $self = shift;
-    my $build = $self->build;
-    my $bucket = $self->bucket;
-
-    return unless $bucket;
-
-    return $build->buckets_result->bucket($bucket);
 }
 
 1;

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller/BucketIterator.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller/BucketIterator.pm
@@ -1,0 +1,67 @@
+package Genome::Model::SingleSampleGenotype::Command::HaplotypeCaller::BucketIterator;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::SingleSampleGenotype::Command::HaplotypeCaller::BucketIterator {
+    is => 'Command::V2',
+    doc => 'Runs the Haplotype Caller on the alignments',
+    has_input => [
+        bucket => {
+            is => 'Text',
+            doc => 'bucket to restrict this run of the haplotype caller',
+        },
+        build => {
+            is => 'Genome::Model::Build::SingleSampleGenotype',
+            doc => 'build for which to run the command',
+            is_output => 1,
+            shell_args_position => 1,
+        },
+    ],
+    doc => 'Runs the haplotype-caller command for each interval in the bucket',
+};
+
+sub shortcut {
+    return $_[0]->_run('shortcut');
+}
+
+sub execute {
+    return $_[0]->_run('execute');
+}
+
+sub _run {
+    my $self = shift;
+    my $mode = shift;
+
+    for my $interval ($self->intervals) {
+        $self->debug_message('Attempting to %s for interval %s.', $mode, $interval);
+        my $cmd = Genome::Model::SingleSampleGenotype::Command::HaplotypeCaller->create(
+            build => $self->build,
+            intervals => [$interval],
+        );
+
+        unless($cmd->$mode) {
+            $self->fatal_message('Could not %s for interval %s.', $mode, $interval);
+        }
+
+        $self->debug_message('Successfully %s for interval %s.', $mode, $interval);
+    }
+
+    return 1;
+}
+
+sub intervals {
+    my $self = shift;
+    my $build = $self->build;
+    my $bucket = $self->bucket;
+
+    unless ($bucket) {
+        $self->fatal_message('No bucket supplied to bucket iterator');
+    }
+
+    return @{ $build->buckets_result->bucket($bucket) };
+}
+
+1;

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller/BucketIterator.t
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller/BucketIterator.t
@@ -1,0 +1,64 @@
+#!/usr/bin/env genome-perl
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use strict;
+use warnings;
+
+use above 'Genome';
+
+use Genome::Test::Factory::Build;
+use Genome::Test::Factory::InstrumentData::AlignmentResult::Merged::Speedseq;
+use Genome::Test::Factory::InstrumentData::Solexa;
+use Genome::Test::Factory::Model::SingleSampleGenotype;
+
+use Sub::Override;
+
+use Test::More tests => 5;
+
+my $pkg = 'Genome::Model::SingleSampleGenotype::Command::HaplotypeCaller::BucketIterator';
+use_ok($pkg);
+
+my $model = Genome::Test::Factory::Model::SingleSampleGenotype->setup_object;
+for(1..3) {
+    $model->add_instrument_data(
+        Genome::Test::Factory::InstrumentData::Solexa->setup_object()
+    );
+}
+
+my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id);
+
+my $speedseq_result = Genome::Test::Factory::InstrumentData::AlignmentResult::Merged::Speedseq->setup_object(
+    instrument_data => [$build->instrument_data],
+    reference_build => $build->reference_sequence_build,
+    map {; $_ => $model->$_ } (qw(aligner_name aligner_version aligner_params)),
+);
+$speedseq_result->add_user(user => $build, label => 'merged_alignment_result');
+is($build->merged_alignment_result, $speedseq_result, 'alignment result added to build');
+
+my $buckets = Genome::Model::Build::ReferenceSequence::Buckets->__define__();
+my $bucket_override = Sub::Override->new(
+    'Genome::Model::Build::ReferenceSequence::Buckets::bucket',
+    sub { return [1,2,3]; }
+);
+
+$buckets->add_user(user => $build, label => 'buckets_result');
+
+require Genome::SoftwareResult;
+
+my $override = Sub::Override->new(
+    'Genome::SoftwareResult::get_or_create',
+    sub {
+        package Genome::SoftwareResult;
+        my $class = shift;
+        return $class->SUPER::create;
+    }
+);
+
+my $cmd = $pkg->create(build => $build, bucket => 1);
+isa_ok($cmd, $pkg, 'created command');
+
+ok($cmd->execute, 'executed command');
+like($cmd->debug_message, qr(^Successfully execute), 'Ran sub-commands');


### PR DESCRIPTION
It has been decided that it is preferable to produce per-chromosome GVCFs rather than have collections of chromosomes bundled together. In order to still have consistently-sized jobs (and avoid splitting hundreds of ways, which will pound the source BAM file), run the HaplotypeCaller on each entry in the bucket in turn.