### PR TITLE
PTero LSF Stuff

### DIFF
--- a/etc/genome/spec/lsf_project_name.yaml
+++ b/etc/genome/spec/lsf_project_name.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_LSF_PROJECT_NAME
+default_value: ''

--- a/etc/genome/spec/ptero_lsf_polling_interval.yaml
+++ b/etc/genome/spec/ptero_lsf_polling_interval.yaml
@@ -1,3 +1,5 @@
 ---
 env: XGENOME_PTERO_LSF_POLLING_INTERVAL
 default_value: 300
+validators:
+  - Numeric

--- a/etc/genome/spec/ptero_lsf_polling_interval.yaml
+++ b/etc/genome/spec/ptero_lsf_polling_interval.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_PTERO_LSF_POLLING_INTERVAL
+default_value: 300

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1396,9 +1396,9 @@ sub _launch {
     local $ENV{UR_COMMAND_DUMP_STATUS_MESSAGES} = 1;
 
     # we don't use 'local' because we want this to persist through
-    # spawned workflows
-    $ENV{Genome::Config::spec('lsf_project_name')->env} =
-        sprintf("build/%s", $self->id);
+    # spawned workflows, and since the build is launched in a commit
+    # observer the 'local' designations ensure the ENV isn't still around then
+    Genome::Config::set_env('lsf_project_name', sprintf("build/%s", $self->id));
 
     my $build_id_guard = set_build_id($self->id);
 

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1395,6 +1395,11 @@ sub _launch {
     local $ENV{UR_DUMP_STATUS_MESSAGES} = 1;
     local $ENV{UR_COMMAND_DUMP_STATUS_MESSAGES} = 1;
 
+    # we don't use 'local' because we want this to persist through
+    # spawned workflows
+    $ENV{Genome::Config::spec('lsf_project_name')->env} =
+        sprintf("build/%s", $self->id);
+
     my $build_id_guard = set_build_id($self->id);
 
     # right now it is "inline" or the name of an LSF queue.

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -71,6 +71,7 @@
                      "numProcessors" : 1,
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
+                  "pollingInterval" : 300,
                   "rLimits" : {
                      "RSS" : 3000000
                   },
@@ -167,6 +168,7 @@
                                                    "numProcessors" : 1,
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
+                                                "pollingInterval" : 300,
                                                 "rLimits" : {
                                                    "RSS" : 3000000
                                                 },

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -115,6 +115,7 @@
                                     "numProcessors" : 1,
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
+                                 "pollingInterval" : 300,
                                  "rLimits" : {
                                     "RSS" : 3000000
                                  },
@@ -213,6 +214,7 @@
                                                                   "numProcessors" : 1,
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
+                                                               "pollingInterval" : 300,
                                                                "rLimits" : {
                                                                   "RSS" : 3000000
                                                                },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -119,6 +119,7 @@
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
+                  "pollingInterval" : 300,
                   "rLimits" : {
                      "RSS" : 200000
                   },
@@ -169,6 +170,7 @@
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
+                  "pollingInterval" : 300,
                   "rLimits" : {
                      "RSS" : 200000
                   },
@@ -219,6 +221,7 @@
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
+                  "pollingInterval" : 300,
                   "rLimits" : {
                      "RSS" : 200000
                   },
@@ -269,6 +272,7 @@
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
+                  "pollingInterval" : 300,
                   "rLimits" : {
                      "RSS" : 200000
                   },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -165,6 +165,7 @@
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
+                                 "pollingInterval" : 300,
                                  "rLimits" : {
                                     "RSS" : 200000
                                  },
@@ -217,6 +218,7 @@
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
+                                 "pollingInterval" : 300,
                                  "rLimits" : {
                                     "RSS" : 200000
                                  },
@@ -269,6 +271,7 @@
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
+                                 "pollingInterval" : 300,
                                  "rLimits" : {
                                     "RSS" : 200000
                                  },
@@ -321,6 +324,7 @@
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
+                                 "pollingInterval" : 300,
                                  "rLimits" : {
                                     "RSS" : 200000
                                  },

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -102,6 +102,7 @@
                                                    "numProcessors" : 1,
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
+                                                "pollingInterval" : 300,
                                                 "rLimits" : {
                                                    "RSS" : 3000000
                                                 },

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -143,6 +143,7 @@
                                                                   "numProcessors" : 1,
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
+                                                               "pollingInterval" : 300,
                                                                "rLimits" : {
                                                                   "RSS" : 3000000
                                                                },

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
@@ -99,6 +99,7 @@
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
                                                 "options" : {},
+                                                "pollingInterval" : 300,
                                                 "rLimits" : {},
                                                 "user" : "dmorton"
                                              },

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
@@ -140,6 +140,7 @@
                                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                                },
                                                                "options" : {},
