### PR TITLE
Let UR re-call with the correct subclass if StageableSimple called abstractly.

### DIFF
--- a/lib/perl/Genome/SoftwareResult/StageableSimple.pm
+++ b/lib/perl/Genome/SoftwareResult/StageableSimple.pm
@@ -11,6 +11,12 @@ class Genome::SoftwareResult::StageableSimple {
 
 sub create {
     my $class = shift;
+
+    if ($class eq __PACKAGE__ || $class->__meta__->is_abstract) {
+        # this class is abstract, and the super-class re-calls the constructor from the correct subclass
+        return $class->SUPER::create(@_);
+    }
+
     my $self = $class->SUPER::create(@_);
     return unless $self;
 


### PR DESCRIPTION
I don't think this fails in practice, because it is far more common to call on either the specific subclass or on `Genome::SoftwareResult` itself.  Just in case, though :smile: 