### PR TITLE
TCGA Priorities: make sample get_tcga_names return all possible tcga names

### DIFF
--- a/lib/perl/Genome/Model/Tools/Tcga/CreateSubmissionArchive.pm
+++ b/lib/perl/Genome/Model/Tools/Tcga/CreateSubmissionArchive.pm
@@ -209,7 +209,7 @@ sub print_manifest {
 
 sub get_info_for_sample {
     my ($self, $desired_sample, $sample_info_collection) = @_;
-    my $tcga_names = Set::Scalar->new($desired_sample->extraction_label, $desired_sample->get_tcga_names);
+    my $tcga_names = Set::Scalar->new($desired_sample->get_tcga_names);
     my $found_sample;
     
     for my $sample (@$sample_info_collection) {

--- a/lib/perl/Genome/Sample.pm
+++ b/lib/perl/Genome/Sample.pm
@@ -289,23 +289,25 @@ sub name_in_vcf {
 
 sub get_tcga_names {
     my $self = shift;
-    my @sample_attributes = $self->attributes(attribute_label => 'external_name');
-    my @tcga_names;
+    
+    my %tcga_names;
+    my $extraction_label = $self->extraction_label;
+    if ($extraction_label and $extraction_label =~ /^TCGA\-/) {
+        $tcga_names{$extraction_label}++;
+    }
 
+    my @sample_attributes = $self->attributes(attribute_label => 'external_name');
     if (@sample_attributes) {
         for my $attr (@sample_attributes) {
             my $sample_tcga_name = $attr->attribute_value;
 
             if ($sample_tcga_name and $sample_tcga_name =~ /^TCGA\-/) {
-                push @tcga_names, $sample_tcga_name;
+                $tcga_names{$sample_tcga_name}++;
             }
         }
     }
-    else {
-        $self->debug_message("No sample attribute with attribute_label as external_name found for sample: %s", $self->name);
-    }
-    $self->debug_message("No TCGA name found from sample attributes for sample: %s", $self->name) unless @tcga_names;
-    return @tcga_names;
+
+    return sort keys %tcga_names;
 }
 
 sub resolve_tcga_patient_id {

--- a/lib/perl/Genome/Sample.t
+++ b/lib/perl/Genome/Sample.t
@@ -23,7 +23,7 @@ ok($source, 'define source');
 my %sample_params = (
     name             => 'full_name.test',
     common_name      => 'common',
-    extraction_label => 'TCGA-1234-232-12',
+    extraction_label => 'TCGA-12-1234-232-12',
     extraction_type  => 'genomic dna',
     extraction_desc  => 'This is a test',
     source           => $source,
@@ -49,10 +49,11 @@ for my $tcga_name (@tcga_names) {
     );
 }
 
+push @tcga_names, 'TCGA-12-1234-232-12';
 
 isa_ok($sample, 'Genome::Sample');
 
-is($sample->name_in_vcf, "TCGA-1234-232-12", 'sample TCGA name');
+is($sample->name_in_vcf, "TCGA-12-1234-232-12", 'sample TCGA name');
 is($sample_special->name_in_vcf, 'TCGA-AB-3012-03A-01D-0741-05', 'special sample TCGA name');
 is($sample->resolve_tcga_patient_id, 'TCGA-12-1234', 'resolve_tcga_patient_id');
 


### PR DESCRIPTION
For some rare cases, LIMS does not store any TCGA name as external_name in sample attributes, but does store as sample extraction_label instead.