### PR TITLE
Set queue and projectName when getting ptero lsf params

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -106,32 +106,22 @@ sub _get_ptero_execute_method {
         parameters => $ptero_lsf_parameters);
 }
 
-sub _get_lsf_resources_from_command {
-    my $self = shift;
-    my $prop = $self->command->__meta__->property_meta_for_name('lsf_resource');
-
-    if ($prop && $prop->{is_param}) {
-        if ($prop->default_value) {
-            return $prop->default_value;
-        } else {
-            die $self->command . "property lsf_resource should have a default value if it is a parameter.";
-        }
-    } else {
-        return '';
-    }
-}
-
 sub _get_ptero_lsf_parameters {
     my $self = shift;
+    my %attributes = $self->operation_type_attributes;
+    my $lsf_params = parse_lsf_params( $attributes{lsfResource} );
 
-    my $lsf_resource = $self->lsf_resource;
-    if (defined($lsf_resource) && length($lsf_resource)) {
-        return parse_lsf_params($lsf_resource);
-    }
+    my $set_lsf_option = sub {
+        my ($option, $value) = @_;
+        if (defined($value) and length($value)) {
+            $lsf_params->{options}->{$option} = $value;
+        }
+    };
 
-    return parse_lsf_params(
-        $self->_get_lsf_resources_from_command
-    )
+    $set_lsf_option->('queue', $attributes{lsfQueue});
+    $set_lsf_option->('projectName', $attributes{lsfProject});
+
+    return $lsf_params;
 }
 
 

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -113,7 +113,8 @@ sub _get_ptero_lsf_parameters {
 
     my $set_lsf_option = sub {
         my ($option, $value) = @_;
-        if (defined($value) and length($value)) {
+        if (defined($value) and length($value) and
+            not exists($lsf_params->{options}->{$option})) {
             $lsf_params->{options}->{$option} = $value;
         }
     };


### PR DESCRIPTION
This commit makes getting lsf parameters for use with PTero work more like other cases by using the existing `operation_type_attributes()` method to decide whether the lsf resource string should come from the Genome command class or from `Genome::WorkflowBuilder::Command`.  It also gets the queue name and project name from the `operation_type_attributes()`.

Since the queue and project name could be specified in the resource string, the workflow builder command, and the genome command class, we should consider the order of precedence.  Clearly, the queue and project specified on the workflow builder command takes precedence over a value supplied on the Genome command class.  It is not clear to me whether a queue or project specified in the lsf resource string should take precedence over the value specified on the workflow builder command.