### PR TITLE
Use pre/post-exec scripts for ptero LSF jobs

### DIFF
--- a/lib/perl/Genome/Ptero/ToJSON.t
+++ b/lib/perl/Genome/Ptero/ToJSON.t
@@ -43,6 +43,9 @@ for my $test_directory (glob test_data_directory('*')) {
             qr/^.*"workingDirectory" :.*$/,
             qr/^.*"user" :.*$/,
             qr/^.*"cwd" :.*$/,
+            qr/^.*"postExecCmd" :.*$/,
+            qr/^.*"outFile" :.*$/,
+            qr/^.*"errFile" :.*$/,
         ],
     );
 }

--- a/lib/perl/Genome/Ptero/ToJSONForProcess.t
+++ b/lib/perl/Genome/Ptero/ToJSONForProcess.t
@@ -58,6 +58,9 @@ for my $test_directory (glob test_data_directory('*')) {
             qr/^.*"workingDirectory" :.*$/,
             qr/^.*"user" :.*$/,
             qr/^.*"cwd" :.*$/,
+            qr/^.*"postExecCmd" :.*$/,
+            qr/^.*"outFile" :.*$/,
+            qr/^.*"errFile" :.*$/,
         ],
     );
 }

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -75,7 +75,11 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
+                     "errFile" : "/tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.err",
                      "numProcessors" : 1,
+                     "outFile" : "/tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
+                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.err --stdout /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
+                     "preExecCmd" : "ptero-lsf-pre-exec",
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
                   "pollingInterval" : 300,
