### PR TITLE
Don't import "compare" since we're defining our own.

### DIFF
--- a/lib/perl/Genome/Utility/File/Comparer.pm
+++ b/lib/perl/Genome/Utility/File/Comparer.pm
@@ -3,7 +3,7 @@ package Genome::Utility::File::Comparer;
 use strict;
 use warnings;
 use Genome;
-use File::Compare;
+use File::Compare ();
 
 class Genome::Utility::File::Comparer {
     has => [


### PR DESCRIPTION
We were already using `File::Compare::compare` explicitly in this module.