### PR TITLE
Use primary queue to submit SomVal AlignReads job.

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.pm
@@ -23,7 +23,7 @@ class Genome::Model::SomaticValidation::Command::AlignReads {
     ],
     has_param => [
         lsf_queue => {
-            default => Genome::Config::get('lsf_queue_build_worker_alt'),
+            default => Genome::Config::get('lsf_queue_build_worker'),
         },
     ],
     has_transient_optional_output => [


### PR DESCRIPTION
Some jobs scheduled by the dispatcher (e.g. the new QC framework job) will end up in the "alt" queue, so this job needs to be in the lower-priority queue.

(In our current configuration, the "alt" queue is `apipe` and the other is `long` (with corresponding `pd` queues for builder).)