### PR TITLE
Add extra parameters when gzipped GVCF requested in version 3.4 of HaplotypeCaller.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.pm
+++ b/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.pm
@@ -95,4 +95,19 @@ sub _shellcmd_extra_params {
     );
 }
 
+sub _cmdline_args {
+    my $self = shift;
+
+    my @args = $self->SUPER::_cmdline_args(@_);
+
+    if ($self->version eq '3.4' and
+            $self->output_vcf =~ /g\.vcf\.gz$/ and
+            $self->emit_reference_confidence eq 'GVCF') {
+        #Handle a bug in GATK 3.4 by including these deprecated parameters.
+        push @args, qw(-variant_index_type LINEAR -variant_index_parameter 128000);
+    }
+
+    return @args;
+}
+
 1;

--- a/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.t
+++ b/lib/perl/Genome/Model/Tools/Gatk/HaplotypeCaller.t
@@ -15,7 +15,7 @@ if (Genome::Sys->arch_os ne 'x86_64') {
     plan skip_all => 'requires 64-bit machine';
 }
 else {
-    plan tests => 7;
+    plan tests => 11;
 }
 
 my $pkg = 'Genome::Model::Tools::Gatk::HaplotypeCaller';
@@ -45,3 +45,20 @@ ok(-s $output_vcf, 'output was created');
 ok(-s "$output_vcf.idx", 'output was indexed');
 
 compare_ok($output_vcf, $expected_output_vcf, name => 'file matched expectations', filters => [qr/^#.*$/]);
+
+
+my $output_vcf_gz = "$output_vcf.gz";
+my $gatk_cmd_with_gz = $pkg->create(
+    version => '3.4',
+    max_memory => 2,
+    input_bam => $input_bam,
+    reference_fasta => $input_reference,
+    emit_reference_confidence => 'GVCF',
+    output_vcf => $output_vcf_gz,
+);
+isa_ok($gatk_cmd_with_gz, $pkg, "Made the command");
+ok($gatk_cmd_with_gz->execute, 'Executed the command');
+
+ok(-s $output_vcf_gz, 'gzipped output was created');
+ok(-s "$output_vcf_gz.tbi", 'gzipped output was indexed');
+


### PR DESCRIPTION
We switched to requesting gzipped GVCF in #1115.  However, GATK 3.4 contains a bug that requires two additional (deprecated) parameters to be supplied when a gzipped file is requested.  (This is fixed in 3.4-46, but that version is not tagged in their public repository.)