### PR TITLE
Remove Old "Default Profile"s

### DIFF
--- a/lib/perl/Genome/InstrumentData/Solexa.pm
+++ b/lib/perl/Genome/InstrumentData/Solexa.pm
@@ -1253,10 +1253,9 @@ sub get_default_alignment_results {
 
     unless(@alignment_results) {
         # Get alignment results for this inst data and the default aligner name
-        my $pp = Genome::ProcessingProfile::ReferenceAlignment->default_profile;
         @alignment_results = Genome::InstrumentData::AlignmentResult->get(
             instrument_data_id => $self->id,
-            aligner_name       => $pp->read_aligner_name,
+            aligner_name       => 'bwa',
         );
     }
 

--- a/lib/perl/Genome/Model/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation.pm
@@ -348,16 +348,6 @@ sub default_filenames{
     return %default_filenames;
 }
 
-sub default_profile {
-    return Genome::ProcessingProfile::SomaticValidation->get(
-        name => 'Feb 2013 default Somatic Validation Extension and Targeted Discovery');
-}
-
-sub default_single_bam_profile {
-    return Genome::ProcessingProfile::SomaticValidation->get(
-        name => 'Jun 2012 Single-Bam Validation (single-bam somatic)');
-}
-
 sub requires_subject_mapping { return 1; }
 
 sub default_model_name {

--- a/lib/perl/Genome/Model/SomaticValidation/Command/DefineModels.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/DefineModels.pm
@@ -81,9 +81,7 @@ sub execute {
             if $self->$param;
     }
 
-    if( $self->processing_profile) {
-        push @params, single_sample_processing_profile => $self->processing_profile;
-    }
+    push @params, single_sample_processing_profile => $self->processing_profile;
 
     if(!$self->region_of_interest_set and $self->target) {
         $self->region_of_interest_set($self->target);

--- a/lib/perl/Genome/Model/SomaticValidation/Command/DefineModels.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/DefineModels.pm
@@ -33,7 +33,6 @@ class Genome::Model::SomaticValidation::Command::DefineModels {
         },
         processing_profile => {
             is => 'Genome::ProcessingProfile',
-            is_optional => 1,
             doc => 'A processing profile to use for all models defined (the current default will be used otherwise)',
         },
         variant_file_list => {
@@ -80,6 +79,10 @@ sub execute {
     for my $param ('processing_profile', 'region_of_interest_set', 'target', 'design') {
         push @params, $param => $self->$param
             if $self->$param;
+    }
+
+    if( $self->processing_profile) {
+        push @params, single_sample_processing_profile => $self->processing_profile;
     }
 
     if(!$self->region_of_interest_set and $self->target) {

--- a/lib/perl/Genome/Model/SomaticValidation/Command/DefineModels.t
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/DefineModels.t
@@ -12,6 +12,7 @@ use above 'Genome';
 use Test::More tests => 19;
 
 use Genome::Test::Factory::InstrumentData::Solexa;
+use Genome::Test::Factory::ProcessingProfile::SomaticValidation;
 use Genome::Test::Factory::ProcessingProfile::SomaticVariation;
 
 my $temp_build_data_dir = File::Temp::tempdir('t_SomaticValidation_Build-XXXXX', CLEANUP => 1, TMPDIR => 1);
@@ -75,6 +76,8 @@ my $model_group = Genome::ModelGroup->create(
     name => 'test_model_for_DefineModels.t',
 );
 
+my $pp = Genome::Test::Factory::ProcessingProfile::SomaticValidation->setup_object();
+
 my $cmd = Genome::Model::SomaticValidation::Command::DefineModels->create(
     variant_file_list => $listing_file,
     models => \@somvar_models,
@@ -82,6 +85,7 @@ my $cmd = Genome::Model::SomaticValidation::Command::DefineModels->create(
     design => $test_targets,
     region_of_interest_set => $test_targets,
     new_model_group => $model_group,
+    processing_profile => $pp,
 );
 isa_ok($cmd, 'Genome::Model::SomaticValidation::Command::DefineModels', 'created importer command');
 
@@ -106,6 +110,7 @@ my $cmd2 = Genome::Model::SomaticValidation::Command::DefineModels->create(
     design => $test_targets,
     region_of_interest_set => $test_targets,
     generate_variant_lists => 1,
+    processing_profile => $pp,
 );
 isa_ok($cmd2, 'Genome::Model::SomaticValidation::Command::DefineModels', 'created importer command');
 

--- a/lib/perl/Genome/Model/SomaticValidation/Command/DefineValidationModel.t
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/DefineValidationModel.t
@@ -14,6 +14,7 @@ use Test::More tests => 37;
 use Genome::Model::Tools::DetectVariants2::Utilities qw(
     final_result_for_variant_type
 );
+use Genome::Test::Factory::ProcessingProfile::SomaticValidation;
 
 use Cwd;
 #use Carp::Always;
@@ -24,6 +25,14 @@ my $temp_build_data_dir = File::Temp::tempdir('t_SomaticValidation_Build-XXXXX',
 
 my $somatic_variation_build = &setup_somatic_variation_build(1);
 isa_ok($somatic_variation_build, 'Genome::Model::Build::SomaticVariation', 'setup test somatic variation build');
+
+#set up fake processing profiles
+my $processing_profile = Genome::Test::Factory::ProcessingProfile::SomaticValidation->setup_object(
+    name => 'somatic test profile for DefineValidationModel.t',
+);
+my $single_sample_processing_profile = Genome::Test::Factory::ProcessingProfile::SomaticValidation->setup_object(
+    name => 'single-sample test profile for DefineValidationModel.t',
+);
 
 #Set up a fake feature-list
 my $data = <<EOBED
@@ -52,6 +61,7 @@ my @params_for_define_1 = (
     target => $test_targets,
     variants => [$variants_1],
     groups => [$mg],
+    processing_profile => $processing_profile,
 );
 
 my $define_1 = Genome::Model::SomaticValidation::Command::DefineValidationModel->create(@params_for_define_1);
@@ -82,6 +92,7 @@ my @params_for_define_2 = (
     name => 'awesome second model',
     design => $test_targets,
     variants => [$variants_1, $result],
+    processing_profile => $processing_profile,
 );
 
 my $define_2 = Genome::Model::SomaticValidation::Command::DefineValidationModel->create(@params_for_define_2);
@@ -102,6 +113,7 @@ my @params_for_define_3 = (
     design => $test_targets,
     target => $test_targets,
     variants => [$variants_1, $variants_2],
+    processing_profile => $processing_profile,
 );
 
 my $define_3 = Genome::Model::SomaticValidation::Command::DefineValidationModel->create(@params_for_define_3);
@@ -119,6 +131,7 @@ my @params_for_define_4 = (
     target => $test_targets,
     tumor_sample => $somatic_variation_build2->tumor_model->subject,
     normal_sample => $somatic_variation_build2->normal_model->subject,
+    processing_profile => $processing_profile,
 );
 
 my $define_4 = Genome::Model::SomaticValidation::Command::DefineValidationModel->create(@params_for_define_4);
@@ -136,6 +149,7 @@ my @params_for_define_5 = (
     design => $test_targets,
     target => $test_targets,
     tumor_sample => $somatic_variation_build2->tumor_model->subject,
+    single_sample_processing_profile => $single_sample_processing_profile,
 );
 
 my $define_5 = Genome::Model::SomaticValidation::Command::DefineValidationModel->create(@params_for_define_5);
@@ -183,6 +197,8 @@ Genome::Sys->write_file($sample_list_file, join("\n",
 my $define_6 = Genome::Model::SomaticValidation::Command::DefineValidationModel->create(
     sample_list_file => $sample_list_file,
     target => $test_targets,
+    processing_profile => $processing_profile,
+    single_sample_processing_profile => $single_sample_processing_profile,
 );
 isa_ok($define_6, 'Genome::Model::SomaticValidation::Command::DefineValidationModel', 'sixth creation command');
 $define_6->dump_status_messages(1);

--- a/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
+++ b/lib/perl/Genome/ProcessingProfile/ReferenceAlignment.pm
@@ -551,15 +551,4 @@ sub transcript_annotation_objects {
     return 'all_sequences';
 }
 
-sub default_profile_id {
-    return 2635769;
-    #This should be updated everytime when new autocron ref-aling default pp is in place
-    #The current default is Nov 2011 Default Reference Alignment
-}
-
-sub default_profile {
-    return __PACKAGE__->get(shift->default_profile_id);
-}
-
-
 1;


### PR DESCRIPTION
These defaults are not up-to-date, and we now use the `ConfigureQueuedInstrumentData` command to decide what profiles to use in most cases.