### PR TITLE
Remove trash folder support.  Delete purged data immediately.

### DIFF
--- a/etc/genome/spec/disk_group_trash.yaml
+++ b/etc/genome/spec/disk_group_trash.yaml
@@ -1,2 +1,0 @@
---- 
-env: XGENOME_DISK_GROUP_TRASH

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -1074,10 +1074,4 @@ sub _default_archive_after_time {
     DateTime->now(time_zone => 'local')->add(seconds => SECONDS_IN_ONE_YEAR)->strftime('%F 00:00:00');
 }
 
-sub _get_trash_folder {
-    my $self = shift;
-
-    return File::Spec->join($self->volume->get_trash_folder(), $self->id);
-}
-
 1;

--- a/lib/perl/Genome/Disk/Command/Allocation/Purge.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/Purge.pm
@@ -24,7 +24,7 @@ class Genome::Disk::Command::Allocation::Purge {
 
 sub help_detail {
     return "PERMANENTLY DELETES the allocation's files. The files are "
-        . 'temporarily stored in a trash folder for short-term recovery. '
+        . 'immediately deleted and cannot be recovered. '
         . 'Database records of this allocation will be kept.';
 }
 

--- a/lib/perl/Genome/Disk/Detail/Allocation/Purger.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Purger.pm
@@ -87,20 +87,15 @@ sub _purge_unarchived {
     my $allocation_object = shift;
 
     unless ($ENV{UR_DBI_NO_COMMIT}) {
-        my $destination_directory = $allocation_object->_get_trash_folder();
-        Genome::Sys->create_directory($destination_directory);
-
-        $self->status_message('Moving allocation path \''.
-            $allocation_object->absolute_path .'\' to temporary path \''.
-            $destination_directory .'\'');
-
-        unless (dirmove($allocation_object->absolute_path,
-                    $destination_directory)) {
-            $self->error_message('Failed to move allocation path \''.
-                $allocation_object->absolute_path .'\' to destination path \''.
-                $destination_directory .'\': '. $!);
+        my $absolute_path = $allocation_object->absolute_path;
+        $self->status_message(q{Removing allocation path '%s'}, $absolute_path);
+        unless (Genome::Sys->remove_directory_tree($absolute_path)) {
+            $self->error_message(
+                'Error removing directory for allocation %s',
+                $allocation_object->id
+            );
             return;
-        };
+        }
     }
 
     $self->_finalize_purge($allocation_object);

--- a/lib/perl/Genome/Disk/Volume.pm
+++ b/lib/perl/Genome/Disk/Volume.pm
@@ -374,28 +374,4 @@ sub is_near_soft_limit {
     return (($self->soft_limit_kb - $kb) < $threshold );
 }
 
-sub get_trash_folder {
-    my $self = shift;
-
-    my $aggr = _extract_aggr($self->physical_path);
-
-    my $trash_volume = Genome::Disk::Volume->get(
-        disk_group_names => Genome::Config::get('disk_group_trash'),
-        'physical_path like' => "/vol/$aggr/%",
-    );
-
-    unless ($trash_volume) {
-        die $self->error_message(
-            "Unable to get trash volume for volume (%s) via aggr (%s)",
-            $self->mount_path, $aggr);
-    }
-
-    return File::Spec->join($trash_volume->mount_path, '.trash');
-}
-
-sub _extract_aggr {
-    return (shift =~ m!/(aggr\d+)/!)[0];
-}
-
-
 1;

--- a/lib/perl/Genome/Site/TGI/SiteLib/Genome/Disk/Group/Validate/GenomeDiskGroups.pm
+++ b/lib/perl/Genome/Site/TGI/SiteLib/Genome/Disk/Group/Validate/GenomeDiskGroups.pm
@@ -58,7 +58,6 @@ sub genome_disk_group_names {
         Genome::Config::get('disk_group_references'),
         Genome::Config::get('disk_group_alignments'),
         Genome::Config::get('disk_group_models'),
-        Genome::Config::get('disk_group_trash'),
         Genome::Config::get('disk_group_research'),
     );
 }


### PR DESCRIPTION
In practice the trash volumes were a waste of space as data was never reclaimed therefrom.  They're being retired, so now we can remove data directly when purging.