### PR TITLE
Use GMT:Joinx::SnvConcordanceByQuality in RefAlign Summary Report.

### DIFF
--- a/lib/perl/Genome/Model/ReferenceAlignment/Report/Summary.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Report/Summary.pm
@@ -7,6 +7,7 @@ use strict;
 use warnings;
 
 use Genome;
+use Genome::Model::Tools::Joinx::SnvConcordanceByQuality;
 
 use IO::String;
 use Template;


### PR DESCRIPTION
This quiets this warning:

```
Use of inherited AUTOLOAD for non-method Genome::Model::Tools::Joinx::SnvConcordanceByQuality::parse_results_file() is deprecated at .../Genome/Model/ReferenceAlignment/Report/Summary.pm line 220.
```