### PR TITLE
Submitting a Process Preserves Environment

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1406,10 +1406,7 @@ sub _launch {
     local $ENV{UR_DUMP_STATUS_MESSAGES} = 1;
     local $ENV{UR_COMMAND_DUMP_STATUS_MESSAGES} = 1;
 
-    # we don't use 'local' because we want this to persist through
-    # spawned workflows, and since the build is launched in a commit
-    # observer the 'local' designations ensure the ENV isn't still around then
-    Genome::Config::set_env('lsf_project_name', sprintf("build/%s", $self->id));
+    my $project_guard = Genome::Config::set_env('lsf_project_name', sprintf("build/%s", $self->id));
 
     my $build_id_guard = set_build_id($self->id);
 

--- a/lib/perl/Genome/Process/Command/Run.pm
+++ b/lib/perl/Genome/Process/Command/Run.pm
@@ -106,8 +106,11 @@ sub submit {
     my $inputs = $self->get_workflow_inputs;
     $self->status_message("Submitting workflow with inputs: %s", pp($inputs));
 
+    my %env_copy = %ENV;
+
     my $commit_observer = Genome::Sys::CommitAction->create(
         on_commit => sub {
+            local %ENV = %env_copy;
             my $wf_proxy = $dag->submit(inputs => $inputs, process => $self->process);
             $self->status_message("Successfully launched process (%s) and ".
                 "submitted PTero workflow (%s)", $self->process->id, $wf_proxy->url);


### PR DESCRIPTION
In Perl closures close over lexical (`my`) variables but not over `local`ized globals.

This change saves a copy of the environment before creating the submission closure.  This allows the environment to be customized the same way before either `submit`ting or `launch`ing a Process.

This addresses an issue using #1201 with PTero.