### PR TITLE
Now that Genome::Logger uses Genome, only require it to break cycle.

### DIFF
--- a/lib/perl/Genome/Sys/Lock/FileBackend.pm
+++ b/lib/perl/Genome/Sys/Lock/FileBackend.pm
@@ -12,7 +12,7 @@ use Path::Class qw();
 use Sys::Hostname qw(hostname);
 use Time::HiRes;
 
-use Genome::Logger;
+require Genome::Logger;
 use Genome::Utility::Instrumentation;
 
 use Mouse;

--- a/lib/perl/Genome/Sys/Lock/NessyBackend.pm
+++ b/lib/perl/Genome/Sys/Lock/NessyBackend.pm
@@ -7,9 +7,8 @@ use Carp qw(carp croak);
 use POSIX qw(strftime);
 use Sys::Hostname qw(hostname);
 
-use Genome::Logger;
-
 require Genome::Model::Build;
+require Genome::Logger;
 
 use Mouse;
 with qw(Genome::Sys::Lock::Backend);


### PR DESCRIPTION
Genome in the TGI environment uses these backends, so if they indirectly use Genome it causes a circular dependency with sometimes indeterminate effects.

This fixes the currently-failing testcase on `master` for me.