### PR TITLE
Remove some redundant methods from Model.pm

### DIFF
--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -638,16 +638,6 @@ sub resolve_last_complete_build {
     return $build
 }
 
-# Returns a list of builds with the specified status sorted from oldest to newest
-# TODO: replace this with $model->builds(status => $whatever), since sorting is implicit
-sub builds_with_status {
-    my ($self, $status) = @_;
-    return grep {
-        $_->status and
-        $_->status eq $status
-    } $self->sorted_builds;
-}
-
 # Overriding build_requested to add a note to the model with information about who requested a build
 sub build_requested {
     my ($self, $value, $reason) = @_;

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -605,12 +605,6 @@ sub from_models {
     return map { $_->value } @inputs;
 }
 
-# Returns a list of builds (all statuses) sorted from oldest to newest
-# TODO: see why this is needed as builds are already sorted by default with get()
-sub sorted_builds {
-    return shift->builds(-order_by => 'created_at');
-}
-
 # Returns a list of succeeded builds sorted from oldest to newest
 sub succeeded_builds { return $_[0]->completed_builds; }
 

--- a/lib/perl/Genome/Model/Build/Command/Start.pm
+++ b/lib/perl/Genome/Model/Build/Command/Start.pm
@@ -113,9 +113,12 @@ sub execute {
             last; 
         }
         $self->_total_command_count($self->_total_command_count + 1);
-        if (!$self->force && ($model->builds_with_status('Running') or $model->builds_with_status('Scheduled'))) {
-            $self->append_error($model->__display_name__, "Model already has running or scheduled builds. Use the '--force' option to override this and start a new build.");
-            next;
+        if(!$self->force) {
+            my @existing_builds = $model->builds(status => ['Running', 'Scheduled']);
+            if (@existing_builds) {
+                $self->append_error($model->__display_name__, "Model already has running or scheduled builds. Use the '--force' option to override this and start a new build.");
+                next;
+            }
         }
         if ($self->skip_succeeded and $model->status eq 'Succeeded') {
             my $msg = 'Skipping succeeded model ' . $model->__display_name__;

--- a/lib/perl/Genome/Model/RnaSeq/Command/CoverageMetrics.pm
+++ b/lib/perl/Genome/Model/RnaSeq/Command/CoverageMetrics.pm
@@ -56,7 +56,7 @@ sub execute {
         if ( defined($model_coverage{$model->name}) ) {
             die('Multiple models with name: '. $model->name);
         }
-        my @model_builds = reverse($model->sorted_builds);
+        my @model_builds = $model->builds;
         my $build;
         my $coverage_directory;
         my $coverage_file;

--- a/lib/perl/Genome/Model/RnaSeq/Command/RnaSeqMetrics.pm
+++ b/lib/perl/Genome/Model/RnaSeq/Command/RnaSeqMetrics.pm
@@ -68,7 +68,7 @@ sub execute {
         if ( defined($model_metrics{$label}) ) {
             die('Multiple models with '. $model_identifier_method .' value: '. $label);
         }
-        my @model_builds = reverse($model->sorted_builds);
+        my @model_builds = $model->builds;
         my $build;
         my $metrics_directory;
         my $metrics_file;

--- a/lib/perl/Genome/Model/RnaSeq/Command/SpliceJunctionMetrics.pm
+++ b/lib/perl/Genome/Model/RnaSeq/Command/SpliceJunctionMetrics.pm
@@ -64,7 +64,7 @@ sub execute {
         if ( defined($model_metrics{$label}) ) {
             die('Multiple models with '. $model_identifier_method .' value: '. $label);
         }
-        my @model_builds = reverse($model->sorted_builds);
+        my @model_builds = $model->builds;
         my $build;
         my $junctions_directory;
         my $junctions_file;

--- a/lib/perl/Genome/ModelDeprecated.pm
+++ b/lib/perl/Genome/ModelDeprecated.pm
@@ -305,29 +305,29 @@ sub last_complete_build_id {
 
 sub abandoned_builds {
     my $self = shift;
-    my @abandoned_builds = $self->builds_with_status('Abandoned');
+    my @abandoned_builds = $self->builds(status => 'Abandoned');
     return @abandoned_builds;
 }
 sub failed_builds {
     my $self = shift;
-    my @failed_builds = $self->builds_with_status('Failed');
+    my @failed_builds = $self->builds(status => 'Failed');
     return @failed_builds;
 }
 sub running_builds {
     my $self = shift;
-    my @running_builds = $self->builds_with_status('Running');
+    my @running_builds = $self->builds(status => 'Running');
     return @running_builds;
 }
 sub scheduled_builds {
     my $self = shift;
-    my @scheduled_builds = $self->builds_with_status('Scheduled');
+    my @scheduled_builds = $self->builds(status => 'Scheduled');
     return @scheduled_builds;
 }
 
 sub current_running_build {
     my $self = shift;
     my @running_builds = $self->running_builds;
-    my $current_running_build = pop(@running_builds);
+    my $current_running_build = shift(@running_builds);
     return $current_running_build;
 }
 


### PR DESCRIPTION
This completes a few long-standing TODOs by removing redundant methods.

(It seems like the `${status}_builds` methods in `ModelDeprecated` are also ripe for removal.  Some of them are still used at the moment.)