### PR TITLE
Set all outputs regardless of why we're skipping.

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
@@ -186,16 +186,10 @@ sub _create_output_directory {
 sub skip_validation {
     my $self = shift;
 
+    my $should_skip = 0;
     unless($self->build->run_indel_validation) {
         $self->debug_message('Build indicates indel validation should be skipped.');
-        $self->skip(1);
-        $self->_resolve_output_directory;
-
-        $self->reference_build_id(1);
-        $self->contigs_fasta(1);
-        $self->tier_files(1);
-
-        return 1;
+        $should_skip = 1;
     }
 
     my $long_indel_bed_file = $self->_resolve_long_indel_bed_file;
@@ -203,17 +197,25 @@ sub skip_validation {
 
     unless ($long_indel_bed_file) {
         $self->warning_message("No long indel bed file exists with size. $skip_msg");
-        $self->skip(1);
-        return 1;
+        $should_skip = 1;
     }
     unless ($self->build->normal_sample) {
         $self->warning_message("Somatic validation of a single bam.  $skip_msg");
-        $self->skip(1);
-        return 1;
+        $should_skip = 1;
     }
 
-    $self->skip(0);
-    return;
+    if ($should_skip) {
+        $self->skip(1);
+        $self->_resolve_output_directory;
+
+        $self->reference_build_id(1);
+        $self->contigs_fasta(1);
+        $self->tier_files(1);
+    } else {
+        $self->skip(0);
+    }
+
+    return $self->skip;
 }
 
 1;


### PR DESCRIPTION
The subsequent step crashes if its inputs aren't set. (Even though the command doesn't especially care since it skips doing anything, it is still an invalid object for save when commit happens.)