### PR TITLE
Only load those converters that don't have test_name set

### DIFF
--- a/lib/perl/Genome/Site/TGI/CleTest/prime-db.pl
+++ b/lib/perl/Genome/Site/TGI/CleTest/prime-db.pl
@@ -110,7 +110,7 @@ sub load_converters {
     for my $from (@reference_ids) {
         for my $to (@reference_ids) {
             if($from != $to) {
-                my @converters = Genome::Model::Build::ReferenceSequence::Converter->get( source_reference_build_id => $from, destination_reference_build_id => $to );
+                my @converters = Genome::Model::Build::ReferenceSequence::Converter->get( source_reference_build_id => $from, destination_reference_build_id => $to, test_name => undef );
                 die "More than one converter found from: $from to: $to!\n" if (@converters > 1);
 
                 load_software_results($converters[0]) if @converters;


### PR DESCRIPTION
We have a few instances of more than one converter for a given pair of reference sequences, but only one shouldn't have test name set. This alters the query to ensure we only pull those converters where test_name is not set and leaves in the check to make sure we only get back one.