### PR TITLE
Asynchronous Shortcutting when using PTero

### DIFF
--- a/etc/genome/spec/software_result_async_locking.yaml
+++ b/etc/genome/spec/software_result_async_locking.yaml
@@ -1,0 +1,5 @@
+---
+env: XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING
+default_value: 0
+validators:
+  - Numeric

--- a/etc/genome/spec/software_result_async_locking_exit_code.yaml
+++ b/etc/genome/spec/software_result_async_locking_exit_code.yaml
@@ -1,0 +1,7 @@
+---
+env: XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING_EXIT_CODE
+# default value chosen based on /usr/include/sysexits.h:
+# >>> define EX_TEMPFAIL     75      /* temp failure; user is invited to retry */
+default_value: 75
+validators:
+  - Numeric

--- a/etc/genome/spec/software_result_async_locking_initial_interval.yaml
+++ b/etc/genome/spec/software_result_async_locking_initial_interval.yaml
@@ -1,0 +1,5 @@
+---
+env: XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING_INITIAL_INTERVAL
+default_value: 60
+validators:
+  - Numeric

--- a/etc/genome/spec/software_result_async_locking_max_interval.yaml
+++ b/etc/genome/spec/software_result_async_locking_max_interval.yaml
@@ -1,0 +1,5 @@
+---
+env: XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING_MAX_INTERVAL
+default_value: 3600
+validators:
+  - Numeric

--- a/etc/genome/spec/software_result_async_locking_num_attempts.yaml
+++ b/etc/genome/spec/software_result_async_locking_num_attempts.yaml
@@ -1,0 +1,7 @@
+---
+env: XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING_MAX_ATTEMPTS
+# with software_result_async_locking_max_interval set to 3600 seconds
+# 750 is approximately 1 month worth of attempts.
+default_value: 750
+validators:
+  - Numeric

--- a/etc/genome/spec/software_result_async_locking_num_attempts.yaml
+++ b/etc/genome/spec/software_result_async_locking_num_attempts.yaml
@@ -1,5 +1,5 @@
 ---
-env: XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING_MAX_ATTEMPTS
+env: XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING_NUM_ATTEMPTS
 # with software_result_async_locking_max_interval set to 3600 seconds
 # 750 is approximately 1 month worth of attempts.
 default_value: 750

--- a/etc/genome/spec/sys_lock_exit_code.yaml
+++ b/etc/genome/spec/sys_lock_exit_code.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_SYS_LOCK_EXIT_CODE
+default_value: ' '

--- a/etc/genome/spec/sys_lock_exit_code.yaml
+++ b/etc/genome/spec/sys_lock_exit_code.yaml
@@ -1,3 +1,0 @@
----
-env: XGENOME_SYS_LOCK_EXIT_CODE
-default_value: ' '

--- a/lib/perl/Genome/Ptero/Wrapper.pm
+++ b/lib/perl/Genome/Ptero/Wrapper.pm
@@ -122,9 +122,9 @@ sub _setup_logging {
     open(SAVED_STDERR, ">&STDERR") || die "Can't save STDERR\n";
 
     # redirect stdout/stderr through the annotate-log filter
-    open OUTPUT, '|-',  'annotate-log cat > ' .
+    open OUTPUT, '|-',  'annotate-log cat >> ' .
         $self->_stdout_log_path or die $!;
-    open ERROR, '|-',  'annotate-log cat > ' .
+    open ERROR, '|-',  'annotate-log cat >> ' .
         $self->_stderr_log_path or die $!;
 
     STDOUT->fdopen(\*OUTPUT, 'w') or die $!;

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -50,7 +50,14 @@
                   ],
                   "environment" : {
                      "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                     "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                  },
+                  "retrySettings" : {
+                     "attempts" : 750,
+                     "exitCode" : 75,
+                     "initialInterval" : 60,
+                     "maxInterval" : 3600
                   },
                   "user" : "dmorton",
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
@@ -147,7 +154,14 @@
                                                 ],
                                                 "environment" : {
                                                    "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                   "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                },
+                                                "retrySettings" : {
+                                                   "attempts" : 750,
+                                                   "exitCode" : 75,
+                                                   "initialInterval" : 60,
+                                                   "maxInterval" : 3600
                                                 },
                                                 "user" : "dmorton",
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -93,7 +93,14 @@
                                  "environment" : {
                                     "FOO" : "bar",
                                     "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                    "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                 },
+                                 "retrySettings" : {
+                                    "attempts" : 750,
+                                    "exitCode" : 75,
+                                    "initialInterval" : 60,
+                                    "maxInterval" : 3600
                                  },
                                  "user" : "dmorton",
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
@@ -192,7 +199,14 @@
                                                                "environment" : {
                                                                   "FOO" : "bar",
                                                                   "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                                  "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                                  "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                                  "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                               },
