### PR TITLE
Include stalled tickets in failed-model-tickets scripts.

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTicketBase.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTicketBase.pm
@@ -24,7 +24,7 @@ sub _find_open_tickets {
     try {
         @ticket_ids = $rt->search(
             type => 'ticket',
-            query => "Queue = 'apipe-support' AND ( Status = 'new' OR Status = 'open' )",
+            query => "Queue = 'apipe-support' AND ( Status = 'new' OR Status = 'open' OR Status = 'stalled' )",
 
         );
     }
@@ -37,7 +37,7 @@ sub _find_open_tickets {
             die $msg->message;
         }
     };
-    $self->status_message($self->_color('Tickets (new or open): ', 'bold').scalar(@ticket_ids));
+    $self->status_message($self->_color('Tickets (new/open/stalled): ', 'bold').scalar(@ticket_ids));
 
     return @ticket_ids;
 }


### PR DESCRIPTION
The `failed-model-tickets` script was reporting a few models that were already in a ticket, because that ticket had been stalled.  This updates the search to include stalled tickets so they are not re-reported.  (Additionally, `failed-model-ticket-status` will also include stalled tickets in its default output.)