### PR TITLE
Return a HASH reference from Composite Workflow Generator

### DIFF
--- a/lib/perl/Genome/InstrumentData/Composite/Workflow-unit.t
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow-unit.t
@@ -119,8 +119,7 @@ sub workflow_and_inputs_for_strategy {
 
     my ($wf, $wf_inputs) = $obj->_generate_workflow($tree);
     isa_ok($wf, "Genome::WorkflowBuilder::DAG", "workflow model");
-    isa_ok($wf_inputs, "ARRAY", "workflow inputs");
+    isa_ok($wf_inputs, "HASH", "workflow inputs");
 
-    my %inputs = @$wf_inputs;
-    return ($wf, \%inputs);
+    return ($wf, $wf_inputs);
 }

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow.pm
@@ -106,8 +106,7 @@ sub _run_workflow {
     Genome::Sys->disconnect_default_handles;
 
     $self->debug_message('Running workflow...');
-    my %inputs_hash = (@$inputs); # For some reason $inputs is an array-ref
-    my $outputs = $workflow->execute(inputs => \%inputs_hash);
+    my $outputs = $workflow->execute(inputs => $inputs);
 
     my @result_ids;
     for my $key (keys %$outputs) {

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator.pm
@@ -78,7 +78,7 @@ sub generate {
         }
     }
 
-    return ($master_workflow, $class->_resolve_inputs(\@inputs, $tree->{api_version}, $input_data));
+    return ($master_workflow, $class->_resolve_inputs({@inputs}, $tree->{api_version}, $input_data));
 }
 
 sub _alignment_objects {
@@ -172,8 +172,7 @@ sub _resolve_inputs {
     my $api_inputs = $class->inputs_for_api_version($api_version);
     my %inputs = (%$api_inputs, %$input_data);
     for my $input ($class->_general_workflow_input_properties) {
-        push @$inputs,
-            'm_' . $input => $inputs{$input};
+            $inputs->{'m_' . $input} = $inputs{$input};
     }
 
     return $inputs;


### PR DESCRIPTION
In the beginning was `Workflow` and it accepted its inputs as a list, so this produced an `ARRAY` reference.  At some point this was changed to call `Genome::WorkflowBuilder::DAG`, which accepts a hash reference, and a comment was added questioning the reasonableness of the choice of an `ARRAY` reference.  In #924 it was suggested we should change it.

Here are a couple versions (either the first commit or both together) of how it might look to change it.  There's a third possibility where even more things get changed to hashes as well.