### PR TITLE
Remove LSF queue overrides in Varscan "high confidence" filters.

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/VarscanHighConfidence.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/VarscanHighConfidence.pm
@@ -14,9 +14,6 @@ class Genome::Model::Tools::DetectVariants2::Filter::VarscanHighConfidence{
         min_tumor_freq  => { is => 'Number', doc => "Minimum tumor freq for HC Somatic", is_input => 1, default_value => '10'},
     ],
     has_param => [
-         lsf_queue => {
-             default_value => Genome::Config::get('lsf_queue_dv2_workflow'),
-         },
          lsf_resource => {
              default_value => Genome::Config::get('lsf_resource_dv2_filter_varscan_high_confidence'),
          },

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/VarscanHighConfidenceIndel.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/VarscanHighConfidenceIndel.pm
@@ -14,9 +14,6 @@ class Genome::Model::Tools::DetectVariants2::Filter::VarscanHighConfidenceIndel{
         min_tumor_freq  => { is => 'Number', doc => "Minimum tumor freq for HC Somatic", is_input => 1, default_value => '10'},
     ],
     has_param => [
-         lsf_queue => {
-             default_value => Genome::Config::get('lsf_queue_dv2_workflow'),
-         },
          lsf_resource => {
              default_value => Genome::Config::get('lsf_resource_dv2_filter_varscan_high_confidence_indel'),
          },


### PR DESCRIPTION
These don't spawn workflows, so with this change they'll use the default queue for workers specified in [DV2/Filter.pm](https://github.com/genome/genome/blob/2d2f91c10ed2187e5d8346400b61b4edcafb2e69/lib/perl/Genome/Model/Tools/DetectVariants2/Filter.pm#L160).