### PR TITLE
Use display_name for printing AnalysisProject when Unarchiving

### DIFF
--- a/lib/perl/Genome/Disk/Command/Allocation/UnarchiveBase.pm
+++ b/lib/perl/Genome/Disk/Command/Allocation/UnarchiveBase.pm
@@ -28,8 +28,8 @@ sub execute {
     unless ($self->requestor) {
         $self->requestor(Genome::Sys->current_user);
     }
-    $self->status_message(sprintf("Unarchiving allocation(s) for Analysis Project %s at the request of %s.",
-            $self->analysis_project, $self->requestor->name));
+    $self->status_message("Unarchiving allocation(s) for Analysis Project %s at the request of %s.",
+            $self->analysis_project->__display_name__, $self->requestor->name);
 
     return $self->_execute();
 }


### PR DESCRIPTION
Currently, the command prints out this:

````
Unarchiving allocation(s) for Analysis Project Genome::Config::AnalysisProject=HASH(0x7c07088)
````

Now it would print out this:

````
Unarchiving allocation(s) for Analysis Project: My super sweet analysis project (id)
````