### PR TITLE
Create a uniform way to get the parent log directory for a DAG.

### DIFF
--- a/etc/genome/spec/ptero_log_directory.yaml
+++ b/etc/genome/spec/ptero_log_directory.yaml
@@ -1,0 +1,2 @@
+--- 
+env: XGENOME_PTERO_LOG_DIRECTORY

--- a/lib/perl/Genome/Ptero/Wrapper.pm
+++ b/lib/perl/Genome/Ptero/Wrapper.pm
@@ -108,6 +108,8 @@ sub _stderr_log_path {
 sub _setup_logging {
     my $self = shift;
 
+    Genome::Config::set_env('ptero_log_directory', $self->log_directory);
+
     $self->debug_message(
         "Preparing to redirect stderr to (%s) and stdout to (%s)",
         $self->_stderr_log_path, $self->_stdout_log_path

--- a/lib/perl/Genome/WorkflowBuilder/DAG.pm
+++ b/lib/perl/Genome/WorkflowBuilder/DAG.pm
@@ -10,6 +10,7 @@ use JSON;
 use List::MoreUtils qw();
 use Genome::Utility::Inputs qw(encode decode);
 use Data::Dump qw(pp);
+use File::Spec;
 
 
 class Genome::WorkflowBuilder::DAG {
@@ -55,6 +56,24 @@ sub recursively_set_log_dir {
         }
     }
     return;
+}
+
+sub parent_log_dir {
+    my $class = shift;
+
+    my $backend = Genome::Config::get('workflow_builder_backend');
+    if ($backend eq 'ptero') {
+        use Try::Tiny qw(try catch);
+        try {
+            return Genome::Config::get('ptero_log_directory');
+        } catch {
+            return;
+        }
+    } elsif ($backend eq 'workflow') {
+        return Workflow::Model->parent_workflow_log_dir();
+    } else {
+        die sprintf("Unknown backend specified: %s", $backend);
+    }
 }
 
 sub add_operation {


### PR DESCRIPTION
This is a proposed solution to the issue raised in #1186.  If it's acceptable, the open `WorkflowBuilder`-conversion PRs will be revised to use it.