### PR TITLE
Quiet warnings in SyncSysUserWithLdap

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.pm
@@ -52,6 +52,7 @@ sub execute {
     }
 
     $self->status_message("done- $create_count creates, $delete_count deletes, $changes_count total\n");
+    return 1;
 }
 
 sub get_ldap_users {

--- a/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.t
+++ b/lib/perl/Genome/Site/TGI/Command/SyncSysUserWithLdap.t
@@ -33,7 +33,7 @@ subtest 'changes delete' => sub {
 
     delete $ldap_users{ $apipe_db_users[0]->email };
     $changes = Genome::Site::TGI::Command::SyncSysUserWithLdap::get_changes(\%ldap_users, \@apipe_db_users);
-    is_deeply($changes, { delete => [ @apipe_db_users[0] ] }, 'need to delete '.$apipe_db_users[0]->email);
+    is_deeply($changes, { delete => [ $apipe_db_users[0] ] }, 'need to delete '.$apipe_db_users[0]->email);
 
 };
 


### PR DESCRIPTION
Without a return value, the status message is used as the exit code, which triggers a message like:
```
Argument "done- 1 creates, 9000 deletes, 9001 total" isn't numeric in numeric lt (<) at Command/Common.pm line 126.
```
An explicit return was added.

Running the test produced another warning:
```
Scalar value @apipe_db_users[0] better written as $apipe_db_users[0] at Genome/Site/TGI/Command/SyncSysUserWithLdap.t line 36.
```
`perl`'s advice was taken here.