+                                                               "pollingInterval" : 300,
                                                                "rLimits" : {},
                                                                "user" : "dmorton"
                                                             },

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
@@ -99,6 +99,7 @@
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
                                                 "options" : {},
+                                                "pollingInterval" : 300,
                                                 "rLimits" : {},
                                                 "user" : "dmorton"
                                              },

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
@@ -140,6 +140,7 @@
                                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                                },
                                                                "options" : {},
+                                                               "pollingInterval" : 300,
                                                                "rLimits" : {},
                                                                "user" : "dmorton"
                                                             },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -56,6 +56,7 @@
                      "numProcessors" : 1,
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
+                  "pollingInterval" : 300,
                   "rLimits" : {
                      "RSS" : 3000000
                   },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -97,6 +97,7 @@
                                     "numProcessors" : 1,
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
+                                 "pollingInterval" : 300,
                                  "rLimits" : {
                                     "RSS" : 3000000
                                  },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -79,6 +79,7 @@
                                     "numProcessors" : 1,
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
+                                 "pollingInterval" : 300,
                                  "rLimits" : {
                                     "RSS" : 3000000
                                  },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -120,6 +120,7 @@
                                                    "numProcessors" : 1,
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
+                                                "pollingInterval" : 300,
                                                 "rLimits" : {
                                                    "RSS" : 3000000
                                                 },

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -100,7 +100,7 @@ sub _get_ptero_execute_method {
     $ptero_lsf_parameters->{user} = Genome::Sys->username;
     $ptero_lsf_parameters->{cwd} = Cwd::getcwd;
     $ptero_lsf_parameters->{pollingInterval} =
-        Genome::Config::get('ptero_lsf_polling_interval');
+        Genome::Config::get('ptero_lsf_polling_interval') + 0;
 
     return Ptero::Builder::Job->new(
         name => 'execute',

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -99,6 +99,8 @@ sub _get_ptero_execute_method {
     $ptero_lsf_parameters->{environment} = $self->_get_sanitized_env();
     $ptero_lsf_parameters->{user} = Genome::Sys->username;
     $ptero_lsf_parameters->{cwd} = Cwd::getcwd;
+    $ptero_lsf_parameters->{pollingInterval} =
+        Genome::Config::get('ptero_lsf_polling_interval');
 
     return Ptero::Builder::Job->new(
         name => 'execute',

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -102,6 +102,11 @@ sub _get_ptero_execute_method {
     $ptero_lsf_parameters->{pollingInterval} =
         Genome::Config::get('ptero_lsf_polling_interval') + 0;
 
+    my $project_name = Genome::Config::get('lsf_project_name');
+    if ($project_name) {
+        $ptero_lsf_parameters->{options}{projectName} = $project_name;
+    }
+
     return Ptero::Builder::Job->new(
         name => 'execute',
         service_url => Genome::Config::get('ptero_lsf_service_url'),


### PR DESCRIPTION
This PR enables you to configure the polling interval that the PTero lsf service uses to track jobs.  Additionally, this PR ensures that lsf jobs associated with a build run with PTero all have a projectName set.