### PR TITLE
update blessed process to account for new N-caller and VAF fixes

### DIFF
--- a/lib/perl/Genome/Process/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Process/Command/DiffBlessed.pm.YAML
@@ -1,2 +1,2 @@
 ---
-trio_main: 1fc938da60ae4c13bf4c512fcb01ae4f
+trio_main: d119fb9806dd4c86a51bc6dc0af16bc4


### PR DESCRIPTION
This should fix failing model tests.