### PR TITLE
Don't try to call ptero_workflow_proxy on an undefined value.

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -557,6 +557,7 @@ sub workflow_name {
 sub ptero_workflow_proxy {
     my $self = shift;
 
+    return unless $self->process;
     return $self->process->ptero_workflow_proxy;
 }
 


### PR DESCRIPTION
Inline builds do not have processes created in [`Genome::Model::Build->_launch`](https://github.com/genome/genome/blob/981439e064d6042a3abb384ccc46bcd52bfa7787/lib/perl/Genome/Model/Build.pm#L1431).