### PR TITLE
Calculate the LSF resource for Alignment based on the Instrument Data

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
@@ -25,9 +25,6 @@ class Genome::InstrumentData::AlignmentResult::PerLaneTophat {
 
 sub required_arch_os { 'x86_64' }
 
-#WARNING: THIS RESOURCE REQUEST IS ONLY VALID FOR EVENT-BASED WORKFLOWS.
-#IF YOU WANT TO CHANGE THE RESOURCE REQUEST FOR NORMAL WORKFLOWS, EDIT
-#THE FILE Genome::InstrumentData::Command::AlignReads::PerLaneTophat INSTEAD!!!
 sub required_rusage {
     my $class = shift;
 

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow-unit.t
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow-unit.t
@@ -24,6 +24,8 @@ my $idata = Genome::Test::Factory::InstrumentData::Solexa->setup_object(
     subset_name => '1',
     run_name => 'workflow-unit-test',
     id => '-42',
+    read_length => 150,
+    clusters => 500,
 );
 
 my $ref = Genome::Model::Build::ReferenceSequence->get_by_name('GRCh37-lite-build37');

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow.t
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow.t
@@ -38,6 +38,8 @@ my $instrument_data_1 = Genome::Test::Factory::InstrumentData::Solexa->setup_obj
     subset_name => '1',
     run_name => 'example',
     id => '-23',
+    read_length => '100',
+    clusters => 1000,
 );
 my $instrument_data_2 = Genome::Test::Factory::InstrumentData::Solexa->setup_object(
     library_id => $instrument_data_1->library_id,
@@ -46,6 +48,8 @@ my $instrument_data_2 = Genome::Test::Factory::InstrumentData::Solexa->setup_obj
     subset_name => '2',
     run_name => 'example',
     id => '-24',
+    read_length => '100',
+    clusters => 2000,
 );
 
 my $sample_2 = Genome::Sample->create(
@@ -60,6 +64,8 @@ my $instrument_data_3 = Genome::InstrumentData::Solexa->__define__(
     run_name => 'example',
     id => '-28',
     sample => $sample_2,
+    read_length => '100',
+    clusters => 3000,
 );
 
 my @one_instrument_data = ($instrument_data_3);

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Align.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/Align.pm
@@ -267,6 +267,13 @@ sub _generate_operation {
         ),
     );
 
+    my $aligner_class = join('::', 'Genome::InstrumentData::AlignmentResult', Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($aligner_name));
+    my $lsf_resource = $aligner_class->required_rusage(
+        instrument_data => $instrument_data,
+        aligner_params => $action->{params},
+    );
+    $operation->lsf_resource($lsf_resource);
+
     $action->{$key} = $operation;
 
     return $operation;


### PR DESCRIPTION
This is a feature that RefAlign has but the AlignmentDispatcher did not.  ("AlignAndMerge" is using this same approach for SpeedSeq in SomaticValidation; this does the same thing for regular "Align".)