### PR TITLE
Remove explicit _id properties that Model.pm will generate for us.

### DIFF
--- a/lib/perl/Genome/Model/SingleSampleGenotype.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype.pm
@@ -67,10 +67,6 @@ class Genome::Model::SingleSampleGenotype {
             via => 'target_region_set',
             to => 'name',
         },
-        reference_sequence_build_id => {
-            via => 'reference_sequence_build',
-            to => 'id'
-        },
     ],
     has_classwide => [
         aligner_name => {
@@ -129,13 +125,6 @@ sub add_region_of_interest_set {
 
     my $rois = Genome::FeatureList->get(@_) or die 'Failed to get FeatureList';
     $self->region_of_interest_set($rois);
-}
-
-sub add_reference_sequence_build {
-    my $self = shift;
-
-    my $build = Genome::Model::Build->get(@_);
-    $self->reference_sequence_build($build);
 }
 
 sub add_qc_genotype_vcf_file {

--- a/lib/perl/Genome/Model/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation.pm
@@ -184,34 +184,6 @@ class Genome::Model::SomaticValidation {
             via => 'target_region_set',
             to => 'name',
         },
-        snv_variant_list_id => {
-            via => 'snv_variant_list',
-            to => 'id',
-        },
-        indel_variant_list_id => {
-            via => 'indel_variant_list',
-            to => 'id',
-        },
-        sv_variant_list_id => {
-            via => 'sv_variant_list',
-            to => 'id',
-        },
-        previously_discovered_variations_build_id => {
-            via => 'previously_discovered_variations_build',
-            to => 'id'
-        },
-        annotation_build_id => {
-            via => 'annotation_build',
-            to => 'id'
-        },
-        reference_sequence_build_id => {
-            via => 'reference_sequence_build',
-            to => 'id'
-        },
-        known_sites_id => {
-            via => 'known_sites',
-            to => 'id',
-        },
     ],
     has_transient_constant_optional => {
         sequencing_platform => {
@@ -234,64 +206,6 @@ sub add_region_of_interest_set {
 
     my $rois = Genome::FeatureList->get(@_) or die 'Failed to get FeatureList';
     $self->region_of_interest_set($rois);
-}
-
-sub add_snv_variant_list {
-    my $self = shift;
-
-    my $variant_list = Genome::SoftwareResult->get(@_);
-    $self->snv_variant_list($variant_list);
-}
-
-sub add_sv_variant_list {
-    my $self = shift;
-
-    my $variant_list = Genome::SoftwareResult->get(@_);
-    $self->sv_variant_list($variant_list);
-}
-
-sub add_indel_variant_list {
-    my $self = shift;
-
-    my $variant_list = Genome::SoftwareResult->get(@_);
-    $self->indel_variant_list($variant_list);
-}
-
-sub add_previously_discovered_variations_build {
-    my $self = shift;
-
-    my $build = Genome::Model::Build->get(@_);
-    $self->previously_discovered_variations_build($build);
-}
-
-sub add_annotation_build {
-    my $self = shift;
-
-    my $build = Genome::Model::Build->get(@_);
-    $self->annotation_build($build);
-}
-
-sub add_reference_sequence_build {
-    my $self = shift;
-
-    my $build = Genome::Model::Build->get(@_);
-    $self->reference_sequence_build($build);
-}
-
-sub _add_known_site {
-    my $self = shift;
-
-    my @builds = Genome::Model::Build->get(@_);
-    map $self->add_input(name => 'known_sites', value => $_), @builds;
-}
-
-sub known_sites_id {
-    my $self = shift;
-    if(@_) {
-        $self->_add_known_site(id => $_[0]);
-    }
-
-    return $self->__known_sites_id;
 }
 
 sub _validate_required_for_start_properties {


### PR DESCRIPTION
The generated version points at the bridge table and so does not require the manually-generated `add_` methods either.