### PR TITLE
Add support for AnP-based envrionmental configuration.

### DIFF
--- a/lib/perl/Genome/Config.pm
+++ b/lib/perl/Genome/Config.pm
@@ -130,6 +130,12 @@ sub all_keys {
 
 sub config_subpath { Path::Class::File->new('genome', 'config.yaml') }
 
+sub project_dir {
+    my $dir = $ENV{XGENOME_CONFIG_PROJECT_DIR};
+    return $dir if $dir;
+    return;
+}
+
 sub home_dir {
     my $path = ( $ENV{XGENOME_CONFIG_HOME} || File::Spec->join($ENV{HOME}, '.config') );
     return Path::Class::Dir->new($path);
@@ -193,7 +199,7 @@ sub _lookup_value {
     if ($spec->has_env && exists $ENV{$spec->env}) {
         return $ENV{$spec->env};
     }
-    my @files = _lookup_files($config_subpath, home_dir());
+    my @files = _lookup_files($config_subpath, project_dir(), home_dir());
     my $value = _lookup_value_from_files($spec, @files);
     if (defined $value) {
         return $value;

--- a/lib/perl/Genome/Config.pm
+++ b/lib/perl/Genome/Config.pm
@@ -132,7 +132,7 @@ sub config_subpath { Path::Class::File->new('genome', 'config.yaml') }
 
 sub project_dir {
     my $dir = $ENV{XGENOME_CONFIG_PROJECT_DIR};
-    return $dir if $dir;
+    return Path::Class::Dir->new($dir) if $dir;
     return;
 }
 
@@ -150,7 +150,7 @@ sub snapshot_dir {
     my @chop = ('lib', 'perl', split('::', __PACKAGE__));
     my @chopped = splice(@path, -1 * @chop);
     my @base_dir = @path;
-    return File::Spec->join(@base_dir, 'etc');
+    return Path::Class::Dir->new(File::Spec->join(@base_dir, 'etc'));
 }
 
 sub global_dirs {

--- a/lib/perl/Genome/Config/AnalysisProject.pm
+++ b/lib/perl/Genome/Config/AnalysisProject.pm
@@ -6,6 +6,7 @@ use warnings;
 use Genome;
 
 use List::MoreUtils qw(any);
+use File::Spec;
 
 class Genome::Config::AnalysisProject {
     roles => [qw(
@@ -138,6 +139,18 @@ sub is_current {
     return if any { $_ eq $status } (qw(Completed Archived Template Deprecated));
 
     return 1;
+}
+
+sub environment_config_dir {
+    my $self = shift;
+
+    my $allocation = Genome::Disk::Allocation->get(owner => $self);
+    if ($allocation) {
+        my $config_path = File::Spec->join($allocation->absolute_path, Genome::Config::config_subpath);
+        return $allocation->absolute_path if -e $config_path;
+    }
+
+    return;
 }
 
 1;

--- a/lib/perl/Genome/Config/AnalysisProject.pm
+++ b/lib/perl/Genome/Config/AnalysisProject.pm
@@ -14,6 +14,7 @@ class Genome::Config::AnalysisProject {
         Genome::Role::ObjectWithCreatedBy
         Genome::Role::SoftwareResultSponsor
         Genome::Role::Searchable
+        Genome::Role::ObjectWithAllocations
     )],
     table_name => 'config.analysis_project',
     id_by => [
@@ -144,7 +145,7 @@ sub is_current {
 sub environment_config_dir {
     my $self = shift;
 
-    my $allocation = Genome::Disk::Allocation->get(owner => $self);
+    my $allocation = $self->disk_allocations;
     if ($allocation) {
         my $config_path = File::Spec->join($allocation->absolute_path, Genome::Config::config_subpath);
         return $allocation->absolute_path if -e $config_path;

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
@@ -1,0 +1,72 @@
+package Genome::Config::AnalysisProject::Command::AddEnvironmentFile;
+
+use strict;
+use warnings;
+
+use File::Spec;
+
+use Genome;
+
+class Genome::Config::AnalysisProject::Command::AddEnvironmentFile {
+    is => 'Genome::Config::AnalysisProject::Command::Base',
+    has_input => [
+        environment_file  => {
+            is                  => 'Path',
+            doc                 => 'path to the environment config file',
+            shell_args_position => 2,
+        },
+    ],
+};
+
+sub help_brief {
+    return 'add a yml environment file to an existing analysis project';
+}
+
+sub help_synopsis {
+    return "genome config analysis-project add-environment-file <analysis-project> <file-path>\n";
+}
+
+sub help_detail {
+    return <<"EOS"
+This command is used to link an environment configuration file to an analysis-project.  This specifies properties of the environment in which builds for the analysis-project will run.
+EOS
+}
+
+sub valid_statuses {
+    return ('Pending', 'In Progress', 'Hold');
+}
+
+sub execute {
+    my $self = shift;
+    my $analysis_project = $self->analysis_project;
+    if($analysis_project->environment_config_dir) {
+        $self->fatal_message('Project %s already has an existing environment file.', $analysis_project->__display_name__);
+    }
+
+    my $allocation = Genome::Disk::Allocation->get(owner => $analysis_project);
+    unless ($allocation) {
+        $allocation = Genome::Disk::Allocation->create(
+            owner_id => $analysis_project->id,
+            owner_class_name => $analysis_project->class,
+            disk_group_name => Genome::Config::get('disk_group_references'),
+            allocation_path => 'analysis_project/' . $analysis_project->id,
+            kilobytes_requested => ((-s $self->environment_file)/1024 + 1),
+        );
+    }
+
+    my $config_subpath = Genome::Config::config_subpath;
+    my $filename = $config_subpath->basename;
+
+    my $dir = File::Spec->join($allocation->absolute_path, $config_subpath->dir->stringify);
+    Genome::Sys->create_directory($dir);
+
+    my $installed_path = File::Spec->join($dir, $filename);
+    Genome::Sys->copy_file($self->environment_file, $installed_path);
+    $allocation->reallocate();
+
+    $self->status_message('Environment file installed to %s', $installed_path);
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
@@ -43,7 +43,7 @@ sub execute {
         $self->fatal_message('Project %s already has an existing environment file.', $analysis_project->__display_name__);
     }
 
-    my $allocation = Genome::Disk::Allocation->get(owner => $analysis_project);
+    my $allocation = $analysis_project->disk_allocations;
     unless ($allocation) {
         $allocation = Genome::Disk::Allocation->create(
             owner_id => $analysis_project->id,

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+use Test::More tests => 3;
+use Test::Exception;
+
+my $class = 'Genome::Config::AnalysisProject::Command::AddEnvironmentFile';
+use_ok($class);
+
+my $ap = Genome::Config::AnalysisProject->create(
+    name => 'Test Project',
+    id => '-500',
+);
+
+my $file = Genome::Sys->create_temp_file_path();
+Genome::Sys->write_file($file, 'no_commit: 1');
+
+my @params = (
+    analysis_project => $ap,
+    environment_file => $file,
+);
+
+my $cmd = $class->create(@params);
+
+$cmd->execute();
+
+ok($ap->environment_config_dir, 'environment file was put in place');
+
+my $cmd2 = $class->create(@params);
+
+throws_ok(sub {$cmd2->execute}, qr/already has an existing environment file/, 'cannot add environment file a second time');
+
+done_testing();
+
+1;

--- a/lib/perl/Genome/Model/Build/Command/Start.pm
+++ b/lib/perl/Genome/Model/Build/Command/Start.pm
@@ -143,6 +143,9 @@ sub create_and_start_build {
 
     my $outer_transaction = UR::Context::Transaction->begin();
     $model->build_requested(0);
+    my $anp = $model->analysis_project;
+    my $config_dir = $anp? $anp->environment_config_dir : undef;
+    local $ENV{XGENOME_CONFIG_PROJECT_DIR} = $config_dir;
 
     my $create_transaction = UR::Context::Transaction->begin();
     my $build = try {


### PR DESCRIPTION
Have you ever wanted to have one Analysis Project run PTero without making them all do so?  Have you ever wished you could change the LSF resource request for an entire project at once rather than manually starting models?  This is the pull request for you!

Features:
* Adds a new location for `Genome::Config` to search for configuration that takes precedence over the home directory (but still lower precedence than manually set environment variables).

Caveats:
* Won't work unless we update our production users to use a `genome/config.yaml` instead of manually set environment variables.