### PR TITLE
Set a default resource request for the BucketIterator.

### DIFF
--- a/etc/genome/spec/lsf_resource_gatk_haplotype_caller.yaml
+++ b/etc/genome/spec/lsf_resource_gatk_haplotype_caller.yaml
@@ -1,0 +1,3 @@
+---
+default_value: "-R 'select[mem>4000 && gtmp>1] rusage[mem=4000,gtmp=1]'"
+env: XGENOME_LSF_RESOURCE_GATK_HAPLOTYPE_CALLER

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller/BucketIterator.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller/BucketIterator.pm
@@ -25,6 +25,10 @@ class Genome::Model::SingleSampleGenotype::Command::HaplotypeCaller::BucketItera
             is => 'Text',
             default => Genome::Config::get('lsf_queue_build_worker_alt'),
         },
+        lsf_resource => {
+            is => 'Text',
+            default => Genome::Config::get('lsf_resource_gatk_haplotype_caller'),
+        },
     ],
     doc => 'Runs the haplotype-caller command for each interval in the bucket',
 };


### PR DESCRIPTION
Thus far the jobs have fit within the standard 4GB memory reservation.  The ones I looked at showed `/tmp` usage around 100-150MB; the reservation of 1 GB should ensure they don't land on a completely full blade.

This will then also be ready if some cases have stronger requirements.