### PR TITLE
Remove Old Alignment Accessors

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
@@ -846,19 +846,6 @@ sub accumulated_alignments_directory {
     return $self->data_directory . '/alignments';
 }
 
-sub accumulated_alignments_disk_allocation {
-    my $self = shift;
-
-    my $dedup_event = Genome::Model::Event::Build::ReferenceAlignment::DeduplicateLibraries->get(model_id=>$self->model->id,
-                                                                                                   build_id=>$self->build_id);
-
-    return if (!$dedup_event);
-    
-    my $disk_allocation = Genome::Disk::Allocation->get(owner_class_name=>ref($dedup_event), owner_id=>$dedup_event->id);
-    
-    return $disk_allocation;
-}
-
 sub delete {
     my $self = shift;
     

--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
@@ -636,16 +636,6 @@ sub mark_duplicates_library_metrics_hash_ref {
     return \%library_metrics;
 }
 
-sub whole_map_file {
-    my $self = shift;
-    return $self->accumulated_alignments_directory .'/whole.map';
-}
-
-sub whole_rmdup_map_file {
-    my $self = shift;
-    return $self->accumulated_alignments_directory .'/whole_rmdup.map';
-}
-
 sub whole_rmdup_bam_file {
     my $self = shift;
 

--- a/lib/perl/Genome/Model/Build/RnaSeq.pm
+++ b/lib/perl/Genome/Model/Build/RnaSeq.pm
@@ -121,21 +121,6 @@ sub picard_rna_seq_pie_chart {
     return $self->metrics_directory .'/'. $self->picard_rna_seq_pie_chart;
 }
 
-sub accumulated_alignments_disk_allocation {
-    my $self = shift;
-
-    my $align_event = Genome::Model::Event::Build::RnaSeq::AlignReads->get(
-        model_id=>$self->model->id,
-        build_id=>$self->build_id
-    );
-
-    return if (!$align_event);
-
-    my $disk_allocation = Genome::Disk::Allocation->get(owner_class_name=>ref($align_event), owner_id=>$align_event->id);
-
-    return $disk_allocation;
-}
-
 sub accumulated_fastq_directory {
     my $self = shift;
     return $self->data_directory . '/fastq';

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -215,34 +215,6 @@ sub create {
     return $self;
 }
 
-sub libraries {
-    my $self = shift;
-    my %libraries = map {$_->library_name => 1} $self->instrument_data;
-    my @distinct_libraries = keys %libraries;
-    if ($self->name =~ /v0b/) {
-        warn "removing any *d libraries from v0b models.  temp hack for AML v0b models.";
-        @distinct_libraries = grep { $_ !~ /d$/ } @distinct_libraries;
-    }
-    return @distinct_libraries;
-}
-
-sub _calculate_library_count {
-    my $self = shift;
-    return scalar($self->libraries);
-}
-
-sub run_names {
-    my $self = shift;
-    my %distinct_run_names = map { $_->run_name => 1}  $self->instrument_data;
-    my @distinct_run_names = keys %distinct_run_names;
-    return @distinct_run_names;
-}
-
-sub _calculate_run_count {
-    my $self = shift;
-    return scalar($self->run_names);
-}
-
 sub region_of_interest_set {
     my $self = shift;
 

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -459,26 +459,6 @@ sub get_lane_qc_models {
     return @lane_qc_models;
 }
 
-sub latest_build_bam_file {
-    my $self = shift;
-
-    my $build = $self->latest_build;
-    unless ($build) { return; }
-
-    my @events = $build->the_events;
-    unless (@events) { return; }
-
-    my ($merge) = grep {($_->class eq 'Genome::Model::Event::Build::ReferenceAlignment::DeduplicateLibraries::Picard') || ($_->class eq 'Genome::Model::Event::Build::ReferenceAlignment::MergeAlignments')} @events;
-    unless ($merge) { return; }
-
-    unless ($merge->event_status eq 'Succeeded') {
-        #print STDERR 'Merge not Succeeded: '. $build->id ."\n";
-        return;
-    }
-    my $bam_file = $build->whole_rmdup_bam_file;
-    return $bam_file;
-}
-
 sub _additional_parts_for_default_name {
     my $self = shift;
     my @parts;

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -333,11 +333,6 @@ sub default_genotype_model {
     return $chosen_genotype_model;
 }
 
-sub build_subclass_name {
-    # TODO: remove, seemingly ununsed
-    return 'reference alignment';
-}
-
 sub dependent_properties {
     my ($self, $property_name) = @_;
     return @{$DEPENDENT_PROPERTIES{$property_name}} if exists $DEPENDENT_PROPERTIES{$property_name};


### PR DESCRIPTION
An abridged history of `sub libraries` (from 176611fdfd9e3818d5c51e827f17cee6c6a58580):
> The "temp hack" was added in bd502ac71a8a613e95af57f429d98b1d948abc76
on 14 July 2008 to the original `Genome::Model`.  It was then migrated to
`Genome::Model::ShortRead` before moving to its most recent location here
in `Genome::Model::ReferenceAlignment`.

As a bonus, this PR also removes one method from `Genome::Model::Build::RnaSeq`.