### PR TITLE
Revert "Convert Diff/DiffBlessed commands into UR Roles"

### DIFF
--- a/lib/perl/Genome/Interfaces/Comparable/Command/Diff.pm
+++ b/lib/perl/Genome/Interfaces/Comparable/Command/Diff.pm
@@ -1,11 +1,12 @@
-package Genome::Role::Comparable::Command::Diff;
+package Genome::Interfaces::Comparable::Command::Diff;
 
 use strict;
 use warnings;
 use Genome;
-use UR::Role;
 
-role Genome::Role::Comparable::Command::Diff {
+class Genome::Interfaces::Comparable::Command::Diff {
+    is => 'Command::V2',
+    is_abstract => 1,
     has => [
         _diffs => {
             is => 'HASH',
@@ -13,7 +14,6 @@ role Genome::Role::Comparable::Command::Diff {
             is_optional => 1,
         },
     ],
-    requires => ['blessed_object', 'new_object'],
 };
 
 sub help_brief {
@@ -24,6 +24,14 @@ sub help_detail {
     return <<EOS
     This tool will use the compare_output method of the comparable objects.
 EOS
+}
+
+sub blessed_object {
+    die "Must implement blessed_object";
+}
+
+sub new_object {
+    die "Must implement new_object";
 }
 
 sub execute {

--- a/lib/perl/Genome/Interfaces/Comparable/Command/Diff.pm
+++ b/lib/perl/Genome/Interfaces/Comparable/Command/Diff.pm
@@ -17,13 +17,11 @@ class Genome::Interfaces::Comparable::Command::Diff {
 };
 
 sub help_brief {
-    return 'Determine if there are differences in the outputs of two comparable objects.';
+    'compare two objects'
 }
 
 sub help_detail {
-    return <<EOS
-    This tool will use the compare_output method of the comparable objects.
-EOS
+    "This command will compare the outputs of 2 objects using the objects' compare_output method. Any differences found will be displayed."
 }
 
 sub blessed_object {

--- a/lib/perl/Genome/Interfaces/Comparable/Command/DiffBlessed.pm
+++ b/lib/perl/Genome/Interfaces/Comparable/Command/DiffBlessed.pm
@@ -11,6 +11,15 @@ class Genome::Interfaces::Comparable::Command::DiffBlessed {
     is_abstract => 1,
 };
 
+sub help_brief {
+    'compare an object to the blessed version'
+}
+
+sub help_detail {
+    "This command will compare an object to the blessed version using the objects' compare_output method. Any differences found will be displayed."
+
+}
+
 sub bless_message {
     my $self = shift;
     my $rel_db_file = $self->rel_db_file();

--- a/lib/perl/Genome/Interfaces/Comparable/Command/DiffBlessed.pm
+++ b/lib/perl/Genome/Interfaces/Comparable/Command/DiffBlessed.pm
@@ -1,14 +1,14 @@
-package Genome::Role::Comparable::Command::DiffBlessed;
+package Genome::Interfaces::Comparable::Command::DiffBlessed;
 
 use strict;
 use warnings;
 use Genome;
-use UR::Role;
 
-use YAML qw();
+use YAML;
 
-role Genome::Role::Comparable::Command::DiffBlessed {
-    requires => ['new_object'],
+class Genome::Interfaces::Comparable::Command::DiffBlessed {
+    is => 'Genome::Interfaces::Comparable::Command::Diff',
+    is_abstract => 1,
 };
 
 sub bless_message {
@@ -16,6 +16,14 @@ sub bless_message {
     my $rel_db_file = $self->rel_db_file();
     my $new_object_id = $self->new_object->id;
     my $m = sprintf('If you want to bless this object (%s) update and commit the DB file (%s).', $new_object_id, $rel_db_file);
+}
+
+sub diffs_message {
+    my $self = shift;
+    my $diff_string = $self->SUPER::diffs_message(@_);
+    my $bless_msg = $self->bless_message();
+    $diff_string = join("\n", $diff_string, $bless_msg);
+    return $diff_string;
 }
 
 sub blessed_id {

--- a/lib/perl/Genome/Model/Build/Command/Diff.pm
+++ b/lib/perl/Genome/Model/Build/Command/Diff.pm
@@ -20,14 +20,6 @@ class Genome::Model::Build::Command::Diff {
     ],
 };
 
-sub help_brief : Overrides(Genome::Role::Comparable::Command::Diff) {
-    &Genome::Role::Comparable::Command::Diff::help_brief;
-}
-
-sub help_detail : Overrides(Genome::Role::Comparable::Command::Diff) {
-    &Genome::Role::Comparable::Command::Diff::help_detail;
-}
-
 sub blessed_object {
     my $self = shift;
     return $self->blessed_build;

--- a/lib/perl/Genome/Model/Build/Command/Diff.pm
+++ b/lib/perl/Genome/Model/Build/Command/Diff.pm
@@ -6,8 +6,7 @@ use warnings;
 use Genome;
 
 class Genome::Model::Build::Command::Diff {
-    is => 'Command::V2',
-    roles => 'Genome::Role::Comparable::Command::Diff',
+    is => 'Genome::Interfaces::Comparable::Command::Diff',
     has => [
         blessed_build => {
             is => 'Genome::Model::Build',

--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm
@@ -8,10 +8,7 @@ use File::Spec;
 use YAML;
 
 class Genome::Model::Build::Command::DiffBlessed {
-    is => 'Command::V2',
-    roles => [ 'Genome::Role::Comparable::Command::Diff',
-               'Genome::Role::Comparable::Command::DiffBlessed',
-            ],
+    is => 'Genome::Interfaces::Comparable::Command::DiffBlessed',
     has => [
         new_build => {
             is => 'Genome::Model::Build',
@@ -23,21 +20,6 @@ class Genome::Model::Build::Command::DiffBlessed {
         },
     ],
 };
-
-sub help_brief : Overrides(Genome::Role::Comparable::Command::Diff) {
-    &Genome::Role::Comparable::Command::Diff::help_brief;
-}
-
-sub help_detail : Overrides(Genome::Role::Comparable::Command::Diff) {
-    &Genome::Role::Comparable::Command::Diff::help_detail;
-}
-
-sub diffs_message : Overrides(Genome::Role::Comparable::Command::Diff) {
-    my $self = shift;
-    my $diff_string = $self->Genome::Role::Comparable::Command::Diff::diffs_message(@_);
-    my $bless_msg = $self->Genome::Role::Comparable::Command::DiffBlessed::bless_message(@_);
-    return join("\n", $diff_string, $bless_msg);
-}
 
 sub blessed_object {
     my $self = shift;

--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.t
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.t
@@ -40,7 +40,7 @@ YAML
     $fh->close;
 
     Sub::Install::reinstall_sub({
-        into => 'Genome::Model::Build::Command::DiffBlessed',
+        into => 'Genome::Interfaces::Comparable::Command::DiffBlessed',
         as => 'db_file',
         code => sub {return $fh->filename},
     });

--- a/lib/perl/Genome/Process/Command/Diff.pm
+++ b/lib/perl/Genome/Process/Command/Diff.pm
@@ -20,14 +20,6 @@ class Genome::Process::Command::Diff {
     ],
 };
 
-sub help_brief : Overrides(Genome::Role::Comparable::Command::Diff) {
-    &Genome::Role::Comparable::Command::Diff::help_brief;
-}
-
-sub help_detail : Overrides(Genome::Role::Comparable::Command::Diff) {
-    &Genome::Role::Comparable::Command::Diff::help_detail;
-}
-
 sub blessed_object {
     my $self = shift;
     return $self->blessed_process;

--- a/lib/perl/Genome/Process/Command/Diff.pm
+++ b/lib/perl/Genome/Process/Command/Diff.pm
@@ -6,8 +6,7 @@ use warnings;
 use Genome;
 
 class Genome::Process::Command::Diff {
-    is => 'Command::V2',
-    roles => 'Genome::Role::Comparable::Command::Diff',
+    is => 'Genome::Interfaces::Comparable::Command::Diff',
     has => [
         new_process => {
             is => 'Genome::Process',

--- a/lib/perl/Genome/Process/Command/DiffBlessed.pm
+++ b/lib/perl/Genome/Process/Command/DiffBlessed.pm
@@ -5,8 +5,7 @@ use warnings;
 use Genome;
 
 class Genome::Process::Command::DiffBlessed {
-    is => 'Command::V2',
-    roles => 'Genome::Role::Comparable::Command::DiffBlessed',
+    is => 'Genome::Interfaces::Comparable::Command::DiffBlessed',
     has => [
         new_process => {
             is => 'Genome::Process',

--- a/lib/perl/Genome/Process/Command/DiffBlessed.t
+++ b/lib/perl/Genome/Process/Command/DiffBlessed.t
@@ -78,7 +78,7 @@ print $fh $yaml;
 $fh->close;
 
 Sub::Install::reinstall_sub({
-    into => 'Genome::Model::Build::Command::DiffBlessed',
+    into => 'Genome::Interfaces::Comparable::Command::DiffBlessed',
     as => 'db_file',
     code => sub {return $fh->filename},
 });


### PR DESCRIPTION
This reverts commit b251a2a9eed11c399251381776550e2aa6b6b2fa.

The error of not finding 'has_diffs' on genome process diff blessed causeed investigation into this issue. It was decided that having the diff as roles was not suitable, and they should remain commands that pass on behavior via inheritance.

A fix for this problem was proposed in #1180.