@@ -179,7 +183,11 @@
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
                                                 "options" : {
+                                                   "errFile" : "/tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.err",
                                                    "numProcessors" : 1,
+                                                   "outFile" : "/tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
+                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.err --stdout /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
+                                                   "preExecCmd" : "ptero-lsf-pre-exec",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -79,7 +79,7 @@
                      "numProcessors" : 1,
                      "outFile" : "/tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.err --stdout /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec",
+                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
                   "pollingInterval" : 300,
@@ -187,7 +187,7 @@
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.err --stdout /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec",
+                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -119,7 +119,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
+                                    "errFile" : "/tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.err",
                                     "numProcessors" : 1,
+                                    "outFile" : "/tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
+                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.err --stdout /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
+                                    "preExecCmd" : "ptero-lsf-pre-exec",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,
@@ -225,7 +229,11 @@
                                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                                },
                                                                "options" : {
+                                                                  "errFile" : "/tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.err",
                                                                   "numProcessors" : 1,
+                                                                  "outFile" : "/tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
+                                                                  "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.err --stdout /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec",
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
                                                                "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -123,7 +123,7 @@
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.err --stdout /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec",
+                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,
@@ -233,7 +233,7 @@
                                                                   "numProcessors" : 1,
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.err --stdout /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec",
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
                                                                "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -126,7 +126,7 @@
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.err --stdout /tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec",
+                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -188,7 +188,7 @@
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.err --stdout /tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec",
+                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -250,7 +250,7 @@
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.err --stdout /tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec",
+                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -312,7 +312,7 @@
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.err --stdout /tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec",
+                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -122,7 +122,11 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
+                     "errFile" : "/tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.err",
                      "numProcessors" : 4,
+                     "outFile" : "/tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.out",
+                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.err --stdout /tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.out",
+                     "preExecCmd" : "ptero-lsf-pre-exec",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -180,7 +184,11 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
+                     "errFile" : "/tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.err",
                      "numProcessors" : 4,
+                     "outFile" : "/tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.out",
+                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.err --stdout /tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.out",
+                     "preExecCmd" : "ptero-lsf-pre-exec",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -238,7 +246,11 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
+                     "errFile" : "/tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.err",
                      "numProcessors" : 4,
+                     "outFile" : "/tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.out",
+                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.err --stdout /tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.out",
+                     "preExecCmd" : "ptero-lsf-pre-exec",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -296,7 +308,11 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
+                     "errFile" : "/tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.err",
                      "numProcessors" : 4,
+                     "outFile" : "/tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.out",
+                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.err --stdout /tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.out",
+                     "preExecCmd" : "ptero-lsf-pre-exec",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -172,7 +172,7 @@
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.err --stdout /tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec",
+                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -236,7 +236,7 @@
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.err --stdout /tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec",
+                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -300,7 +300,7 @@
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.err --stdout /tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec",
+                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -364,7 +364,7 @@
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.err --stdout /tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec",
+                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -168,7 +168,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
+                                    "errFile" : "/tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.err",
                                     "numProcessors" : 4,
+                                    "outFile" : "/tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.out",
+                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.err --stdout /tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.out",
+                                    "preExecCmd" : "ptero-lsf-pre-exec",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -228,7 +232,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
+                                    "errFile" : "/tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.err",
                                     "numProcessors" : 4,
+                                    "outFile" : "/tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.out",
+                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.err --stdout /tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.out",
+                                    "preExecCmd" : "ptero-lsf-pre-exec",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -288,7 +296,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
+                                    "errFile" : "/tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.err",
                                     "numProcessors" : 4,
+                                    "outFile" : "/tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.out",
+                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.err --stdout /tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.out",
+                                    "preExecCmd" : "ptero-lsf-pre-exec",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -348,7 +360,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
+                                    "errFile" : "/tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.err",
                                     "numProcessors" : 4,
+                                    "outFile" : "/tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.out",
+                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.err --stdout /tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.out",
+                                    "preExecCmd" : "ptero-lsf-pre-exec",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -110,7 +110,7 @@
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.err --stdout /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec",
+                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -106,7 +106,11 @@
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
                                                 "options" : {
+                                                   "errFile" : "/tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.err",
                                                    "numProcessors" : 1,
+                                                   "outFile" : "/tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
+                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.err --stdout /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
+                                                   "preExecCmd" : "ptero-lsf-pre-exec",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -151,7 +151,7 @@
                                                                   "numProcessors" : 1,
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.err --stdout /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec",
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
                                                                "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -147,7 +147,11 @@
                                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                                },
                                                                "options" : {
+                                                                  "errFile" : "/tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.err",
                                                                   "numProcessors" : 1,
+                                                                  "outFile" : "/tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
+                                                                  "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.err --stdout /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec",
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
                                                                "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
@@ -105,7 +105,12 @@
                                                    "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
-                                                "options" : {},
+                                                "options" : {
+                                                   "errFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err",
+                                                   "outFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
+                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err --stdout /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
+                                                   "preExecCmd" : "ptero-lsf-pre-exec"
+                                                },
                                                 "pollingInterval" : 300,
                                                 "rLimits" : {},
                                                 "user" : "dmorton"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
@@ -109,7 +109,7 @@
                                                    "errFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err",
                                                    "outFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err --stdout /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec"
+                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"
                                                 },
                                                 "pollingInterval" : 300,
                                                 "rLimits" : {},

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
@@ -150,7 +150,7 @@
                                                                   "errFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err",
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err --stdout /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec"
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"
                                                                },
                                                                "pollingInterval" : 300,
                                                                "rLimits" : {},

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
@@ -146,7 +146,12 @@
                                                                   "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
                                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                                },
-                                                               "options" : {},
+                                                               "options" : {
+                                                                  "errFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err",
+                                                                  "outFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
+                                                                  "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err --stdout /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec"
+                                                               },
                                                                "pollingInterval" : 300,
                                                                "rLimits" : {},
                                                                "user" : "dmorton"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
@@ -105,7 +105,12 @@
                                                    "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
-                                                "options" : {},
+                                                "options" : {
+                                                   "errFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err",
+                                                   "outFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
+                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err --stdout /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
+                                                   "preExecCmd" : "ptero-lsf-pre-exec"
+                                                },
                                                 "pollingInterval" : 300,
                                                 "rLimits" : {},
                                                 "user" : "dmorton"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
@@ -109,7 +109,7 @@
                                                    "errFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err",
                                                    "outFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err --stdout /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec"
