### PR TITLE
Add LSF queue and resource request to the SSG QC command.

### DIFF
--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/QualityControl.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/QualityControl.pm
@@ -8,6 +8,14 @@ use Genome;
 class Genome::Model::SingleSampleGenotype::Command::QualityControl {
     is => 'Genome::Model::SingleSampleGenotype::Command::Base',
     doc => 'Perform quality control analysis on the alignments for the build.',
+    has => [
+        lsf_queue => {
+            default_value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
+        lsf_resource => {
+            default_value => Genome::Config::get('lsf_resource_qc_run'),
+        },
+    ],
 };
 
 sub _result_accessor {


### PR DESCRIPTION
The values from `Genome::Qc::Run` weren't getting used since this pipeline bypasses the alignment dispatcher.