### PR TITLE
Commit after each interval of the HaplotypeCaller runs.

### DIFF
--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller/BucketIterator.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/HaplotypeCaller/BucketIterator.pm
@@ -56,6 +56,11 @@ sub _run {
             $self->fatal_message('Could not %s for interval %s.', $mode, $interval);
         }
 
+        unless($ENV{UR_DBI_NO_COMMIT}) {
+            #save our progress after creating a new result
+            UR::Context->commit() or $self->fatal_message('Failed to commit after %s for interval %s.', $mode, $interval);
+        }
+
         $self->debug_message('Successfully %s for interval %s.', $mode, $interval);
     }
 


### PR DESCRIPTION
Since each interval is an independent run, we can save the results for those intervals even if a subsequent one does not succeed.

(This would probably be better with genome/UR#62.)

I didn't go with the shell-out approach that some things (like `IntermediateAlignmentResult`) use, but that is a possible alternative if calling `commit` mid-way seems suboptimal.