### PR TITLE
Unarchiving now requires an AnP instead of a lab.

### DIFF
--- a/lib/perl/Genome/Disk/Command/Allocation/Unarchive.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/Unarchive.pm
@@ -32,6 +32,7 @@ sub _execute {
 
     for my $allocation ($self->allocations) {
         $self->status_message("Unarchiving allocation " . $allocation->id);
+        $self->_link_allocation_to_analysis_project($allocation);
         my $rv = $allocation->unarchive(reason => $self->reason);
         unless ($rv) {
             Carp::confess "Could not unarchive alloation " . $allocation->id;
@@ -40,6 +41,28 @@ sub _execute {
     }
 
     $self->status_message("Done unarchiving, exiting...");
+    return 1;
+}
+
+sub _link_allocation_to_analysis_project {
+    my $self = shift;
+    my $allocation = shift;
+
+    my $owner = $allocation->owner;
+    unless ($owner) {
+        $self->fatal_message('This allocation appears to be orphaned: %s', $allocation->id);
+    }
+
+    if($owner->isa('Genome::SoftwareResult')) {
+        $owner->add_user(label => 'sponsor', user => $self->analysis_project);
+    } elsif ($owner->isa('Genome::Model::Build')) {
+        unless($owner->model->analysis_project) {
+            $self->fatal_message('No analysis project set on model for build %s.  Please use `genome analysis-project add-model` to correct this.', $owner->__display_name__);
+        }
+    } else {
+        $self->fatal_message('Setting the analysis project of %s is currently not handled.  Please open a support request to unarchive this allocation.', $owner->__display_name__);
+    }
+
     return 1;
 }
 

--- a/lib/perl/Genome/Disk/Command/Allocation/Unarchive.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Unarchive.t
@@ -101,6 +101,7 @@ my $analysis_project = Genome::Config::AnalysisProject->__define__(name => 'test
 my $model = Genome::Test::Factory::Model::SingleSampleGenotype->setup_object(name => 'test model for Unarchive.t');
 Genome::Config::AnalysisProject::ModelBridge->create(analysis_project => $analysis_project, model => $model);
 my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id);
+my $sr = Genome::InstrumentData::AlignmentResult::Speedseq->__define__(test_name => 'testing Unarchive.t');
 
 # Make test allocation
 my $allocation_path = tempdir(
@@ -138,8 +139,8 @@ my $cmd = Genome::Disk::Command::Allocation::Unarchive->create(
 ok($cmd, 'created unarchive command');
 throws_ok(sub { $cmd->execute }, qr/currently not handled/, 'command fails with unsupported owner');
 
-$allocation->owner_id($build->id);
-$allocation->owner_class_name($build->class);
+$allocation->owner_id($sr->id);
+$allocation->owner_class_name($sr->class);
 $cmd = Genome::Disk::Command::Allocation::Unarchive->create(
     allocations => [$allocation],
     analysis_project => $analysis_project,
@@ -148,6 +149,8 @@ $cmd = Genome::Disk::Command::Allocation::Unarchive->create(
 ok($cmd->execute, 'successfully executed unarchive command');
 is($allocation->volume->id, $volume->id, 'allocation moved to active volume');
 ok($allocation->is_archived == 0, 'allocation is not archived');
+my @users = $sr->users;
+is($users[0]->user, $analysis_project, 'analysis project linked to SR whose allocation was unarchived');
 
 # Make another allocation
 $allocation_path = tempdir(

--- a/lib/perl/Genome/Disk/Command/Allocation/UnarchiveBase.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/UnarchiveBase.pm
@@ -10,10 +10,9 @@ class Genome::Disk::Command::Allocation::UnarchiveBase {
     is => 'Command::V2',
     is_abstract => 1,
     has => {
-        lab => {
-            is => 'Text',
-            valid_values => [qw(Ding Informatics Maher Mardis-Wilson Mitreva Warren Weinstock)],
-            doc => 'The lab which requests the data be unarchived.',
+        analysis_project => {
+            is => 'Genome::Config::AnalysisProject',
+            doc => 'The analysis project for which the data is being unarchived',
         },
         requestor => {
             is => 'Genome::Sys::User',
@@ -29,8 +28,8 @@ sub execute {
     unless ($self->requestor) {
         $self->requestor(Genome::Sys->current_user);
     }
-    $self->status_message(sprintf("Unarchiving allocation(s) for the %s lab at the request of %s.",
-            $self->lab, $self->requestor->name));
+    $self->status_message(sprintf("Unarchiving allocation(s) for Analysis Project %s at the request of %s.",
+            $self->analysis_project, $self->requestor->name));
 
     return $self->_execute();
 }
@@ -39,7 +38,7 @@ sub reason {
     my $self = shift;
 
     my %reason = (
-        'lab'=>$self->lab,
+        'analysis_project'=>$self->analysis_project->id,
         'requestor'=> $self->requestor->id
     );
     return to_json(\%reason);

--- a/lib/perl/Genome/Model/Build/Command/Unarchive.pm
+++ b/lib/perl/Genome/Model/Build/Command/Unarchive.pm
@@ -163,7 +163,7 @@ sub _bsub_unarchives_and_wait_completion {
     my $log_file_dir = shift;
     my @allocations = @_;
 
-    my $lab = $self->lab;
+    my $analysis_project = $self->analysis_project->id;
     my $requestor = $self->requestor->id;
 
     my @allocation_ids = map { $_->id } @allocations;
@@ -171,7 +171,7 @@ sub _bsub_unarchives_and_wait_completion {
     for my $allocation (@allocations) {
         my $allocation_id = $allocation->id;
         my @cmd = ('genome', 'disk', 'allocation', 'unarchive', $allocation_id,
-            '--lab', $lab, '--requestor', $requestor,
+            '--analysis-project', $analysis_project, '--requestor', $requestor,
         );
         push @unarchive_commands,
                 { cmd => \@cmd,


### PR DESCRIPTION
Unarchiving now requires an analysis project to be specified instead of a lab.  This analysis project will be linked to any software results that are unarchived.  Additionaly, unarchiving a build now
requires that its model belong to an analysis project.

Arbitrary unarchives will be supported via the new export command in #1090.