### PR TITLE
Shortcut Several Skipped SomVal Steps

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/DetectVariants.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/DetectVariants.pm
@@ -54,6 +54,25 @@ class Genome::Model::SomaticValidation::Command::DetectVariants{
 
 sub sub_command_category { 'pipeline steps' }
 
+sub shortcut {
+    my $self = shift;
+
+    return $self->should_skip_run;
+}
+
+sub should_skip_run {
+    my $self = shift;
+    my $build = $self->build;
+
+    unless ($build->snv_detection_strategy or $build->indel_detection_strategy or $build->sv_detection_strategy or $build->cnv_detection_strategy) {
+        $self->warning_message("No detection strategies provided. Skipping detect variants step");
+        return 1;
+    }
+
+    return;
+}
+
+
 sub execute{
     my $self = shift;
 
@@ -63,10 +82,7 @@ sub execute{
         die $self->error_message("no build provided!");
     }
 
-    unless ($build->snv_detection_strategy or $build->indel_detection_strategy or $build->sv_detection_strategy or $build->cnv_detection_strategy) {
-        $self->warning_message("No detection strategies provided. Skipping detect variants step");
-        return 1;
-    }
+    return 1 if $self->should_skip_run;
 
     my %params;
     $params{snv_detection_strategy} = $build->snv_detection_strategy if $build->snv_detection_strategy;

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ReviewVariants.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ReviewVariants.pm
@@ -202,6 +202,22 @@ sub intersects{
     return 0;
 }
 
+sub shortcut {
+    my $self = shift;
+
+    return $self->should_skip_run;
+}
+
+sub should_skip_run {
+    my $self = shift;
+
+    unless ($self->build->snv_detection_strategy) {
+        $self->warning_message("snv_detection_strategy undefined, skipping Review Variants. This tool could be rewritten to allow for no snv_detection_strategy if a variant list is provided.");
+        return 1;
+    }
+
+    return;
+}
 
 sub execute {
     my $self = shift;
@@ -245,10 +261,7 @@ sub execute {
     #    $normal_bam = $build->normal_bam;
     #}
 
-    unless ($build->snv_detection_strategy) {
-        $self->warning_message("snv_detection_strategy undefined, skipping Review Variants. This tool could be rewritten to allow for no snv_detection_strategy if a variant list is provided.");
-        return 1;
-    }
+    return 1 if $self->should_skip_run;
 
     # Ensure the necessary files exist in this build
     my $snv_file = "$build_dir/variants/snvs.hq.bed";

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
@@ -87,19 +87,6 @@ sub execute {
     $self->tier_files(1);
 
     my $long_indel_bed_file = $self->_resolve_long_indel_bed_file;
-    my $skip_msg = 'Skipping long indel validation';
-
-    unless ($long_indel_bed_file) {
-        $self->warning_message("No long indel bed file exists with size. $skip_msg");
-        $self->skip(1);
-        return 1;
-    }
-    unless ($self->build->normal_sample) {
-        $self->warning_message("Somatic validation of a single bam.  $skip_msg");
-        $self->skip(1);
-        return 1;
-    }
-    $self->skip(0);
     $self->_long_indel_bed_file($long_indel_bed_file);
 
     my $sample_id = Data::UUID->new->create_str();
@@ -127,7 +114,7 @@ sub execute {
 
     my $contigs_file = $cmd->contigs_fasta;
     unless (-s $contigs_file) {
-        $self->warning_message("Failed to get valid assembly contig fasta. $skip_msg");
+        $self->warning_message("Failed to get valid assembly contig fasta. Skipping remainder of long indel validation.");
         $self->skip(1);
         return 1;
     }
@@ -211,7 +198,23 @@ sub skip_validation {
         return 1;
     }
 
+    my $long_indel_bed_file = $self->_resolve_long_indel_bed_file;
+    my $skip_msg = 'Skipping long indel validation';
+
+    unless ($long_indel_bed_file) {
+        $self->warning_message("No long indel bed file exists with size. $skip_msg");
+        $self->skip(1);
+        return 1;
+    }
+    unless ($self->build->normal_sample) {
+        $self->warning_message("Somatic validation of a single bam.  $skip_msg");
+        $self->skip(1);
+        return 1;
+    }
+
+    $self->skip(0);
     return;
 }
+
 1;
 


### PR DESCRIPTION
I noticed several builds that were done save for PENDing jobs for things that weren't going to run.  This allows these two steps to shortcut so we don't wait for slots just to find there's nothing to do.