+                                                               "retrySettings" : {
+                                                                  "attempts" : 750,
+                                                                  "exitCode" : 75,
+                                                                  "initialInterval" : 60,
+                                                                  "maxInterval" : 3600
                                                                },
                                                                "user" : "dmorton",
                                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -97,7 +97,14 @@
                   ],
                   "environment" : {
                      "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                     "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                  },
+                  "retrySettings" : {
+                     "attempts" : 750,
+                     "exitCode" : 75,
+                     "initialInterval" : 60,
+                     "maxInterval" : 3600
                   },
                   "user" : "dmorton",
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
@@ -148,7 +155,14 @@
                   ],
                   "environment" : {
                      "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                     "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                  },
+                  "retrySettings" : {
+                     "attempts" : 750,
+                     "exitCode" : 75,
+                     "initialInterval" : 60,
+                     "maxInterval" : 3600
                   },
                   "user" : "dmorton",
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
@@ -199,7 +213,14 @@
                   ],
                   "environment" : {
                      "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                     "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                  },
+                  "retrySettings" : {
+                     "attempts" : 750,
+                     "exitCode" : 75,
+                     "initialInterval" : 60,
+                     "maxInterval" : 3600
                   },
                   "user" : "dmorton",
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
@@ -250,7 +271,14 @@
                   ],
                   "environment" : {
                      "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                     "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                  },
+                  "retrySettings" : {
+                     "attempts" : 750,
+                     "exitCode" : 75,
+                     "initialInterval" : 60,
+                     "maxInterval" : 3600
                   },
                   "user" : "dmorton",
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -142,7 +142,14 @@
                                  "environment" : {
                                     "FOO" : "bar",
                                     "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                    "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                 },
+                                 "retrySettings" : {
+                                    "attempts" : 750,
+                                    "exitCode" : 75,
+                                    "initialInterval" : 60,
+                                    "maxInterval" : 3600
                                  },
                                  "user" : "dmorton",
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
@@ -195,7 +202,14 @@
                                  "environment" : {
                                     "FOO" : "bar",
                                     "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                    "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                 },
+                                 "retrySettings" : {
+                                    "attempts" : 750,
+                                    "exitCode" : 75,
+                                    "initialInterval" : 60,
+                                    "maxInterval" : 3600
                                  },
                                  "user" : "dmorton",
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
@@ -248,7 +262,14 @@
                                  "environment" : {
                                     "FOO" : "bar",
                                     "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                    "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                 },
+                                 "retrySettings" : {
+                                    "attempts" : 750,
+                                    "exitCode" : 75,
+                                    "initialInterval" : 60,
+                                    "maxInterval" : 3600
                                  },
                                  "user" : "dmorton",
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
@@ -301,7 +322,14 @@
                                  "environment" : {
                                     "FOO" : "bar",
                                     "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                    "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                 },
+                                 "retrySettings" : {
+                                    "attempts" : 750,
+                                    "exitCode" : 75,
+                                    "initialInterval" : 60,
+                                    "maxInterval" : 3600
                                  },
                                  "user" : "dmorton",
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -81,7 +81,14 @@
                                                 ],
                                                 "environment" : {
                                                    "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                   "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                },
+                                                "retrySettings" : {
+                                                   "attempts" : 750,
+                                                   "exitCode" : 75,
+                                                   "initialInterval" : 60,
+                                                   "maxInterval" : 3600
                                                 },
                                                 "user" : "dmorton",
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -121,7 +121,14 @@
                                                                "environment" : {
                                                                   "FOO" : "bar",
                                                                   "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                                  "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                                  "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                                  "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                               },
+                                                               "retrySettings" : {
+                                                                  "attempts" : 750,
+                                                                  "exitCode" : 75,
+                                                                  "initialInterval" : 60,
+                                                                  "maxInterval" : 3600
                                                                },
                                                                "user" : "dmorton",
                                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
@@ -81,7 +81,14 @@
                                                 ],
                                                 "environment" : {
                                                    "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                   "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                },
+                                                "retrySettings" : {
+                                                   "attempts" : 750,
+                                                   "exitCode" : 75,
+                                                   "initialInterval" : 60,
+                                                   "maxInterval" : 3600
                                                 },
                                                 "user" : "dmorton",
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
@@ -121,7 +121,14 @@
                                                                "environment" : {
                                                                   "FOO" : "bar",
                                                                   "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                                  "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                                  "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                                  "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                               },
+                                                               "retrySettings" : {
+                                                                  "attempts" : 750,
+                                                                  "exitCode" : 75,
+                                                                  "initialInterval" : 60,
+                                                                  "maxInterval" : 3600
                                                                },
                                                                "user" : "dmorton",
                                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
@@ -81,7 +81,14 @@
                                                 ],
                                                 "environment" : {
                                                    "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                   "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                },
