### PR TITLE
Don't try to format body_text when displaying notes.

### DIFF
--- a/lib/perl/Genome/Process/Command/View.pm
+++ b/lib/perl/Genome/Process/Command/View.pm
@@ -171,8 +171,7 @@ EOS
     print $handle sprintf($format_str,
         $note->entry_date,
         $self->_color_pair('Header', $note->header_text),
-        $self->_color_pair('Body',
-            $self->_clean_up_timestamp($note->body_text)),
+        $self->_color_pair('Body', $note->body_text),
     );
 }
 


### PR DESCRIPTION
The clean_up_timestamp was throwing away everything after the first '.'
which isn't desired here.