### PR TITLE
Stop subclassing ReferenceAlignment ProcessingProfiles on sequencing_platform.

### DIFF
--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -7,19 +7,6 @@ use Genome;
 
 class Genome::ProcessingProfile::ReferenceAlignment {
     is => 'Genome::ProcessingProfile::Staged',
-    is_abstract => 1,
-    subclassify_by => 'subclass_name',
-    has => [
-        subclass_name => { is_mutable => 0,
-                           calculate_from => ['sequencing_platform'],
-                           calculate => sub {
-                                            my($sequencing_platform) = @_;
-                                            Carp::confess "No sequencing platform given to resolve subclass name" unless $sequencing_platform;
-                                            return 'Genome::ProcessingProfile::ReferenceAlignment::'.Genome::Utility::Text::string_to_camel_case($sequencing_platform);
-                                          }
-                         },
-    ],
-
     has_param => [
         sequencing_platform => {
             doc => 'The sequencing platform from whence the model data was generated',

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -163,6 +163,21 @@ class Genome::ProcessingProfile::ReferenceAlignment {
     ],
 };
 
+#TODO Once old snapshots stop subclassifying by sequencing platform, remove this!
+sub get {
+    my $class = shift;
+
+    if(ref $class) {
+        return $class->SUPER::get(@_);
+    }
+
+    my $bx = UR::BoolExpr->resolve_normalized('Genome::ProcessingProfile::ReferenceAlignment', @_);
+    #until the database is updated, need to check all possible class names
+    $bx = $bx->add_filter(subclass_name => ['Genome::ProcessingProfile::ReferenceAlignment', 'Genome::ProcessingProfile::ReferenceAlignment::Solexa', 'Genome::ProcessingProfile::ReferenceAlignment::454'],);
+
+    return Genome::ProcessingProfile->get($bx);
+}
+
 sub _resolve_type_name_for_class {
     return 'reference alignment';
 }

--- a/lib/perl/Genome/processing_profile_subclassing.t
+++ b/lib/perl/Genome/processing_profile_subclassing.t
@@ -4,7 +4,7 @@ use Test::More;
 
 UR::DBI->no_commit(1);
 
-plan tests => 25;
+plan tests => 23;
 
 # Some Processing Profiles are abstract and require further info to subclass properly
 # Genome::ProcessingProfile, G::PP::ReferenceAlignment and G::PP::RnaSeq
@@ -35,7 +35,6 @@ $pp = Genome::ProcessingProfile::ReferenceAlignment->create(name => 'test refali
                                                             dna_type => 'genomic dna',
                                                             read_aligner_name => 'foo');
 ok($pp, 'Created an ReferenceAlignment PP');
-isa_ok($pp, 'Genome::ProcessingProfile::ReferenceAlignment::454');
 isa_ok($pp, 'Genome::ProcessingProfile::ReferenceAlignment');
 isa_ok($pp, 'Genome::ProcessingProfile');
 
@@ -45,7 +44,6 @@ $pp = Genome::ProcessingProfile->create(name => 'test refalign 2',
                                         dna_type => 'genomic dna',
                                         read_aligner_name => 'foo2');
 ok($pp, 'Created a Processing Profile with type_name => reference alignment');
-isa_ok($pp, 'Genome::ProcessingProfile::ReferenceAlignment::454');
 isa_ok($pp, 'Genome::ProcessingProfile::ReferenceAlignment');
 isa_ok($pp, 'Genome::ProcessingProfile');
 


### PR DESCRIPTION
We'll need to wait for old snapshots to fall out of use before editing the class of existing profiles and removing the subclasses altogether.