### PR TITLE
Qc metrics fix

### DIFF
--- a/lib/perl/Genome/Qc/Command/BuildMetrics.pm
+++ b/lib/perl/Genome/Qc/Command/BuildMetrics.pm
@@ -49,7 +49,7 @@ sub execute {
         die($self->error_message);
     }
 
-    DumpFile($self->output_file,@metrics);
+    DumpFile($self->output_file,\@metrics);
 
     return 1;
 }

--- a/lib/perl/Genome/Qc/Command/BuildMetrics.t
+++ b/lib/perl/Genome/Qc/Command/BuildMetrics.t
@@ -59,8 +59,8 @@ my $expected_output_file = $test_dir .'/expected_build_metrics.yml';
 my $test_output_file = Genome::Sys->create_temp_file_path();
 
 # Get expected IDs from YAML file.
-my @expected_metrics = LoadFile($expected_output_file);
-my $expected_metrics_hash = $expected_metrics[0];
+my $expected_metrics = LoadFile($expected_output_file);
+my $expected_metrics_hash = $expected_metrics->[0];
 my $expected_build_id = $expected_metrics_hash->{'build_id'};
 my $expected_instrument_data_id = $expected_metrics_hash->{'instrument_data_ids'};
 

--- a/lib/perl/Genome/Qc/Command/BuildMetrics.t.d/expected_build_metrics.yml
+++ b/lib/perl/Genome/Qc/Command/BuildMetrics.t.d/expected_build_metrics.yml
@@ -1,18 +1,19 @@
 --- 
-DUPLICATION_RATE: 0.116666666666667
-GENOME_TERRITORY: 1000
-HAPLOID_COVERAGE: 26.5
-PAIR: 
-  PF_ALIGNED_BASES: 30000
-  PF_READS_ALIGNED: 3000
-build_id: 373409c039084aec90af7f0997c3e5e5
-instrument_data_count: 1
-instrument_data_ids: f7a92847871f42ee93c879a8ccf53975
-label_1: 
-  metric_E: 5
-  metric_F: 6
-metric_A: 1
-metric_B: 2
-metric_C: 3
-metric_D: 4
-reads_marked_duplicates: 350
+- 
+  DUPLICATION_RATE: 0.116666666666667
+  GENOME_TERRITORY: 1000
+  HAPLOID_COVERAGE: 26.5
+  PAIR: 
+    PF_ALIGNED_BASES: 30000
+    PF_READS_ALIGNED: 3000
+  build_id: dcf62eb21b384f718d183bbcd5244b8c
+  instrument_data_count: 1
+  instrument_data_ids: 502fe6c1c8e84537bc930de1e3c70f50
+  label_1: 
+    metric_E: 5
+    metric_F: 6
+  metric_A: 1
+  metric_B: 2
+  metric_C: 3
+  metric_D: 4
+  reads_marked_duplicates: 350


### PR DESCRIPTION
I think it is only valid to dump a ref to a file with DumpFile - at least I was having problems loading it in when I had more than one entry in the array.  Or, I might be misunderstanding something about yaml format.  Anyway, this seems to work much better for me.