### PR TITLE
SomaticValidation Workflow is Instantiated with WorkflowBuilder.

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation.pm
@@ -275,10 +275,10 @@ sub _resolve_workflow_for_build {
     my $self = shift;
     my $build = shift;
 
-    my $operation = Workflow::Operation->create_from_xml(__FILE__ . '.xml');
+    my $operation = Genome::WorkflowBuilder::DAG->from_xml_filename(__FILE__ . '.xml');
 
     my $log_directory = $build->log_directory;
-    $operation->log_dir($log_directory);
+    $operation->recursively_set_log_dir($log_directory);
     $operation->name($build->workflow_name);
 
     return $operation;


### PR DESCRIPTION
This change is of little consequence for the moment (since `Build` converts this back into XML regardless), but it is a step on the path to removing `Workflow`!