### PR TITLE
BamToCna declares "params" as an Input and Output

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/BamToCna.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/BamToCna.pm
@@ -30,6 +30,8 @@ class Genome::Model::Tools::DetectVariants2::BamToCna{
             doc => 'enable this flag to normalize by the whole genome median.',
         },
         params => { #calculated for SoftwareResult for now--in the future should support this fully
+            is_input => 1,
+            is_output => 1,
             is_optional => 1,
             calculate_from => ['ratio', 'window_size', 'normalize_by_genome'],
             calculate => q{


### PR DESCRIPTION
WorkflowBuilder is more stringent about validating its components than Workflow.  "params" needs to be declared as an input and output for the workflow that the DetectVariants2 Dispatcher creates to validate.  (The Dispatcher passes "params" to all DV2 detectors--the base Detector class declares "params" appropriately, but this class overrides that definition.)