### PR TITLE
Add back _status_color subroutine.

### DIFF
--- a/lib/perl/Genome/Role/CommandWithColor.pm
+++ b/lib/perl/Genome/Role/CommandWithColor.pm
@@ -58,6 +58,11 @@ sub _status_colors {
     return $STATUS_COLORS{$status};
 }
 
+sub _status_color {
+    my ($self, $text) = @_;
+    return $self->_colorize_text_by_map($text, $text, %STATUS_COLORS);
+}
+
 sub _colorize_text_by_map {
     my ($self, $text, $color_key, %color_map) = @_;
 


### PR DESCRIPTION
This was removed in the conversion to a role in c583791b93cc8ba669fa7730de9e4515f96b5039, but it is still being used in several places.

This fixes one of the issues exposed by the model tests (i.e., it restores the function of `genome model build view`).