+                                                "retrySettings" : {
+                                                   "attempts" : 750,
+                                                   "exitCode" : 75,
+                                                   "initialInterval" : 60,
+                                                   "maxInterval" : 3600
                                                 },
                                                 "user" : "dmorton",
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
@@ -121,7 +121,14 @@
                                                                "environment" : {
                                                                   "FOO" : "bar",
                                                                   "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                                  "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                                  "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                                  "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                               },
+                                                               "retrySettings" : {
+                                                                  "attempts" : 750,
+                                                                  "exitCode" : 75,
+                                                                  "initialInterval" : 60,
+                                                                  "maxInterval" : 3600
                                                                },
                                                                "user" : "dmorton",
                                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -35,7 +35,14 @@
                   ],
                   "environment" : {
                      "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                     "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                  },
+                  "retrySettings" : {
+                     "attempts" : 750,
+                     "exitCode" : 75,
+                     "initialInterval" : 60,
+                     "maxInterval" : 3600
                   },
                   "user" : "dmorton",
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -75,7 +75,14 @@
                                  "environment" : {
                                     "FOO" : "bar",
                                     "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                    "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                 },
+                                 "retrySettings" : {
+                                    "attempts" : 750,
+                                    "exitCode" : 75,
+                                    "initialInterval" : 60,
+                                    "maxInterval" : 3600
                                  },
                                  "user" : "dmorton",
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -58,7 +58,14 @@
                                  ],
                                  "environment" : {
                                     "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                    "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                 },
+                                 "retrySettings" : {
+                                    "attempts" : 750,
+                                    "exitCode" : 75,
+                                    "initialInterval" : 60,
+                                    "maxInterval" : 3600
                                  },
                                  "user" : "dmorton",
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -98,7 +98,14 @@
                                                 "environment" : {
                                                    "FOO" : "bar",
                                                    "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
-                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
+                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1",
+                                                   "XGENOME_SOFTWARE_RESULT_ASYNC_LOCKING" : "1"
+                                                },
+                                                "retrySettings" : {
+                                                   "attempts" : 750,
+                                                   "exitCode" : 75,
+                                                   "initialInterval" : 60,
+                                                   "maxInterval" : 3600
                                                 },
                                                 "user" : "dmorton",
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"

--- a/lib/perl/Genome/Sys/Lock/FileBackend.pm
+++ b/lib/perl/Genome/Sys/Lock/FileBackend.pm
@@ -73,7 +73,7 @@ sub lock {
 
         #If symlink no longer exists
         if ($! == ENOENT || !$target) {
-            $self->_block_sleep($resource_lock, $block_sleep);
+            sleep $block_sleep;
             next;
         }
 
@@ -117,7 +117,7 @@ sub lock {
             }
         }
 
-        $self->_block_sleep($resource_lock, $block_sleep);
+        sleep $block_sleep;
         $lock_attempts += 1;
     }
     $self->owned_resources->{$resource_lock} = $$;
@@ -141,22 +141,6 @@ sub lock {
     }
 
     return $resource_lock;
-}
-
-sub _block_sleep {
-    my $self = shift;
-    my $resource_lock = shift;
-    my $block_sleep = shift;
-
-    my $exit_code = Genome::Config::get("sys_lock_exit_code");
-    if ($exit_code ne ' ') {
-        Genome::Logger->notice(sprintf("Could not obtain lock (%s)... exiting " .
-            "with exit-code (%s) instead of sleeping.", $resource_lock,
-            $exit_code));
-        exit $exit_code;
-    } else {
-        sleep $block_sleep;
-    }
 }
 
 sub unlock {

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -68,7 +68,8 @@ sub _get_ptero_shortcut_method {
 
     my $self = shift;
     my $log_dir = shift;
-    return Ptero::Builder::Job->new(
+
+    my %job_args = (
         name => 'shortcut',
         service_url => Genome::Config::get('ptero_shell_command_service_url'),
         parameters => {
@@ -83,6 +84,17 @@ sub _get_ptero_shortcut_method {
             workingDirectory => Cwd::getcwd,
         },
     );
+
+    my $retry_exit_code = Genome::Config::get('sys_lock_exit_code');
+    if ($retry_exit_code ne ' ') {
+        $job_args{parameters}{retrySettings} = {
+            exitCode => $retry_exit_code + 0,
+            initialInterval => 10,
+            maxInterval => 60,
+            attempts => 60 * 24 * 30 # ~30 days of attempts
+        };
+    }
+    return Ptero::Builder::Job->new(%job_args);
 }
 
 sub _get_ptero_execute_method {


### PR DESCRIPTION
Instead of sleeping and consuming a shell-command worker while waiting on locks, this PR allows you to configure Genome to exit with a particular exit-code when a lock cannot be obtained.  When submitting the workflow, 'retrySettings' are specified to the shell-command service that specify that when the job exits with that particular exit-code the service should retry the job.

This will allow us to scale up without increasing the number of shell-command workers.