### PR TITLE
Remove unused CCSVCF includes.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Vcf/CreateCrossSampleVcf/CreateCrossSampleVcfBase.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/CreateCrossSampleVcf/CreateCrossSampleVcfBase.pm
@@ -4,10 +4,6 @@ use strict;
 use warnings;
 
 use Genome;
-use Workflow;
-use Workflow::Simple;
-use Switch;
-use List::MoreUtils "each_array";
 use File::Basename qw/fileparse/;
 use File::Spec;
 


### PR DESCRIPTION
This doesn't really use `Workflow` since it was converted to a Process as part of #429.