### PR TITLE
Make name/value accessors consistent for differing metric types.

### DIFF
--- a/lib/perl/Genome/Model/Metric.pm
+++ b/lib/perl/Genome/Model/Metric.pm
@@ -26,6 +26,8 @@ class Genome::Model::Metric {
         model_id => { via => 'build' },
         model_name => { via => 'model', to => 'name' },
         data_directory => { via => 'build' },
+        metric_name => { via => '__self__', to => 'name' },
+        metric_value => { via => '__self__', to => 'value' },
     ],
     schema_name => 'GMSchema',
     data_source => 'Genome::DataSource::GMSchema',

--- a/lib/perl/Genome/SoftwareResult/Metric.pm
+++ b/lib/perl/Genome/SoftwareResult/Metric.pm
@@ -20,6 +20,8 @@ class Genome::SoftwareResult::Metric {
             id_by => 'software_result_id',
             constraint_name => 'SRM_SR_FK',
         },
+        name => { via => '__self__', to => 'metric_name' },
+        value => { via => '__self__', to => 'metric_value' },
     ],
     schema_name => 'GMSchema',
     data_source => 'Genome::DataSource::GMSchema',


### PR DESCRIPTION
While working with @susannasiebert today, we noticed that `Genome::Model::Metric`s and `Genome::SoftwareResult::Metric`s have different interfaces. One responds to `metric_{name,value}` and the other `{name,value}` which is frustrating :frowning: Ironically, their column names are consistent with each other, but the properties are named differently in the class definitions.

This PR makes it so both types of metrics respond to both interfaces. There are other small inconsistencies that this does not address (one has read-only properties, the other doesn't for instance). Eventually it seems like we should have one `Metric` class with `SoftwareResult` and `Model` metrics varying only in table name.

Thoughts?