### PR TITLE
Include status in `genome analysis-project view` output

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/View.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/View.pm
@@ -153,6 +153,7 @@ sub _get_heading_lines {
         ["ID", $ap->id, "Name", $ap->name],
         ["Run as", $ap->run_as, "Created", $ap->created_at ],
         ["Updated", $ap->updated_at, "Created by", $ap->created_by],
+        ["Status", $ap->status],
     );
 }
 


### PR DESCRIPTION
Although the `view` command shows a warning banner when the project is pending or on hold (to notify the user they need to `release` it before processing begins), it didn't otherwise display the status of the project.  Now it does!