### PR TITLE
Check for directory existence each time before calling mkdir.

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -891,6 +891,8 @@ sub make_path {
     for (my $i = 0; $i < @dirs; $i++) {
         my $subpath = File::Spec->catdir(@dirs[0..$i]);
 
+        next if -d $subpath;
+
         my $rv = mkdir $subpath;
         my $mkdir_errno = $!;
         if ($rv) {


### PR DESCRIPTION
This partially reverts 0a28189020054af452b08c8d496234b1734bf403 from PR #809.  The initial check does not seem to be sufficient to ensure the volume is mounted.