### PR TITLE
Add an LSF Queue specification to GMT: Sam::Readcount

### DIFF
--- a/lib/perl/Genome/Model/Tools/Sam/Readcount.pm
+++ b/lib/perl/Genome/Model/Tools/Sam/Readcount.pm
@@ -66,6 +66,12 @@ class Genome::Model::Tools::Sam::Readcount {
             doc => "do not include reads containing insertions after the current position in per-base counts. This is the -i parameter in version 0.5.",
         },
     ],
+    has_param => [
+        lsf_queue => {
+            is => 'Text',
+            default_value => Genome::Config::get('lsf_queue_build_worker'),
+        },
+    ],
     doc => "Tool to get readcount information from a bam",
 };
 


### PR DESCRIPTION
This should take care of another class of jobs that was ending up in the default queue.