### PR TITLE
Stop using Workflow since this is built with WorkflowBuilder.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Composite/Workflow.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow.pm
@@ -5,9 +5,6 @@ use warnings;
 
 use Genome;
 
-use Workflow;
-use Workflow::Simple qw(run_workflow_lsf);
-
 class Genome::InstrumentData::Composite::Workflow {
     is => 'Command',
     has => [
@@ -28,7 +25,7 @@ class Genome::InstrumentData::Composite::Workflow {
     ],
     has_transient_optional => [
         _workflow => {
-            is => 'Workflow::Model',
+            is => 'Genome::WorkflowBuilder::DAG',
             doc => 'The underlying workflow to run the alignment/merge',
             is_output => 1,
         },


### PR DESCRIPTION
This was updated to stop using Workflow in #924, but these straggling references were not changed.