### PR TITLE
PurgeSoftwareResultsFromAnalysisProject report

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -71,6 +71,8 @@ sub execute {
     foreach my $anp ( $self->analysis_projects ) {
         $self->purge_one_analysis_project($anp, $sth);
     }
+
+    1;
 }
 
 sub _prepare_sql_statement {

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -169,6 +169,12 @@ sub purge_one_analysis_project {
     }
 }
 
+my $report_obj;
+sub _report_obj {
+    my $self = shift;
+    $report_obj ||= Genome::Model::Command::Admin::PurgeSoftwareResultsFromAnalysisProject::PurgeReport->new($self);
+}
+
 sub _do_expunge {
     my($self, $sr, $reason) = @_;
 

--- a/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeSoftwareResultsFromAnalysisProject.pm
@@ -224,7 +224,7 @@ sub print {
         foreach my $id ( keys %$this_class_data ) {
             $self->purger->status_message("\t%s => %s",
                                             $id,
-                                            $self->_format_disk_size($total_size));
+                                            $self->_format_disk_size($this_class_data->{$id}));
         }
     }
     $self->{data} = {};


### PR DESCRIPTION
This replaces the old --dry-run option with --report.  When --report is used, it prints a report about what would be removed without actually removing anything.  The report looks like this (some lines removed for clarity):
```
Genome::Model::Tools::DetectVariants2::Classify::Tier: 1.125 MB in 9 software results
	4722238e6ade46989326d76f08b560d4 => 128 KB
	a65b5fe4e1254e7390a0bbd31fbd90b3 => 128 KB
	2ffc70827eee4822aa025869119d4933 => 128 KB
Genome::Model::Tools::DetectVariants2::Result: 5.938 MB in 23 software results
	37166635e58a4867a100a1a5c239e7f0 => 384 KB
	47f985e931ec4a50b09540a9dde1cfcb => 64 KB
	62f19130ea9443e395ea8804b3c6b726 => 512 KB
	2fb27568cfb64d1aaf9fe39f28b81bac => 320 KB
Genome::Model::Tools::DetectVariants2::Result::Filter: 100.812 MB in 728 software results
	742915f3dc4b4d808dd64537449963db => 128 KB
	40b89f9f4a96463bbbdffdb239070185 => 704 KB
	ad911088bd4f4f8c869e624ddd626bb4 => 128 KB
    2ac1999577a74843b1062d5965f9fb0f => 1.312 MB
209.812 MB in 1497 software results
```
