### PR TITLE
It is reference_sequence_build not reference_build

### DIFF
--- a/lib/perl/Genome/Model/RnaSeq/Command/PicardRnaSeqMetrics.pm
+++ b/lib/perl/Genome/Model/RnaSeq/Command/PicardRnaSeqMetrics.pm
@@ -61,7 +61,7 @@ sub should_skip {
     }
 
     # Skip if annotation build does not have required files
-    my @missing_files = Genome::InstrumentData::AlignmentResult::Command::PicardRnaSeqMetrics->missing_files_for_annotation_build($build->annotation_build, $build->reference_build);
+    my @missing_files = Genome::InstrumentData::AlignmentResult::Command::PicardRnaSeqMetrics->missing_files_for_annotation_build($build->annotation_build, $build->reference_sequence_build);
     if ( @missing_files ) {
         $self->debug_message('Skipping PicardRnaSeqMetrics since annotation build is missing required files');
         return 1;

--- a/lib/perl/Genome/Model/RnaSeq/Command/PicardRnaSeqMetrics.t
+++ b/lib/perl/Genome/Model/RnaSeq/Command/PicardRnaSeqMetrics.t
@@ -28,7 +28,7 @@ subtest "setup" => sub{
     $reference_build =  Test::MockObject->new;
     ok($reference_build, 'create mock reference build');
     $reference_build->set_always('id', '1');
-    $build->set_always('reference_build', $reference_build);
+    $build->set_always('reference_sequence_build', $reference_build);
 
     $annotation_build = Genome::Test::Factory::Model::ImportedAnnotation->create_mock_build;
     ok($annotation_build, 'create mock annotation build');


### PR DESCRIPTION
This bug of RnaSeq build property name is from #1195 and causing jenkins rnaseq test build failures. It needs a early merge.