### PR TITLE
allow for multiple reference converters to exist

### DIFF
--- a/lib/perl/Genome/Site/TGI/CleTest/prime-db.pl
+++ b/lib/perl/Genome/Site/TGI/CleTest/prime-db.pl
@@ -111,9 +111,11 @@ sub load_converters {
         for my $to (@reference_ids) {
             if($from != $to) {
                 my @converters = Genome::Model::Build::ReferenceSequence::Converter->get( source_reference_build_id => $from, destination_reference_build_id => $to );
-                die "More than one converter found from: $from to: $to!\n" if (@converters > 1);
+                for my $converter (@converters) {
+                #die "More than one converter found from: $from to: $to!\n" if (@converters > 1);
 
-                load_software_results($converters[0]) if @converters;
+                    load_software_results($converter) if $converter;
+                }
             }
         }
     }


### PR DESCRIPTION
The CLE test database priming script was dying because we have multiple converters. This fix simply pushes all converters over. 

A better solution might be to only push those over that don't have test names set?