### PR TITLE
apipe-builder user and the apipe queue

### DIFF
--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -6,6 +6,7 @@ use warnings;
 use Genome::Sys;
 use Exporter qw(import);
 use Params::Validate qw(:types);
+use List::MoreUtils qw(any);
 
 our @EXPORT = qw(bsub);
 our @EXPORT_OK = qw(bsub);
@@ -139,7 +140,8 @@ sub _args_spec {
 }
 
 sub _valid_lsf_queue {
-    return grep { /$_[0]/ } _queues();
+    my $requested_queue = shift;
+    return any { $requested_queue eq $_ } _queues();
 }
 
 sub _queues {

--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -141,7 +141,11 @@ sub _args_spec {
 
 sub _valid_lsf_queue {
     my $requested_queue = shift;
-    return any { $requested_queue eq $_ } _queues();
+
+    my $username = Genome::Sys->username;
+    return any { $requested_queue eq $_ }
+          grep { $username ne 'apipe-builder' or $_ ne 'apipe' }
+                _queues();
 }
 
 sub _queues {

--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -7,26 +7,41 @@ use Genome::Sys;
 use Exporter qw(import);
 use Params::Validate qw(:types);
 use List::MoreUtils qw(any);
+use Try::Tiny;
+use Genome::Utility::Email;
 
 our @EXPORT = qw(bsub);
 our @EXPORT_OK = qw(bsub);
 
 sub run {
     my $executable = shift;
-    my @args = args_builder(@_);
+    my @run_args = @_;
+    try {
+        my @args = args_builder(@run_args);
 
-    if (ref($executable) ne 'ARRAY') {
-        $executable = [$executable];
-    }
+        if (ref($executable) ne 'ARRAY') {
+            $executable = [$executable];
+        }
 
-    my @output = Genome::Sys->capture(@$executable, @args);
+        my @output = Genome::Sys->capture(@$executable, @args);
 
-    my $job_id = ($output[-1] =~ /^Job <(\d+)> is submitted to/)[0];
-    unless ($job_id) {
-        die "Could not get job id from bsub output!";
-    }
+        my $job_id = ($output[-1] =~ /^Job <(\d+)> is submitted to/)[0];
+        unless ($job_id) {
+            die "Could not get job id from bsub output!";
+        }
 
-    return $job_id;
+        return $job_id;
+    } catch {
+        if (Genome::Sys->username eq 'apipe-builder' and $_ =~ m/The 'queue' parameter \("apipe"\) to Genome::Sys::LSF::bsub::_args did not pass/) {
+            Genome::Utility::Email::send(
+                from => 'abrummet@genome.wustl.edu',
+                to => 'abrummet@genome.wustl.edu',
+                subject => 'apipe-builder using apipe queue',
+                body => $_,
+            );
+        }
+        die $_;
+    };
 }
 
 sub bsub {

--- a/lib/perl/Genome/Sys/LSF/bsub.t
+++ b/lib/perl/Genome/Sys/LSF/bsub.t
@@ -20,7 +20,7 @@ ok( !Genome::Sys::LSF::bsub::_valid_lsf_queue($fake_queue),
     qq('$fake_queue' is not a valid queue));
 
 ok( Genome::Sys::LSF::bsub::_valid_lsf_queue($queues[0]),
-    qq('$queues[0]' is not a valid queue));
+    qq('$queues[0]' is a valid queue));
 
 like( exception { Genome::Sys::LSF::bsub::_args(queue => $fake_queue, cmd => 'true') },
     qr/valid LSF queue/,

--- a/lib/perl/Genome/Sys/LSF/bsub.t
+++ b/lib/perl/Genome/Sys/LSF/bsub.t
@@ -6,11 +6,11 @@ use Test::Builder;
 use Test::Fatal qw(exception);
 use Genome::Sys::LSF::bsub qw();
 
-plan tests => 10;
+plan tests => 13;
 
 do {
     no warnings 'redefine';
-    *Genome::Sys::LSF::bsub::_queues = sub { qw(long short) };
+    *Genome::Sys::LSF::bsub::_queues = sub { qw(long short apipe) };
 };
 
 my $fake_queue = 'fake_queue';
@@ -21,6 +21,18 @@ ok( !Genome::Sys::LSF::bsub::_valid_lsf_queue($fake_queue),
 
 ok( Genome::Sys::LSF::bsub::_valid_lsf_queue($queues[0]),
     qq('$queues[0]' is a valid queue));
+
+do {
+    local $ENV{REMOTE_USER} = 'apipe-builder';
+    ok( !Genome::Sys::LSF::bsub::_valid_lsf_queue($fake_queue),
+        qq('$fake_queue' is not a valid queue for apipe-builder));
+
+    ok( Genome::Sys::LSF::bsub::_valid_lsf_queue($queues[0]),
+        qq('$queues[0]' is a valid queue for apipe-builder));
+
+    ok( !Genome::Sys::LSF::bsub::_valid_lsf_queue('apipe'),
+        qq('apipe' is not a valid queue for apipe-builder));
+};
 
 like( exception { Genome::Sys::LSF::bsub::_args(queue => $fake_queue, cmd => 'true') },
     qr/valid LSF queue/,


### PR DESCRIPTION
This should prevent apipe-builder from submitting jobs to the apipe queue.  Then we'll be able to track them down and move the jobs to a different queue.