+                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"
                                                 },
                                                 "pollingInterval" : 300,
                                                 "rLimits" : {},

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
@@ -146,7 +146,12 @@
                                                                   "XGENOME_PTERO_LSF_SERVICE_URL" : "http://lsf.example.com/v1",
                                                                   "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                                },
-                                                               "options" : {},
+                                                               "options" : {
+                                                                  "errFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err",
+                                                                  "outFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
+                                                                  "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err --stdout /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec"
+                                                               },
                                                                "pollingInterval" : 300,
                                                                "rLimits" : {},
                                                                "user" : "dmorton"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
@@ -150,7 +150,7 @@
                                                                   "errFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err",
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err --stdout /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec"
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"
                                                                },
                                                                "pollingInterval" : 300,
                                                                "rLimits" : {},

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -64,7 +64,7 @@
                      "numProcessors" : 1,
                      "outFile" : "/tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.err --stdout /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec",
+                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
                   "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -60,7 +60,11 @@
                      "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                   },
                   "options" : {
+                     "errFile" : "/tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.err",
                      "numProcessors" : 1,
+                     "outFile" : "/tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
+                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.err --stdout /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
+                     "preExecCmd" : "ptero-lsf-pre-exec",
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
                   "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -101,7 +101,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
+                                    "errFile" : "/tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.err",
                                     "numProcessors" : 1,
+                                    "outFile" : "/tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
+                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.err --stdout /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
+                                    "preExecCmd" : "ptero-lsf-pre-exec",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -105,7 +105,7 @@
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.err --stdout /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec",
+                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -87,7 +87,7 @@
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.err --stdout /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec",
+                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -83,7 +83,11 @@
                                     "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                  },
                                  "options" : {
+                                    "errFile" : "/tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.err",
                                     "numProcessors" : 1,
+                                    "outFile" : "/tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
+                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.err --stdout /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
+                                    "preExecCmd" : "ptero-lsf-pre-exec",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -124,7 +124,11 @@
                                                    "XGENOME_PTERO_SHELL_COMMAND_SERVICE_URL" : "http://example.com/v1"
                                                 },
                                                 "options" : {
+                                                   "errFile" : "/tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.err",
                                                    "numProcessors" : 1,
+                                                   "outFile" : "/tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
+                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.err --stdout /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
+                                                   "preExecCmd" : "ptero-lsf-pre-exec",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -128,7 +128,7 @@
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.err --stdout /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec",
+                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -6,6 +6,7 @@ use warnings;
 use Genome;
 use Cwd qw();
 use Genome::Sys::LSF::ResourceParser qw(parse_lsf_params);
+use Data::UUID;
 
 
 class Genome::WorkflowBuilder::Command {
@@ -150,7 +151,24 @@ sub _get_ptero_lsf_parameters {
     $set_lsf_option->('queue', $attributes{lsfQueue});
     $set_lsf_option->('projectName', $attributes{lsfProject});
 
+    $lsf_params->{options}->{preExecCmd} = "ptero-lsf-pre-exec";
+
+    my ($stderr, $stdout) = _get_stderr_stdout_paths();
+    $lsf_params->{options}->{errFile} = $stderr;
+    $lsf_params->{options}->{outFile} = $stdout;
+    $lsf_params->{options}->{postExecCmd} = "ptero-lsf-post-exec ".
+        "--stderr $stderr --stdout $stdout";
+
     return $lsf_params;
+}
+
+sub _get_stderr_stdout_paths {
+    my $ug = Data::UUID->new();
+    my $uuid = $ug->create();
+    my $uuid_str = $ug->to_string($uuid);
+
+    my $base = sprintf("/tmp/ptero-lsf-logfile-%s", $uuid_str);
+    return ($base . '.err', $base . '.out');
 }
 
 


### PR DESCRIPTION
This should not be merged before:

https://github.com/genome/ptero-perl-sdk/pull/109 is packaged and deployed via genome-snapshot-deps.

and

https://github.com/genome/ptero-lsf/pull/110 is deployed to production.