### PR TITLE
Use config to get lsf_resource for chimerascan

### DIFF
--- a/etc/genome/spec/lsf_resource_chimerascan.yaml
+++ b/etc/genome/spec/lsf_resource_chimerascan.yaml
@@ -1,4 +1,0 @@
-# This spec controls the LSF resource for chimerascan run in RnaSeq fusion detection
----
-default_value: "-R 'select[mem>32000 && tmp>50000] span[hosts=1] rusage[mem=32000,tmp=50000]' -M 32000000 -n 2"
-env: XGENOME_LSF_RESOURCE_CHIMERASCAN

--- a/etc/genome/spec/lsf_resource_chimerascan.yaml
+++ b/etc/genome/spec/lsf_resource_chimerascan.yaml
@@ -1,0 +1,4 @@
+# This spec controls the LSF resource for chimerascan run in RnaSeq fusion detection
+---
+default_value: "-R 'select[mem>32000 && tmp>50000] span[hosts=1] rusage[mem=32000,tmp=50000]' -M 32000000 -n 2"
+env: XGENOME_LSF_RESOURCE_CHIMERASCAN

--- a/etc/genome/spec/lsf_resource_rnaseq_chimerascan.yaml
+++ b/etc/genome/spec/lsf_resource_rnaseq_chimerascan.yaml
@@ -1,4 +1,4 @@
 # This spec controls the LSF resource for chimerascan run in RnaSeq fusion detection
 ---
 default_value: "-R 'select[mem>32000 && tmp>50000] span[hosts=1] rusage[mem=32000,tmp=50000]' -M 32000000 -n 2"
-env: XGENOME_LSF_RESOURCE_CHIMERASCAN
+env: XGENOME_LSF_RESOURCE_RNASEQ_CHIMERASCAN

--- a/etc/genome/spec/lsf_resource_rnaseq_chimerascan.yaml
+++ b/etc/genome/spec/lsf_resource_rnaseq_chimerascan.yaml
@@ -1,0 +1,4 @@
+# This spec controls the LSF resource for chimerascan run in RnaSeq fusion detection
+---
+default_value: "-R 'select[mem>32000 && tmp>50000] span[hosts=1] rusage[mem=32000,tmp=50000]' -M 32000000 -n 2"
+env: XGENOME_LSF_RESOURCE_CHIMERASCAN

--- a/lib/perl/Genome/Model/RnaSeq/Command/DetectFusions/Chimerascan/DetectorBase.pm
+++ b/lib/perl/Genome/Model/RnaSeq/Command/DetectFusions/Chimerascan/DetectorBase.pm
@@ -45,7 +45,7 @@ class Genome::Model::RnaSeq::Command::DetectFusions::Chimerascan::DetectorBase {
             doc => 'queue to use when running in a workflow',
         },
         lsf_resource => {
-            default_value => Genome::Config::get('lsf_resource_chimerascan'),
+            default_value => Genome::Config::get('lsf_resource_rnaseq_chimerascan'),
             is_optional => 1,
             doc => 'default LSF resource expectations',
         },

--- a/lib/perl/Genome/Model/RnaSeq/Command/DetectFusions/Chimerascan/DetectorBase.pm
+++ b/lib/perl/Genome/Model/RnaSeq/Command/DetectFusions/Chimerascan/DetectorBase.pm
@@ -45,7 +45,7 @@ class Genome::Model::RnaSeq::Command::DetectFusions::Chimerascan::DetectorBase {
             doc => 'queue to use when running in a workflow',
         },
         lsf_resource => {
-            default_value => "-R 'select[mem>32000 && tmp>50000] span[hosts=1] rusage[mem=32000,tmp=50000]' -M 32000000 -n 2",
+            default_value => Genome::Config::get('lsf_resource_chimerascan'),
             is_optional => 1,
             doc => 'default LSF resource expectations',
         },


### PR DESCRIPTION
So users do not need run builds with changed lsf limit from custom snapshot or checkout.