### PR TITLE
RemoveDiskAllocationsFromTestDb remembers which TestDB was used.

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/RemoveDiskAllocationsFromTestdb.pm
+++ b/lib/perl/Genome/Model/Command/Admin/RemoveDiskAllocationsFromTestdb.pm
@@ -222,7 +222,8 @@ my @ENV_VARS_FOR_TEST_DB = map { Genome::Config::spec($_)->env }
 sub _dbh_for_production_db {
     my $self = shift;
 
-    delete local @ENV{ @ENV_VARS_FOR_TEST_DB };
+    local @ENV{ @ENV_VARS_FOR_TEST_DB };
+    delete @ENV{ @ENV_VARS_FOR_TEST_DB };
     my $db_settings = $self->_parse_database_connection_info_from_config();
     my $conn = sprintf('dbi:Pg:dbname=%s;host=%s', $db_settings->{dbname}, $db_settings->{host});
     if ($db_settings->{port}) {

--- a/lib/perl/Genome/Model/Command/Admin/RemoveDiskAllocationsFromTestdb.pm
+++ b/lib/perl/Genome/Model/Command/Admin/RemoveDiskAllocationsFromTestdb.pm
@@ -27,7 +27,6 @@ class Genome::Model::Command::Admin::RemoveDiskAllocationsFromTestdb {
             is => 'Text',
             default_value => _get_default_database_server(),
             doc => 'database server name, derived from the ds_gmschema_server config value',
-        
         },
         database_port => {
             is => 'Text',


### PR DESCRIPTION
`delete local` did not only remove the key from the hash locally. Thus, when the allocation shelled out to perform the deletion, it connected to the production database and couldn't find the allocation.

Splitting this to two lines seems to have the intended effect of removing the localized version.