### PR TITLE
Dont fail ptero builds

### DIFF
--- a/lib/perl/Genome/Command/PteroWorkflowMixin.pm
+++ b/lib/perl/Genome/Command/PteroWorkflowMixin.pm
@@ -13,6 +13,7 @@ use Genome::Utility::Text qw(justify strip_color);
 use Try::Tiny qw(try catch);
 use Ptero::Proxy::Workflow;
 use Ptero::Proxy::Workflow::Execution qw();
+use Genome::Ptero::Utils qw(ptero_proxy ptero_workflow_url);
 
 my $INDENTATION_STR = '. ';
 
@@ -51,14 +52,10 @@ sub _display_ptero_workflow {
     return unless $self->workflow;
     $handle->say($self->_color_heading("Workflow"));
 
-    my $url = sprintf("%s?name=%s", Genome::Config::get('ptero_workflow_submit_url'),
-        $workflow_name);
-
-    my $wf_proxy = try {
-        return Ptero::Proxy::Workflow->new($url);
-    };
+    my $wf_proxy = ptero_proxy($workflow_name);
     unless (defined($wf_proxy)) {
-        $handle->say("No ptero workflow found at url ($url)");
+        my $url = ptero_workflow_url($workflow_name);
+        $handle->say("No ptero workflow found for workflow named ($workflow_name) at url ($url)");
         return;
     }
 

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -554,6 +554,12 @@ sub workflow_name {
     return $self->build_id . ' all stages';
 }
 
+sub ptero_workflow_proxy {
+    my $self = shift;
+
+    return $self->process->ptero_workflow_proxy;
+}
+
 sub workflow_instances {
     my $self = shift;
     my @instances = Workflow::Operation::Instance->get(

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -108,6 +108,7 @@ class Genome::Model::Build {
         },
         software_revision => { is => 'Text', len => 1000 },
         process => {
+            is_many => 1,
             is => 'Genome::Model::Build::Process',
             reverse_as => 'build',
         }

--- a/lib/perl/Genome/Model/Command/Services/Build/Scan.pm
+++ b/lib/perl/Genome/Model/Command/Services/Build/Scan.pm
@@ -60,9 +60,23 @@ sub _build_is_bad {
     #checking the jobs
     UR::Context->current->reload($build);
     if ($build->status eq "Scheduled" or $build->status eq "Running") {
+        if (_build_was_run_using_ptero($build)) {
+            # PTero builds are never bad!
+            return 0;
+        }
         return 1;
     }
     else {
+        return 0;
+    }
+}
+
+sub _build_was_run_using_ptero {
+    my $build = shift;
+
+    if ($build->ptero_workflow_proxy) {
+        return 1;
+    } else {
         return 0;
     }
 }

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -14,6 +14,7 @@ use Genome::Disk::Group::Validate::GenomeDiskGroups;
 use Genome::Utility::Inputs qw(encode);
 use Cwd qw(abs_path);
 use File::DirCompare;
+use Genome::Ptero::Utils qw(ptero_proxy);
 
 class Genome::Process {
     is => [
@@ -337,6 +338,11 @@ sub lsf_job_id {
 sub workflow_name {
     my $self = shift;
     return sprintf('Genome::Process(%s)', $self->id);
+}
+
+sub ptero_workflow_proxy {
+    my $self = shift;
+    return ptero_proxy($self->workflow_name);
 }
 
 sub lsf_project_name {

--- a/lib/perl/Genome/Ptero/Utils.pm
+++ b/lib/perl/Genome/Ptero/Utils.pm
@@ -1,0 +1,34 @@
+package Genome::Ptero::Utils;
+
+use strict;
+use warnings FATAL => 'all';
+use Params::Validate qw(validate_pos :types);
+use Ptero::Proxy::Workflow;
+use Try::Tiny qw(try);
+
+use Exporter 'import';
+
+our @EXPORT_OK = qw(
+    ptero_proxy
+    ptero_workflow_url
+);
+
+sub ptero_workflow_url {
+    my ($workflow_name) = validate_pos(@_, {type => SCALAR});
+
+    return sprintf("%s?name=%s", Genome::Config::get('ptero_workflow_submit_url'),
+        $workflow_name);
+}
+
+sub ptero_proxy {
+    my ($workflow_name) = validate_pos(@_, {type => SCALAR});
+
+    my $proxy = try {
+        return Ptero::Proxy::Workflow->new(
+            ptero_workflow_url($workflow_name));
+    };
+    return $proxy;
+}
+
+
+1;


### PR DESCRIPTION
Because PTero run builds don't have an LSF job related to the workflow, the build scan thinks they're bad.