### PR TITLE
Lsf resource parsing

### DIFF
--- a/lib/perl/Genome/Model/Tools/Gatk/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Gatk/Base.pm
@@ -44,7 +44,7 @@ class Genome::Model::Tools::Gatk::Base {
     ],
     has_param => [
         lsf_resource => {
-            default => '-M 16777216 rusage[mem=16384] select[mem > 16384] span[hosts=1]',
+            default => "-M 16777216 -R 'rusage[mem=16384] select[mem > 16384] span[hosts=1]'",
         },
     ],
 };

--- a/lib/perl/Genome/Model/Tools/Mutect.pm
+++ b/lib/perl/Genome/Model/Tools/Mutect.pm
@@ -85,7 +85,7 @@ class Genome::Model::Tools::Mutect {
     ],
     has_param => [
         lsf_resource => {
-            default => '-M 16777216 rusage[mem=16384] select[mem > 16384] span[hosts=1]',
+            default => "-M 16777216 -R 'rusage[mem=16384] select[mem > 16384] span[hosts=1]'",
         },
     ],
 };

--- a/lib/perl/Genome/Model/Tools/Somatic/PlotCircos.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/PlotCircos.pm
@@ -130,8 +130,8 @@ class Genome::Model::Tools::Somatic::PlotCircos{
         },
         lsf_resource => {
             is_param => 1,
-            default_value => 'rusage[mem=8000, tmp=2000] select[mem > 8000 && tmp > 2000] span[hosts=1] -M 8000000'
-        }, 
+            default_value => "-R 'rusage[mem=8000, tmp=2000] select[mem > 8000 && tmp > 2000] span[hosts=1]' -M 8000000"
+        },
         lsf_queue => {
             is_param => 1,
             default_value => Genome::Config::get('lsf_queue_build_worker'),

--- a/lib/perl/Genome/Sys/LSF/ResourceParser.pm
+++ b/lib/perl/Genome/Sys/LSF/ResourceParser.pm
@@ -62,14 +62,23 @@ sub _parse_lsf_params {
         _create_getopt_specs($lsf_params{options}, _valid_options()),
         _create_getopt_specs($lsf_params{rLimits}, _valid_rlimits()));
 
-    return ($parse_ok, \%lsf_params, $message);
+    my $res_req = exists($lsf_params{options}{resReq})
+        ? $lsf_params{options}{resReq} : '';
+
+    if ($parse_ok && !parse_resource_requirements($res_req)) {
+        return (0, \%lsf_params, 'Invalid resource requirements specification');
+    }
+    else {
+        return ($parse_ok, \%lsf_params, $message);
+    }
 }
 
 sub _get_options_from_string {
     my $getopt_fh = IO::String->new;
     local *STDERR = $getopt_fh;
-    my $ret = GetOptionsFromString(@_);
-    return ($ret, ${$getopt_fh->string_ref});
+    my ($ret, $args) = GetOptionsFromString(@_);
+    my $parse_ok = $ret && (scalar @$args == 0);
+    return ($parse_ok, ${$getopt_fh->string_ref});
 }
 
 sub _create_getopt_specs {

--- a/lib/perl/Genome/Sys/LSF/ResourceParser.t
+++ b/lib/perl/Genome/Sys/LSF/ResourceParser.t
@@ -5,7 +5,7 @@ use Data::Dumper;
 use above "Genome";
 
 BEGIN {
-    use_ok('Genome::Sys::LSF::ResourceParser', 'parse_lsf_params')
+    use_ok('Genome::Sys::LSF::ResourceParser', 'parse_lsf_params', 'parse_resource_requirements')
 }
 
 sub parse_ok {
@@ -15,6 +15,71 @@ sub parse_ok {
         got => $parsed, expected => $lsf_params }));
 }
 
