### PR TITLE
Remove Delegation of `_initialize_build` to ProcessingProfiles.

### DIFF
--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -438,13 +438,10 @@ sub _resolve_resource_requirements_for_build {
     return "-R 'rusage[tmp=10000:mem=1000]' -M 1000000";
 }
 
+# Override in subclasses for actions that should be taken at build creation time
 sub _initialize_build {
-    # TODO remove call to processing_profile method after moving pp._initialize_builds to the respective model subclasses.
     my ($self, $build) = @_;
-    my $pp = $self->processing_profile;
-    if ($pp->can('_initialize_build')) {
-        return $pp->_initialize_build($build);
-    }
+
     return 1;
 }
 

--- a/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AnnotateTranscriptVariants.pm
+++ b/lib/perl/Genome/Model/Event/Build/ReferenceAlignment/AnnotateTranscriptVariants.pm
@@ -50,7 +50,7 @@ sub execute {
         return 1;
     }
 
-    # This has been vetted by the processing profile's _initialize_build method already
+    # This has been vetted by the model's _initialize_build method already
     my $annotator_version;
     my $annotator_filter;
     my $accept_reference_IUB_codes;

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -182,35 +182,6 @@ sub _resolve_type_name_for_class {
     return 'reference alignment';
 }
 
-sub _initialize_build {
-    my($self,$build) = @_;
-
-    # Check that the annotator version param is sane before doing the build
-    my $annotator_version;
-    my $worked = eval {
-        my $model = $build->model;
-        my $pp = $model->processing_profile;
-        $annotator_version = $pp->transcript_variant_annotator_version;
-        # When all processing profiles have a param for this, remove this unless block so
-        # they'll fail if it's missing
-        unless (defined $annotator_version) {
-            $annotator_version = Genome::Model::Tools::Annotate::TranscriptVariants->default_annotator_version;
-        }
-
-        my %available_versions = map { $_ => 1 } Genome::Model::Tools::Annotate::TranscriptVariants->available_versions;
-        unless ($available_versions{$annotator_version}) {
-            die "Requested annotator version ($annotator_version) is not in the list of available versions: "
-                . join(', ',keys(%available_versions));
-        }
-        1;
-    };
-    unless ($worked) {
-        $self->error_message("Could not determine which version of the Transcript Variants annotator to use: $@");
-        return;
-    }
-    return 1;
-}
-
 # get alignments (generic name)
 sub results_for_instrument_data_input {
     my $self = shift;


### PR DESCRIPTION
`ReferenceAlignment` was the last laggard still using this feature.