### PR TITLE
Add optional property to VerifyBamId QC tool to set default genotype vcf file

### DIFF
--- a/lib/perl/Genome/Qc/Tool/VerifyBamId.pm
+++ b/lib/perl/Genome/Qc/Tool/VerifyBamId.pm
@@ -7,6 +7,16 @@ use List::MoreUtils qw(any);
 
 class Genome::Qc::Tool::VerifyBamId {
     is => 'Genome::Qc::Tool::WithVariationListVcf',
+    has => [
+        default_genotype_vcf_file_id => {
+            is => 'Text',
+            is_optional => 1,
+        },
+        default_genotype_vcf_file => {
+            is => 'Genome::SoftwareResult::ImportedFile',
+            id_by => 'default_genotype_vcf_file_id',
+        },
+    ],
 };
 
 
@@ -54,6 +64,19 @@ sub _non_metric_columns {
 
 sub _file_extensions_to_parse {
     return qw(selfSM selfRG);
+}
+
+sub genotype_vcf_file {
+    my $self = shift;
+    if ($self->qc_genotype_vcf_file) {
+        return $self->qc_genotype_vcf_file->file_path;
+    }
+    elsif ($self->default_genotype_vcf_file) {
+        return $self->default_genotype_vcf_file->file_path;
+    }
+    else {
+        $self->fatal_message("No qc genotype vcf file provided.");
+    }
 }
 
 1;

--- a/lib/perl/Genome/Qc/Tool/VerifyBamId.pm
+++ b/lib/perl/Genome/Qc/Tool/VerifyBamId.pm
@@ -13,7 +13,7 @@ class Genome::Qc::Tool::VerifyBamId {
             is_optional => 1,
         },
         default_genotype_vcf_file => {
-            is => 'Genome::SoftwareResult::ImportedFile',
+            is => 'Genome::SoftwareResult::StageableSimple::SingleFile',
             id_by => 'default_genotype_vcf_file_id',
         },
     ],

--- a/lib/perl/Genome/Qc/Tool/VerifyBamId.t
+++ b/lib/perl/Genome/Qc/Tool/VerifyBamId.t
@@ -38,6 +38,7 @@ my $alignment_result = Genome::Test::Factory::InstrumentData::AlignmentResult->s
     instrument_data => $instrument_data,
 );
 my $vcf_file = Genome::Test::Factory::SoftwareResult::ImportedFile->setup_object();
+my $default_vcf_file = Genome::Test::Factory::SoftwareResult::ImportedFile->setup_object();
 use Genome::SoftwareResult::StageableSimple::SingleFile;
 my $vcf_file_path_overwrite = Sub::Override->new(
     'Genome::SoftwareResult::StageableSimple::SingleFile::file_path',
@@ -61,6 +62,9 @@ my $config_override = Sub::Override->new(
                     precise => '1',
                     version => '20120620',
                     ignore_read_group => 0,
+                },
+                additional_params => {
+                    default_genotype_vcf_file_id => $default_vcf_file->id,
                 },
             }
         };
@@ -93,6 +97,13 @@ my @expected_cmd_line = (
     '--precise',
 );
 is_deeply([$tool->cmd_line], [@expected_cmd_line], 'Command line list as expected');
+
+my $command_without_qc_genotype_vcf_file = Genome::Qc::Run->create(
+    config_name => 'testing-qc-run',
+    alignment_result => $alignment_result,
+    %{Genome::Test::Factory::SoftwareResult::User->setup_user_hash},
+);
+ok($command_without_qc_genotype_vcf_file->execute, "Command with qc_genotype_vcf_file executes ok");
 
 my %expected_metrics = (
     '2883581792-2883255521	#READS' => 0,

--- a/lib/perl/Genome/Qc/Tool/VerifyBamId.t
+++ b/lib/perl/Genome/Qc/Tool/VerifyBamId.t
@@ -103,7 +103,7 @@ my $command_without_qc_genotype_vcf_file = Genome::Qc::Run->create(
     alignment_result => $alignment_result,
     %{Genome::Test::Factory::SoftwareResult::User->setup_user_hash},
 );
-ok($command_without_qc_genotype_vcf_file->execute, "Command with qc_genotype_vcf_file executes ok");
+ok($command_without_qc_genotype_vcf_file->execute, "Command without qc_genotype_vcf_file executes ok");
 
 my %expected_metrics = (
     '2883581792-2883255521	#READS' => 0,


### PR DESCRIPTION
This file would then be used if no qc_genotype_vcf_file is specified in the build