### PR TITLE
Add lsf_resource_rnaseq_cufflinks to genome config

### DIFF
--- a/etc/genome/spec/lsf_resource_rnaseq_cufflink.yaml
+++ b/etc/genome/spec/lsf_resource_rnaseq_cufflink.yaml
@@ -1,0 +1,4 @@
+# This spec controls the LSF resource for cufflinks run in RnaSeq expression
+---
+default_value: "-R 'select[mem>=64000] rusage[mem=64000] span[hosts=1]' -M 64000000 -n 4"
+env: XGENOME_LSF_RESOURCE_RNASEQ_CUFFLINK

--- a/etc/genome/spec/lsf_resource_rnaseq_cufflinks.yaml
+++ b/etc/genome/spec/lsf_resource_rnaseq_cufflinks.yaml
@@ -1,4 +1,4 @@
 # This spec controls the LSF resource for cufflinks run in RnaSeq expression
 ---
 default_value: "-R 'select[mem>=64000] rusage[mem=64000] span[hosts=1]' -M 64000000 -n 4"
-env: XGENOME_LSF_RESOURCE_RNASEQ_CUFFLINK
+env: XGENOME_LSF_RESOURCE_RNASEQ_CUFFLINKS

--- a/lib/perl/Genome/Model/RnaSeq/Command/Expression/Cufflinks.pm
+++ b/lib/perl/Genome/Model/RnaSeq/Command/Expression/Cufflinks.pm
@@ -9,7 +9,7 @@ use Genome;
 
 my $DEFAULT_LSF_RESOURCE = Genome::Config::get('testing')
     ? "-R 'span[hosts=1]' -n 4"
-    : Genome::Config::get('lsf_resource_rnaseq_cufflink');
+    : Genome::Config::get('lsf_resource_rnaseq_cufflinks');
 
 class Genome::Model::RnaSeq::Command::Expression::Cufflinks {
     is => ['Command::V2'],

--- a/lib/perl/Genome/Model/RnaSeq/Command/Expression/Cufflinks.pm
+++ b/lib/perl/Genome/Model/RnaSeq/Command/Expression/Cufflinks.pm
@@ -9,7 +9,7 @@ use Genome;
 
 my $DEFAULT_LSF_RESOURCE = Genome::Config::get('testing')
     ? "-R 'span[hosts=1]' -n 4"
-    : "-R 'select[mem>=64000] rusage[mem=64000] span[hosts=1]' -M 64000000 -n 4";
+    : Genome::Config::get('lsf_resource_rnaseq_cufflink');
 
 class Genome::Model::RnaSeq::Command::Expression::Cufflinks {
     is => ['Command::V2'],


### PR DESCRIPTION
So it is convenient to change lsf limit for cufflink run.