### PR TITLE
TCGA Priorities: Add alternative way to get cghub id

### DIFF
--- a/lib/perl/Genome/Model/Tools/Tcga/Sdrf.pm
+++ b/lib/perl/Genome/Model/Tools/Tcga/Sdrf.pm
@@ -220,7 +220,7 @@ sub resolve_cghub_id {
         unless (defined $id) {
             $id = $id_by_bam_base->{basename $merged_bam};
             unless (defined $id) {
-                $self->fatal_message("CGHub id could not be resolved for build %s with bam file: %s", $build->id, $build->whole_rmdup_bam_file);
+                $self->fatal_message("CGHub id could not be resolved for build %s with bam file: %s", $build->id, $merged_bam);
             }
         }
     }

--- a/lib/perl/Genome/Model/Tools/Tcga/Sdrf.pm
+++ b/lib/perl/Genome/Model/Tools/Tcga/Sdrf.pm
@@ -216,9 +216,9 @@ sub resolve_cghub_id {
     my $merged_bam = $build->whole_rmdup_bam_file;
     my $id = $CGHUB_INFO->{$merged_bam};
     unless (defined $id) {
-        $id = $id_by_bam_base->{basename $merged_bam};
+        $id = $CGHUB_INFO_BY_TCGA_NAME->{$build->subject->name_in_vcf};
         unless (defined $id) {
-            $id = $CGHUB_INFO_BY_TCGA_NAME->{$build->subject->name_in_vcf};
+            $id = $id_by_bam_base->{basename $merged_bam};
             unless (defined $id) {
                 $self->fatal_message("CGHub id could not be resolved for build %s with bam file: %s", $build->id, $build->whole_rmdup_bam_file);
             }

--- a/lib/perl/Genome/Model/Tools/Tcga/Sdrf.pm
+++ b/lib/perl/Genome/Model/Tools/Tcga/Sdrf.pm
@@ -218,7 +218,7 @@ sub resolve_cghub_id {
     unless (defined $id) {
         $id = $id_by_bam_base->{basename $merged_bam};
         unless (defined $id) {
-            $id = $CGHUB_INFO_BY_TCGA_NAME->{$build->subject->extraction_label};
+            $id = $CGHUB_INFO_BY_TCGA_NAME->{$build->subject->name_in_vcf};
             unless (defined $id) {
                 $self->fatal_message("CGHub id could not be resolved for build %s with bam file: %s", $build->id, $build->whole_rmdup_bam_file);
             }


### PR DESCRIPTION
For some TCGA builds, current cghub id retrieve ways do not work. For example, mount path of merged bam could be changed after unarchiving and build subject extraction_label do not always return proper TCGA names. This PR adds a lookup hash by searching for unique bam base_name and uses name_in_vcf to replace extraction_label. This PR needs early merge.