### PR TITLE
Add running build limit in "list-build-queue"

### DIFF
--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -59,7 +59,12 @@ sub execute {
 
         # avoid extra DB queries below if we are just going to skip anyway
         if ($count >= $self->max) {
-            Genome::Logger->infof(qq(%s's scheduled count exceeds %d\n), $run_as, $count);
+            Genome::Logger->infof(
+                "%s's scheduled count (%d) meets or exceeds specified maximum (%d)\n",
+                $run_as,
+                $count,
+                $self->max,
+            );
             next RUN_AS;
         }
 
@@ -68,7 +73,12 @@ sub execute {
 
             MODEL: while (my $model = $models->next) {
                 if ($count >= $self->max) {
-                    Genome::Logger->infof(qq(%s's scheduled count exceeds %d\n), $run_as, $count);
+                    Genome::Logger->infof(
+                        "%s's scheduled count (%d) reached specified maximum (%d)\n",
+                        $run_as,
+                        $count,
+                        $self->max,
+                    );
                     next RUN_AS;
                 }
                 $count++;

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -21,6 +21,10 @@ class Genome::Model::Command::Services::ListBuildQueue {
             default => 50,
             is_optional => 1,
         },
+        running_max => {
+            doc => 'maximum number of running builds per user (assumes run_as will be used)',
+            default => 150,
+        },
     ],
 };
 
@@ -68,7 +72,10 @@ sub execute {
             next RUN_AS;
         }
 
-        my $max_running = ($run_as eq 'apipe-builder'? 650 : 150);
+        my $max_running = $self->running_max;
+        if($run_as eq 'apipe-builder') {
+            $max_running *= 5;
+        }
         my $running_count = $scheduled_count + builds_for($run_as, 'Running');
         if($running_count > $max_running) {
             Genome::Logger->infof(

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -55,7 +55,7 @@ sub execute {
 
     my @run_as = run_as_list();
     RUN_AS: while (my $run_as = shift @run_as) {
-        my $count = scheduled_builds_for($run_as);
+        my $count = builds_for($run_as, 'Scheduled');
 
         # avoid extra DB queries below if we are just going to skip anyway
         if ($count >= $self->max) {
@@ -97,10 +97,11 @@ sub run_as_list {
     return map { $_->[0] } @{$rows};
 }
 
-sub scheduled_builds_for {
+sub builds_for {
     my $username = shift;
+    my $status = shift;
 
-    my $set = Genome::Model::Build->define_set(run_by => $username, status => 'Scheduled');
+    my $set = Genome::Model::Build->define_set(run_by => $username, status => $status);
     return $set->count();
 }
 

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -100,20 +100,8 @@ sub run_as_list {
 sub scheduled_builds_for {
     my $username = shift;
 
-    my $type = Genome::Model::Build->__meta__;
-
-    my $table_name    = $type->table_name;
-    my $run_by_column = $type->properties(property_name => 'run_by')->column_name;
-    my $status_column = $type->properties(property_name => 'status')->column_name;
-
-    my $sql_t = q/SELECT count(*) FROM %s WHERE %s = ? AND %s = 'Scheduled'/;
-    my $sql = sprintf($sql_t, $table_name, $run_by_column, $status_column);
-
-    my $dbh = $type->data_source->get_default_handle;
-    my $sth = $dbh->prepare($sql);
-    $sth->execute($username);
-    my $row = $sth->fetchrow_arrayref();
-    return $row->[0];
+    my $set = Genome::Model::Build->define_set(run_by => $username, status => 'Scheduled');
+    return $set->count();
 }
 
 sub sprint {

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -69,7 +69,7 @@ sub execute {
         }
 
         my $max_running = ($run_as eq 'apipe-builder'? 650 : 150);
-        my $running_count = builds_for($run_as, 'Running');
+        my $running_count = $scheduled_count + builds_for($run_as, 'Running');
         if($running_count > $max_running) {
             Genome::Logger->infof(
                 "%s's running count (%d) meets or exceeds maximum (%d)\n",

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -6,7 +6,7 @@ use warnings;
 use Genome;
 
 class Genome::Model::Command::Services::ListBuildQueue {
-    is => 'Command',
+    is => 'Command::V2',
     doc => 'List queued models for processing by cron.',
     has => [
         delimiter => {

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.t
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More tests => 2;
 
-use Genome;
+use above 'Genome';
 
 use Genome::Model::Command::Services::ListBuildQueue;
 use Genome::Test::Factory::Model::ReferenceAlignment;

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.t
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.t
@@ -19,7 +19,7 @@ do {
     my $count;
     no warnings qw(once redefine);
     local *Genome::Model::Command::Services::ListBuildQueue::run_as_list = sub { uniq map { $_->run_as } @m };
-    local *Genome::Model::Command::Services::ListBuildQueue::scheduled_builds_for = sub { 0 };
+    local *Genome::Model::Command::Services::ListBuildQueue::builds_for = sub { 0 };
     local *Genome::Model::Command::Services::ListBuildQueue::print = sub { $count++ };
     Genome::Model::Command::Services::ListBuildQueue->execute(
         max => $max,

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.t
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.t
@@ -5,6 +5,10 @@ use warnings;
 
 use Test::More tests => 2;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
 use above 'Genome';
 
 use Genome::Model::Command::Services::ListBuildQueue;


### PR DESCRIPTION
As we move to PTero, we can't rely on the size of the workflow LSF queues to limit our build starts.  

It is not ideal that this hard-codes a multiplier for apipe-builder; several things about the build process seem to have this "feature".