### PR TITLE
Specify a default LSF queue for aligners that don't list one explicitly.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/AlignReads.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignReads.pm
@@ -112,6 +112,9 @@ class Genome::InstrumentData::Command::AlignReads {
             },
             default_value => &_fallback_lsf_resource, # workflow doesn't support varying this per instance
         },
+        lsf_queue => {
+            default_value => Genome::Config::get('lsf_queue_alignment_default'),
+        },
     ]
 };
 


### PR DESCRIPTION
In #1182 the resource request generation for alignments was changed.

Because the fallback is now overridden, the queue information can be lost if the aligner-specific implementation doesn't reiterate it.  These parameters establish a default, so the job still goes to the alignment queues if not otherwise specified.