### PR TITLE
Ptero submit after process committed

### DIFF
--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -242,10 +242,7 @@ sub _submit_process {
 
     my $cmd = Genome::Process::Command::Run->create(
         process => $self, update_with_commit => 0);
-    my $wf_proxy = $cmd->submit();
-    $self->status_message("Successfully launched process (%s) and ".
-        "submitted PTero workflow (%s)",
-        $self->id, $wf_proxy->url);
+    $cmd->submit();
 }
 
 sub create {

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -241,8 +241,7 @@ sub _submit_process {
     }
 
     my $cmd = Genome::Process::Command::Run->create(
-        process => $self,
-    );
+        process => $self, update_with_commit => 0);
     my $wf_proxy = $cmd->submit();
     $self->status_message("Successfully launched process (%s) and ".
         "submitted PTero workflow (%s)",


### PR DESCRIPTION
These changes are necessary for starting builds using PTero as the workflow backend.