### PR TITLE
InstData Import: Avoid shell errors associated with odd charcters

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.pm
@@ -8,6 +8,7 @@ use Genome;
 use Data::Dumper 'Dumper';
 require File::Basename;
 require File::Spec;
+require Genome::Utility::Text;
 require List::Util;
 use Try::Tiny;
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.pm
@@ -7,6 +7,7 @@ use Genome;
 
 use Data::Dumper 'Dumper';
 require File::Basename;
+require File::Spec;
 require List::Util;
 use Try::Tiny;
 
@@ -35,7 +36,7 @@ class Genome::InstrumentData::Command::Import::WorkFlow::FastqsToBam {
         output_bam_path => {
             is => 'Text',
             calculate_from => [qw/ working_directory sample_name /],
-            calculate => q( return $working_directory.'/'.$sample_name.'.bam'; ),
+            calculate => q| return File::Spec->join($working_directory, Genome::Utility::Text::sanitize_string_for_filesystem($sample_name).'.bam'); |,
             doc => 'The path of the bam.',
         },
     ],
@@ -75,7 +76,7 @@ sub _unarchive_fastqs_if_necessary {
         $self->debug_message('Unarchiving: '.$fastq_path);
         
         my $success = try {
-            Genome::Sys->shellcmd(cmd => "gunzip $fastq_path");
+            Genome::Sys->shellcmd(cmd => [ 'gunzip', $fastq_path ]);
         }
         catch {
             $self->error_message($_) if $_;

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SortBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SortBam.pm
@@ -64,7 +64,7 @@ sub _sort_bam {
     my $output_bam_path = $self->output_bam_path;
     $self->debug_message("Sorted bam path: $output_bam_path");
 
-    my @cmd = (qw/ samtools  sort -m 3000000000 -n /, $bam_path, $sorted_bam_prefix );
+    my @cmd = (qw/ samtools sort -m 3000000000 -n /, $bam_path, $sorted_bam_prefix );
     my $rv = eval{ Genome::Sys->shellcmd(cmd => \@cmd); };
     if ( not $rv or not -s $output_bam_path ) {
         $self->error_message($@) if $@;

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SortBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SortBam.pm
@@ -64,8 +64,8 @@ sub _sort_bam {
     my $output_bam_path = $self->output_bam_path;
     $self->debug_message("Sorted bam path: $output_bam_path");
 
-    my $cmd = "samtools sort -m 3000000000 -n $bam_path $sorted_bam_prefix";
-    my $rv = eval{ Genome::Sys->shellcmd(cmd => $cmd); };
+    my @cmd = (qw/ samtools  sort -m 3000000000 -n /, $bam_path, $sorted_bam_prefix );
+    my $rv = eval{ Genome::Sys->shellcmd(cmd => \@cmd); };
     if ( not $rv or not -s $output_bam_path ) {
         $self->error_message($@) if $@;
         $self->error_message('Failed to run samtools sort!');


### PR DESCRIPTION
use arrayref shellcmd sanitize sample name before using it in  afile name
problems