### PR TITLE
Updates to HaplotypeCaller file naming in SSG

### DIFF
--- a/lib/perl/Genome/Model/SingleSampleGenotype/Result/HaplotypeCaller.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Result/HaplotypeCaller.pm
@@ -5,6 +5,8 @@ use warnings;
 
 use Genome;
 
+use Genome::Utility::Text;
+
 class Genome::Model::SingleSampleGenotype::Result::HaplotypeCaller {
     is => 'Genome::SoftwareResult::StageableSimple',
     has_input => {
@@ -35,13 +37,26 @@ class Genome::Model::SingleSampleGenotype::Result::HaplotypeCaller {
 };
 
 
+sub _vcf_filename {
+    my $self = shift;
+
+    my @intervals = $self->intervals;
+    my $filename = (@intervals == 1)? Genome::Utility::Text::sanitize_string_for_filesystem($intervals[0]) : 'output';
+
+    $filename .= '.g.vcf';
+
+    return $filename;
+}
+
 sub _run {
     my $self = shift;
 
     my $input_bam = $self->alignment_result->bam_path;
     my $reference = $self->alignment_result->reference_build->full_consensus_path('fa');
     my $output_dir = $self->temp_staging_directory;
-    my $output_file = File::Spec->join($output_dir, 'output.g.vcf');
+    my $filename = $self->_vcf_filename;
+
+    my $output_file = File::Spec->join($output_dir, $filename);
 
 
     my $cmd = Genome::Model::Tools::Gatk::HaplotypeCaller->create(

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Result/HaplotypeCaller.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Result/HaplotypeCaller.pm
@@ -33,6 +33,16 @@ class Genome::Model::SingleSampleGenotype::Result::HaplotypeCaller {
             doc => 'Version of GATK to use',
         },
     },
+    has => {
+        vcf_file => {
+            is => 'Text',
+            is_calculated => 1,
+            calculate_from => ['output_dir'],
+            calculate => q{
+                File::Spec->join($output_dir, $self->_vcf_filename);
+            },
+        },
+    },
     doc => 'SoftwareResult wrapper for GATK HaplotypeCaller',
 };
 

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Result/HaplotypeCaller.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Result/HaplotypeCaller.pm
@@ -53,7 +53,7 @@ sub _vcf_filename {
     my @intervals = $self->intervals;
     my $filename = (@intervals == 1)? Genome::Utility::Text::sanitize_string_for_filesystem($intervals[0]) : 'output';
 
-    $filename .= '.g.vcf';
+    $filename .= '.g.vcf.gz';
 
     return $filename;
 }

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Result/HaplotypeCaller.t
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Result/HaplotypeCaller.t
@@ -16,7 +16,7 @@ use Genome::Test::Factory::Model::ImportedReferenceSequence;
 use File::Spec;
 use Sub::Override;
 
-use Test::More tests => 2;
+use Test::More tests => 4;
 
 my $pkg = 'Genome::Model::SingleSampleGenotype::Result::HaplotypeCaller';
 use_ok($pkg);
@@ -48,4 +48,8 @@ my $result = $pkg->create(
     emit_reference_confidence => 'GVCF',
 );
 isa_ok($result, $pkg, 'generated result');
+
+is($result->_vcf_filename, '1.g.vcf.gz', 'VCF filename is as expected');
+my $vcf = $result->vcf_file;
+ok(-s $vcf, 'vcf_file points to the VCF that was created');
 


### PR DESCRIPTION
* Include the name of the contig (if there's only one).
* Use `.gz` extension so the file is compressed.
* Add an accessor so the VCF files can be listed more easily.