### PR TITLE
Don't copy entire allocations in place of symlinks.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Export.pm
+++ b/lib/perl/Genome/Model/Build/Command/Export.pm
@@ -46,12 +46,7 @@ sub execute {
         my $path = $File::Find::name;
         if (-l $path) {
             my $symlink_target = $File::Find::fullname;
-            my $allocation = Genome::Disk::Allocation->get_allocation_for_path($symlink_target);
-            if (defined($allocation) && $allocation->is_active) {
-                unlink $path;
-                $allocation->copy(output_dir => $path);
-            }
-            elsif (-e $symlink_target) {
+            if (-e $symlink_target) {
                 #Only do this if symlink doesn't point to somewhere within
                 #this directory structure
                 unless (index($symlink_target, $export_directory) == 0) {


### PR DESCRIPTION
The path_for_allocation might be a parent of the file or directory being symlinked.  We were getting infinite recursion when the allocation resolved to a parent of the current allocation's directory.  This
solution ignores that the symlink might be in an allocation and happily copies the contents.