### PR TITLE
ReferenceAlignment: Use user relationships to find alignments.

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.pm
@@ -266,36 +266,13 @@ sub reference_being_replaced_for_input {
 sub alignment_results_for_instrument_data {
     my $self = shift;
     my $instrument_data = shift;
-    my $model = $self->model;
-    my $processing_profile = $model->processing_profile;
-    my $input = $model->input_for_instrument_data($instrument_data);
 
-    my $result_users = Genome::SoftwareResult::User->user_hash_for_build($self);
+    my @results =
+        grep { $_->instrument_data eq $instrument_data }
+        grep { $_->isa('Genome::InstrumentData::AlignmentResult') }
+    $self->results();
 
-    if ($processing_profile->can('results_for_instrument_data_input')) {
-        my @results;
-        # TODO There's gotta be a better way to get segment info
-        my @align_reads_events = Genome::Model::Event::Build::ReferenceAlignment::AlignReads->get(
-            instrument_data_id => $instrument_data->id,
-            build_id => $self->id,
-        );
-
-        if (@align_reads_events) {
-            for my $align_reads_event (@align_reads_events) {
-                my %segment_info = ();
-                if ($align_reads_event->instrument_data_segment_type) {
-                    $segment_info{instrument_data_segment_type} = $align_reads_event->instrument_data_segment_type;
-                    $segment_info{instrument_data_segment_id} = $align_reads_event->instrument_data_segment_id;
-                };
-                push @results, $processing_profile->results_for_instrument_data_input($input, $result_users, %segment_info);
-            }
-            return @results;
-        } else {
-            return $processing_profile->results_for_instrument_data_input($input, $result_users);
-        }
-    }
-
-    return;
+    return @results;
 }
 
 sub alignment_directory_for_instrument_data {

--- a/lib/perl/Genome/Model/Command/InstrumentData/AlignmentBams.t
+++ b/lib/perl/Genome/Model/Command/InstrumentData/AlignmentBams.t
@@ -11,6 +11,7 @@ use above 'Genome';
 
 use Genome::Test::Factory::Build;
 use Genome::Test::Factory::DiskAllocation;
+use Genome::Test::Factory::InstrumentData::AlignmentResult;
 use Genome::Test::Factory::InstrumentData::Solexa;
 use Genome::Test::Factory::Model::ReferenceAlignment;
 
@@ -35,10 +36,8 @@ for my $i (1..NUM_INSTRUMENT_DATA) {
 my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id);
 for my $input ($build->instrument_data_inputs) {
 
-    my ($params) = $model->processing_profile->params_for_alignment($input);
-
-    my $ar = Genome::InstrumentData::AlignmentResult::Bwa->__define__(
-        %$params,
+    my $ar = Genome::Test::Factory::InstrumentData::AlignmentResult->setup_object(
+        instrument_data_id => $input->value_id,
         output_dir => '/fake/' . $input->value_id,
 
     );


### PR DESCRIPTION
This is far more direct than assembling all the aligner params and querying!