### PR TITLE
Remove Obsolete RefAlign ProcessingProfile Parameters

### DIFF
--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -140,8 +140,6 @@ class Genome::Model::ReferenceAlignment {
                 return $latest_build_event;
             |,
         },
-        filter_ruleset_name   => { via => 'processing_profile' },
-        filter_ruleset_params => { via => 'processing_profile' },
         target_region_set_name => {
             is_many => 1, is_mutable => 1, is => 'Text', via => 'inputs', to => 'value_id', 
             where => [ name => 'target_region_set_name', value_class_name => 'UR::Value' ],

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -75,16 +75,7 @@ class Genome::Model::ReferenceAlignment {
         transcript_variant_annotator_filter => { via => 'processing_profile' },
         transcript_variant_annotator_accept_reference_IUB_codes => {via => 'processing_profile'},
         prior_ref_seq                => { via => 'processing_profile'},
-        read_aligner_name => {
-            calculate_from => 'processing_profile',
-            calculate => q|
-                my $read_aligner_name = $processing_profile->read_aligner_name;
-                if ($read_aligner_name =~ /^maq/) {
-                    return 'maq';
-                }
-                return $read_aligner_name;
-            |,
-        },
+        read_aligner_name            => { via => 'processing_profile'},
         read_aligner_version         => { via => 'processing_profile'},
         read_aligner_params          => { via => 'processing_profile'},
         read_trimmer_name            => { via => 'processing_profile'},

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -57,7 +57,6 @@ class Genome::Model::ReferenceAlignment {
     ],
     has => [
         subject                     => { is => 'Genome::Sample', id_by => 'subject_id', doc => 'the subject of alignment and variant detection is a single sample' },
-        align_dist_threshold         => { via => 'processing_profile'},
         dna_type                     => { via => 'processing_profile'},
         picard_version               => { via => 'processing_profile'},
         samtools_version             => { via => 'processing_profile'},

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -74,7 +74,6 @@ class Genome::Model::ReferenceAlignment {
         transcript_variant_annotator_version => { via => 'processing_profile' },
         transcript_variant_annotator_filter => { via => 'processing_profile' },
         transcript_variant_annotator_accept_reference_IUB_codes => {via => 'processing_profile'},
-        multi_read_fragment_strategy => { via => 'processing_profile'},
         prior_ref_seq                => { via => 'processing_profile'},
         read_aligner_name => {
             calculate_from => 'processing_profile',
@@ -260,17 +259,6 @@ sub accumulated_alignments_directory {
     my $last_complete_build = $self->last_complete_build;
     return if not $last_complete_build;
     return File::Spec->join($last_complete_build->data_directory, 'alignments');
-}
-
-sub is_eliminate_all_duplicates {
-    my $self = shift;
-
-    if ($self->multi_read_fragment_strategy and
-        $self->multi_read_fragment_strategy eq 'EliminateAllDuplicates') {
-        1;
-    } else {
-        0;
-    }
 }
 
 sub is_capture {

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -73,7 +73,6 @@ class Genome::Model::ReferenceAlignment {
         transcript_variant_annotator_version => { via => 'processing_profile' },
         transcript_variant_annotator_filter => { via => 'processing_profile' },
         transcript_variant_annotator_accept_reference_IUB_codes => {via => 'processing_profile'},
-        prior_ref_seq                => { via => 'processing_profile'},
         read_aligner_name            => { via => 'processing_profile'},
         read_aligner_version         => { via => 'processing_profile'},
         read_aligner_params          => { via => 'processing_profile'},

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -80,8 +80,6 @@ class Genome::Model::ReferenceAlignment {
         read_trimmer_version         => { via => 'processing_profile'},
         read_trimmer_params          => { via => 'processing_profile'},
         force_fragment               => { via => 'processing_profile'},
-        read_calibrator_name         => { via => 'processing_profile'},
-        read_calibrator_params       => { via => 'processing_profile'},
         dbsnp_model => {
             via => 'dbsnp_build',
             to => 'model',

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -131,14 +131,6 @@ class Genome::ProcessingProfile::ReferenceAlignment {
             doc => 'command line args for the trimmer',
             is_optional => 1,
         },
-        read_calibrator_name => {
-            doc => '',
-            is_optional => 1,
-        },
-        read_calibrator_params => {
-            doc => '',
-            is_optional => 1,
-        },
         coverage_stats_params => {
             doc => 'parameters necessary for generating reference coverage in the form of two comma delimited lists split by a colon like 1,5,10,15,20:0,200,500',
             is_optional => 1,

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -64,10 +64,6 @@ class Genome::ProcessingProfile::ReferenceAlignment {
             is_optional =>1,
             doc => "Strategy to be used to detect cnvs.",
         },
-        multi_read_fragment_strategy => {
-            doc => '',
-            is_optional => 1,
-        },
         picard_version => {
             doc => 'picard version for MarkDuplicates, MergeSamfiles, CreateSequenceDictionary...',
             is_optional => 1,

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -152,10 +152,6 @@ class Genome::ProcessingProfile::ReferenceAlignment {
             is_optional => 1,
             is_deprecated => 1,
         },
-        align_dist_threshold => {
-            doc => '',
-            is_optional => 1,
-        },
     ],
 };
 

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -143,11 +143,6 @@ class Genome::ProcessingProfile::ReferenceAlignment {
             doc => 'parameters necessary for generating reference coverage in the form of two comma delimited lists split by a colon like 1,5,10,15,20:0,200,500',
             is_optional => 1,
         },
-        capture_set_name => {
-            doc => 'The name of the capture set to evaluate coverage and limit variant calls to within the defined target regions',
-            is_optional => 1,
-            is_deprecated => 1,
-        },
     ],
 };
 

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -366,27 +366,6 @@ sub params_for_merged_alignment {
     return @param_set;
 }
 
-# TODO: remove
-sub prior {
-    my $self = shift;
-    warn("For now prior has been replaced with the actual column name prior_ref_seq");
-    if (@_) {
-        die("Method prior() is read-only since it's deprecated");
-    }
-    return $self->prior_ref_seq();
-}
-
-# TODO: remove
-sub filter_ruleset_name {
-    #TODO: move into the db so it's not constant
-    'basic'
-}
-
-# TODO: remove
-sub filter_ruleset_params {
-    ''
-}
-
 
 #### IMPLEMENTATION #####
 

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -143,10 +143,6 @@ class Genome::ProcessingProfile::ReferenceAlignment {
             doc => 'parameters necessary for generating reference coverage in the form of two comma delimited lists split by a colon like 1,5,10,15,20:0,200,500',
             is_optional => 1,
         },
-        prior_ref_seq => {
-            doc => '',
-            is_optional => 1,
-        },
         capture_set_name => {
             doc => 'The name of the capture set to evaluate coverage and limit variant calls to within the defined target regions',
             is_optional => 1,


### PR DESCRIPTION
They're hold-overs from `maq` or early versions of the pipeline.