+ok(parse_resource_requirements(
+        'rusage[mem=16384] select[mem > 16384] span[hosts=1]'));
+ok(!parse_resource_requirements(
+        '-M 16777216 rusage[mem=16384] select[mem > 16384] span[hosts=1]'),
+        'leading -M flag');
+ok(!parse_resource_requirements(
+        '-q long rusage[tmp=100]'),
+        'leading -q flag');
+
+ok(parse_resource_requirements(
+        '2*{select[type==X86_64] rusage[licA=1] span[hosts=1]} + 8*{select[type==any]}'));
+ok(!parse_resource_requirements(
+        '2*{select[type==X86_64] rusage[licA=1] span[hosts=1]} 8*{select[type==any]}'),
+        'missing plus sign between simple strings');
+ok(!parse_resource_requirements(
+        '*{select[type==X86_64] rusage[licA=1] span[hosts=1]} + 8*{select[type==any]}'),
+        'missing number multiplier');
+
+ok(parse_resource_requirements('rusage[mem=4000] span[hosts=1]'));
+ok(parse_resource_requirements('rusage[tmp=100]'));
+ok(parse_resource_requirements('span[hosts=1] rusage[mem=1000]'));
+ok(parse_resource_requirements('span[hosts=1] rusage[mem=1000]'));
+ok(parse_resource_requirements('select[tmp>1000] rusage[tmp=1000]'));
+ok(parse_resource_requirements('select[mem>6000] rusage[mem=6000]'));
+ok(parse_resource_requirements('rusage[mem=2000] select[mem > 2000] span[hosts=1]'));
+ok(parse_resource_requirements('select[mem>16000] rusage[mem=16000]'));
+ok(parse_resource_requirements('select[mem>16000] rusage[mem=16000]'));
+ok(parse_resource_requirements('select[mem>1024] rusage[mem=1024]'));
+ok(parse_resource_requirements('rusage[mem=4000,tmp=1000] select[tmp>1000] span[hosts=1]'));
+ok(parse_resource_requirements('rusage[mem=2000]'));
+ok(parse_resource_requirements('select[mem>16000] rusage[mem=16000]'));
+ok(parse_resource_requirements('rusage[mem=16384] select[mem > 16384] span[hosts=1]'));
+ok(parse_resource_requirements('select[mem>32000 && gtmp>200] rusage[mem=32000:gtmp=200] span[hosts=1]'));
+ok(parse_resource_requirements('select[mem>30000] rusage[mem=30000] span[hosts=1]'));
+ok(parse_resource_requirements('select[gtmp>20 && mem>4000] span[hosts=1] rusage[gtmp=20,mem=4000]'));
+ok(parse_resource_requirements('select[mem>8000] rusage[mem=8000]'));
+ok(parse_resource_requirements('select[mem>16000] rusage[mem=16000]'));
+ok(parse_resource_requirements('select[mem>12000] rusage[mem=12000]'));
+ok(parse_resource_requirements('select[mem>32000] rusage[mem=32000]'));
+ok(parse_resource_requirements('select[mem>12000] rusage[mem=12000]'));
+ok(parse_resource_requirements('select[mem>4096] rusage[mem=4096]'));
+ok(parse_resource_requirements('rusage[tmp=2000] select[tmp>2000]'));
+ok(parse_resource_requirements('rusage[mem=8000, tmp=2000] select[mem > 8000 && tmp > 2000] span[hosts=1]'));
+ok(parse_resource_requirements('rusage[mem=6000,tmp=10000] select[mem>6000 && tmp>10000] span[hosts=1]'));
+ok(parse_resource_requirements('select[mem>8192] rusage[mem=8192,tmp=100]'));
+ok(parse_resource_requirements('select[mem>32000] rusage[mem=32000]'));
+ok(parse_resource_requirements('rusage[tmp=100]'));
+ok(parse_resource_requirements('span[hosts=1] rusage[mem=8000]'));
+ok(parse_resource_requirements('select[tmp>2000] rusage[tmp=2000]'));
+ok(parse_resource_requirements('select[tmp>1000 && mem>16000] span[hosts=1] rusage[tmp=1000:mem=16000]'));
+ok(parse_resource_requirements('select[mem>=16000] rusage[mem=16000] span[hosts=1]'));
+ok(parse_resource_requirements('select[mem>32000] span[hosts=1] rusage[mem=32000]'));
+ok(parse_resource_requirements('select[mem>32000 && tmp>50000] span[hosts=1] rusage[mem=32000,tmp=50000]'));
+ok(parse_resource_requirements('select[mem>16000 && tmp>150000] span[hosts=1] rusage[tmp=150000, mem=16000]'));
+ok(parse_resource_requirements('select[mem>12000] rusage[mem=12000]'));
+ok(parse_resource_requirements('select[mem=8192] rusage[mem=8192,tmp=1024]'));
+ok(parse_resource_requirements('select[gtmp>1] span[hosts=1] rusage[gtmp=1]'));
+ok(parse_resource_requirements('select[gtmp>1000] rusage[gtmp=1000] span[hosts=1]'));
+ok(parse_resource_requirements('select[mem>7000 && tmp>10240] rusage[mem=7000]'));
+ok(parse_resource_requirements('select[mem>4500 && tmp>20000] rusage[mem=4500]'));
+ok(parse_resource_requirements('select[mem>4000] rusage[mem=4000]'));
+ok(parse_resource_requirements('select[mem>25000] rusage[mem=25000]'));
+ok(parse_resource_requirements('select[mem>20000] rusage[mem=20000]'));
+ok(parse_resource_requirements('rusage[mem=200:gtmp=5]'));
+ok(parse_resource_requirements('select[mem>14000] rusage[mem=14000]'));
 
 parse_ok('', { 'options' => {}, 'rLimits' => {} });
 parse_ok('rusage[mem=4000] span[hosts=1]', {

--- a/lib/perl/PAP/Command/BlastP.pm
+++ b/lib/perl/PAP/Command/BlastP.pm
@@ -50,7 +50,7 @@ class PAP::Command::BlastP {
         },
     ],
     has_param => [
-        lsf_resource => { default_value => '-q long rusage[tmp=100]', },
+        lsf_resource => { default_value => "-q long -R 'rusage[tmp=100]'", },
     ],
 };
 


### PR DESCRIPTION
The Genome codebase contained some strings meant to represent lsf resources that were neither valid resource requirement strings or bsub command options.  This PR fixes those problems.