### PR TITLE
AnP Replace Model Uses Config Profile

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/ReplaceModel.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/ReplaceModel.t
@@ -4,18 +4,18 @@ use strict;
 use warnings;
 
 BEGIN {
+    $SIG{__DIE__} = sub{ Carp::confess(@_); };
     $ENV{UR_DBI_NO_COMMIT} = 1;
     $ENV{UR_COMMAND_DUMP_STATUS_MESSAGES} = 1;
     $ENV{UR_COMMAND_DUMP_DEBUG_MESSAGES} = 1;
 };
 
-use Test::Exception;
-use Test::More tests => 4;
-
 use above 'Genome';
-#use Genome::Test::Factory::AnalysisProject;
 use Genome::Test::Factory::DiskAllocation;
 use Genome::Test::Factory::InstrumentData::Solexa;
+
+use Test::Exception;
+use Test::More tests => 4;
 
 my $class = 'Genome::Config::AnalysisProject::Command::ReplaceModel';
 use_ok($class) or die;
@@ -65,6 +65,7 @@ EOFILE
 
     my $instdata = Genome::Test::Factory::InstrumentData::Solexa->setup_object;
     $model = $model_class->create(
+        run_as => Genome::Sys->username,
         subject => $instdata->sample,
         processing_profile_id => -11,
         auto_assign_inst_data => 1
@@ -85,6 +86,7 @@ subtest "fails" => sub{
     plan tests => 3;
 
     my $profile_item = Genome::Config::Profile::Item->get(-11);
+
     throws_ok(
         sub{
             $class->execute(

--- a/lib/perl/Genome/Config/AnalysisProject/Command/ReplaceModel.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/ReplaceModel.t
@@ -5,25 +5,31 @@ use warnings;
 
 BEGIN {
     $ENV{UR_DBI_NO_COMMIT} = 1;
+    $ENV{UR_COMMAND_DUMP_STATUS_MESSAGES} = 1;
+    $ENV{UR_COMMAND_DUMP_DEBUG_MESSAGES} = 1;
 };
 
 use Test::Exception;
 use Test::More tests => 4;
 
 use above 'Genome';
-use Genome::Test::Factory::AnalysisProject;
+#use Genome::Test::Factory::AnalysisProject;
 use Genome::Test::Factory::DiskAllocation;
+use Genome::Test::Factory::InstrumentData::Solexa;
 
 my $class = 'Genome::Config::AnalysisProject::Command::ReplaceModel';
 use_ok($class) or die;
 
 my $model_class = 'Genome::Model::Tester';
-my $analysis_project = Genome::Test::Factory::AnalysisProject->setup_object(status => 'Completed');
+my $analysis_project = Genome::Config::AnalysisProject->create(
+    run_as => Genome::Sys->username,
+    status => 'Completed',
+);
 class Genome::Model::Tester { is => 'Genome::Model', };
 my ($model);
 
 subtest "setup" => sub{
-    plan tests => 8;
+    plan tests => 9;
 
     # create a pp and profile item
     for my $id ( -11, -22 ) {
@@ -43,19 +49,28 @@ subtest "setup" => sub{
             mount_path => Genome::Sys->create_temp_file_path,
         );
     my $data = <<EOFILE
+rules:
+  sequencing_platform: solexa
+
 models:
-    "$model_class":
-        processing_profile_id: $id
+  "$model_class":
+    processing_profile_id: $id
+    instrument_data_properties:
+      subject: sample
 EOFILE
 ;
         Genome::Sys->write_file( File::Spec->join($profile_alloc->absolute_path, 'config.yml'), $data );
         ok(-s $profile_item->file_path, 'created profile item file path');
     }
 
+    my $instdata = Genome::Test::Factory::InstrumentData::Solexa->setup_object;
     $model = $model_class->create(
-        subject => Genome::Sample->create(name => '_SAMPLE_'),
+        subject => $instdata->sample,
         processing_profile_id => -11,
+        auto_assign_inst_data => 1
     );
+    $model->add_instrument_data($instdata);
+    ok($model->instrument_data, 'added model instrument data');
 
     my $profile_item =  Genome::Config::Profile::Item->get(-11);
     $analysis_project->add_model_bridge(
@@ -98,8 +113,8 @@ subtest "fails" => sub{
                 new_profile_item => $profile_item,
                 model => $model,
             ); },
-        qr/No overrides found/,
-        'fails when overrides not found',
+        qr/No model found or created/,
+        'fails when no model found/created',
     );
 
 };

--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -66,7 +66,7 @@ sub execute {
         }
         eval {
             my $config = $analysis_project->get_configuration_profile();
-            my $hashes = $self->_prepare_configuration_hashes_for_instrument_data($current_inst_data, $config);
+            my $hashes = $config->prepare_configuration_hashes_for_instrument_data($current_inst_data);
             for my $model_type (keys %$hashes) {
                 my $model_hashes = $hashes->{$model_type};
                 if ($model_type->requires_subject_mapping) {
@@ -248,36 +248,6 @@ sub _get_model_for_config_hash {
     }
 
     return wantarray ? @model_info : $model_info[0];
-}
-
-sub _prepare_configuration_hashes_for_instrument_data {
-    my ($self, $instrument_data, $config_obj) = @_;
-
-    my $config_hash = $config_obj->get_config($instrument_data);
-
-    for my $model_type (keys %$config_hash) {
-        if (ref $config_hash->{$model_type} ne 'ARRAY') {
-            $config_hash->{$model_type} = [$config_hash->{$model_type}];
-        }
-
-        for my $model_instance (@{$config_hash->{$model_type}}) {
-            my $instrument_data_properties = delete $model_instance->{instrument_data_properties};
-            if($instrument_data_properties) {
-                while((my $model_property, my $instrument_data_property) = each %$instrument_data_properties) {
-                    if (ref $instrument_data_property eq 'ARRAY') {
-                        $model_instance->{$model_property} = [
-                            grep { defined($_) }
-                            map { $instrument_data->$_ }
-                            @$instrument_data_property
-                        ];
-                    } else {
-                        $model_instance->{$model_property} = $instrument_data->$instrument_data_property;
-                    }
-                }
-            }
-        }
-    }
-    return $config_hash;
 }
 
 sub _process_mapped_samples {

--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -69,9 +69,6 @@ sub execute {
             my $hashes = $config->prepare_configuration_hashes_for_instrument_data($current_inst_data);
             for my $model_type (keys %$hashes) {
                 my $model_hashes = $hashes->{$model_type};
-                if ($model_type->requires_subject_mapping) {
-                    $model_hashes = $config->process_mapped_samples($current_inst_data, $model_hashes);
-                }
                 $self->_process_models($analysis_project, $current_inst_data, $model_type, $model_hashes);
             }
         };

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -116,5 +116,43 @@ sub prepare_configuration_hashes_for_instrument_data {
     return $config_hash;
 }
 
+sub process_mapped_samples {
+    my ($self, $instrument_data, $model_hashes) = @_;
+    die('Must provide an analysis project, a piece of instrument data and a config hash!')
+        unless($instrument_data && $model_hashes);
+
+    my @subject_mappings = Genome::Config::AnalysisProject::SubjectMapping->get(
+        analysis_project => $self->analysis_project,
+        subjects => $instrument_data->sample
+    );
+
+    unless (@subject_mappings) {
+        die(sprintf('Found no mapping information for %s in project %s for a model type that requires mapping!',
+            $instrument_data->__display_name__,
+            $self->analysis_project->__display_name__));
+    }
+
+    return [ map {
+        my $mapping = $_;
+        my %tags = map { $_->id => 1 } $mapping->tags;
+        map { {
+          (map { $_->label => $_->subject } $mapping->subject_bridges),
+          (map { $_->key => $_->value } $mapping->inputs),
+          %$_
+        } } grep { $self->_model_hash_matches_tags($_, \%tags) } @$model_hashes
+    } @subject_mappings ];
+}
+
+sub _model_hash_matches_tags {
+    my ($self, $model_hash, $tag_hash) = @_;
+
+    my @model_hash_tags = $model_hash->{config_profile_item}->tags;
+    if(keys %$tag_hash) {
+        return List::MoreUtils::any { exists $tag_hash->{$_->id} } @model_hash_tags;
+    } else {
+        return !@model_hash_tags;
+    }
+}
+
 1;
 

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -39,6 +39,15 @@ sub create_from_analysis_project {
     );
 }
 
+sub create_from_config_profile_item {
+    my ($class, $config_profile_item) = @_;
+
+    return $class->create(
+        config_rule_maps => [ Genome::Config::Translator->get_rule_model_map_from_config($config_profile_item) ],
+        analysis_project => $config_profile_item->analysis_project,
+    );
+}
+
 sub get_config {
     my $self = shift;
     my $inst_data = shift;

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -112,11 +112,13 @@ sub prepare_configuration_hashes_for_instrument_data {
                 }
             }
         }
+
+        $config_hash->{$model_type} = $self->_process_mapped_samples($instrument_data, $config_hash->{$model_type}) if $model_type->requires_subject_mapping;
     }
     return $config_hash;
 }
 
-sub process_mapped_samples {
+sub _process_mapped_samples {
     my ($self, $instrument_data, $model_hashes) = @_;
     die('Must provide an analysis project, a piece of instrument data and a config hash!')
         unless($instrument_data && $model_hashes);

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -86,4 +86,35 @@ sub _add_user_if_not_present {
     return 1;
 }
 
+sub prepare_configuration_hashes_for_instrument_data {
+    my ($self, $instrument_data) = @_;
+
+    my $config_hash = $self->get_config($instrument_data);
+
+    for my $model_type (keys %$config_hash) {
+        if (ref $config_hash->{$model_type} ne 'ARRAY') {
+            $config_hash->{$model_type} = [$config_hash->{$model_type}];
+        }
+
+        for my $model_instance (@{$config_hash->{$model_type}}) {
+            my $instrument_data_properties = delete $model_instance->{instrument_data_properties};
+            if($instrument_data_properties) {
+                while((my $model_property, my $instrument_data_property) = each %$instrument_data_properties) {
+                    if (ref $instrument_data_property eq 'ARRAY') {
+                        $model_instance->{$model_property} = [
+                            grep { defined($_) }
+                            map { $instrument_data->$_ }
+                            @$instrument_data_property
+                        ];
+                    } else {
+                        $model_instance->{$model_property} = $instrument_data->$instrument_data_property;
+                    }
+                }
+            }
+        }
+    }
+    return $config_hash;
+}
+
 1;
+

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -3,6 +3,8 @@ package Genome::Config::Profile;
 use strict;
 use warnings;
 
+use List::MoreUtils qw/ any uniq /;
+
 use Genome;
 use UR::Util;
 
@@ -86,11 +88,23 @@ sub _add_user_if_not_present {
     return 1;
 }
 
-sub prepare_configuration_hashes_for_instrument_data {
+sub process_models_for_instrument_data {
+    my ($self, $instrument_data) = @_;
+
+    my $hashes = $self->_prepare_configuration_hashes_for_instrument_data($instrument_data);
+    my @models;
+    for my $model_type (keys %$hashes) {
+        my $model_hashes = $hashes->{$model_type};
+        push @models, $self->_process_models($instrument_data, $model_type, $model_hashes);
+    }
+
+    return uniq @models;
+}
+
+sub _prepare_configuration_hashes_for_instrument_data {
     my ($self, $instrument_data) = @_;
 
     my $config_hash = $self->get_config($instrument_data);
-
     for my $model_type (keys %$config_hash) {
         if (ref $config_hash->{$model_type} ne 'ARRAY') {
             $config_hash->{$model_type} = [$config_hash->{$model_type}];
@@ -150,9 +164,117 @@ sub _model_hash_matches_tags {
 
     my @model_hash_tags = $model_hash->{config_profile_item}->tags;
     if(keys %$tag_hash) {
-        return List::MoreUtils::any { exists $tag_hash->{$_->id} } @model_hash_tags;
+        return any { exists $tag_hash->{$_->id} } @model_hash_tags;
     } else {
         return !@model_hash_tags;
+    }
+}
+
+sub _process_models {
+    my $self = shift;
+    my $instrument_data = shift;
+    my $model_type = shift;
+    my $model_list = shift;
+
+    my @models;
+    for my $model_instance (@$model_list) {
+        my ($model, $created_new, $config_profile_item) = $self->_get_model_for_config_hash($model_type, $model_instance);
+
+        $self->status_message(sprintf('Model: %s %s for instrument data: %s.',
+                $model->id, ($created_new ? 'created' : 'found'), $instrument_data->id ));
+
+        $self->_assign_model_to_analysis_project($model, $config_profile_item, $created_new);
+        $self->_assign_instrument_data_to_model($model, $instrument_data, $created_new);
+        $self->_update_model($model);
+        $self->_request_build_if_necessary($model, $created_new);
+        push @models, $model;
+    }
+
+    return @models;
+}
+
+sub _get_model_for_config_hash {
+    my $self = shift;
+    my $class_name = shift;
+    my $config = shift;
+
+    my $config_profile_item = delete $config->{config_profile_item};
+    my %read_config = %$config;
+    for my $key (keys %read_config) {
+        my $value = $read_config{$key};
+        if(ref($value) eq 'ARRAY' and scalar(@$value) == 0) {
+            $read_config{$key} = undef;
+        }
+    }
+
+    my @extra_params = (auto_assign_inst_data => 1);
+    my @found_models = $class_name->get(@extra_params, %read_config, analysis_project => $self->analysis_project);
+    my @m = grep { $_->analysis_project_bridges->profile_item_id eq $config_profile_item->id } @found_models;
+
+    if (scalar(@m) > 1) {
+        die(sprintf("Sorry, but multiple identical models were found: %s", join(',', map { $_->id } @m)));
+    };
+
+    #return the model, plus a 'boolean' value indicating if we created a new model
+    my @model_info;
+    if ($m[0]) {
+       @model_info = ($m[0], 0, $config_profile_item);
+    } else {
+       for my $key (keys %$config) {
+            delete $config->{$key} unless defined $config->{$key};
+       }
+       @model_info = ($class_name->create(@extra_params, %$config), 1, $config_profile_item);
+    }
+
+    return wantarray ? @model_info : $model_info[0];
+}
+
+sub _assign_model_to_analysis_project {
+    my $self = shift;
+    my $model = shift;
+    my $config_profile_item = shift;
+    my $created_new = shift;
+
+    die('Must specify an analysis project and a model!') unless $model && $config_profile_item;
+
+    $self->analysis_project->add_model_bridge(model => $model, config_profile_item => $config_profile_item) if $created_new;
+    return 1;
+}
+
+sub _assign_instrument_data_to_model {
+    my ($self, $model, $instrument_data, $newly_created) = @_;
+
+    #if a model is newly created, we want to assign all applicable instrument data to it
+    my %params_hash = (model => $model);
+    my $cmd = Genome::Model::Command::InstrumentData::Assign::ByExpression->create(
+            model => $model,
+            instrument_data => [$instrument_data],
+            force => 1, #trust the configuration to know what it's doing
+        );
+    my $executed_ok = eval{ $cmd->execute };
+
+    unless ($executed_ok) {
+        die(sprintf('Failed to assign %s to %s', $instrument_data->__display_name__,
+                $model->__display_name__));
+    }
+}
+
+sub _update_model {
+    my ($self, $model) = @_;
+    if ($model->can("check_for_updates")) {
+        unless ($model->check_for_updates) {
+            Carp::confess "Could not update model!";
+        }
+    }
+}
+
+sub _request_build_if_necessary {
+    my ($self, $model, $newly_created) = @_;
+
+    my $reason = $newly_created? 'created' : 'processed';
+
+    if($model->build_needed) {
+        $model->build_requested(1, "CQID $reason model");
     }
 }
 

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -42,6 +42,8 @@ sub create_from_analysis_project {
 sub create_from_config_profile_item {
     my ($class, $config_profile_item) = @_;
 
+    $class->fatal_message('Cannot use a non current config item to create profile!') if not $config_profile_item->is_current;
+
     return $class->create(
         config_rule_maps => [ Genome::Config::Translator->get_rule_model_map_from_config($config_profile_item) ],
         analysis_project => $config_profile_item->analysis_project,

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -183,7 +183,7 @@ sub _is_created {
 sub is_current {
     my $self = shift;
 
-    return $self->status ne 'disabled' and $self->analysis_project->is_current;
+    return $self->status ne 'disabled' && $self->analysis_project->is_current;
 }
 
 1;

--- a/lib/perl/Genome/Config/Profile/Item.t
+++ b/lib/perl/Genome/Config/Profile/Item.t
@@ -66,6 +66,26 @@ Genome::Config::Tag::Profile::Item->create(profile_item => $profile_item_from_me
 Genome::Config::Tag::Profile::Item->create(profile_item => $profile_item_from_menu_item, tag => $tags[2]);
 cmp_bag([$profile_item_from_menu_item->tag_names], [map $_->name, @tags[0,2]], 'found assigned tag names for profile item');
 
+subtest 'is_current' => sub{
+    plan tests => 12;
+
+    is($analysis_project->status('Pending'), 'Pending', 'analysis project status is Pending');
+    ok($analysis_project->is_current, 'AnP is current');
+    is($profile_item_from_file->status, 'active', 'profile item status is active');
+    ok($profile_item_from_file->is_current, 'profile item is current');
+
+    is($profile_item_from_file->status('inactive'), 'inactive', 'profile item status is inactive');
+    ok($profile_item_from_file->is_current, 'profile item is current');
+
+    is($profile_item_from_file->status('disabled'), 'disabled', 'profile item status is disabled');
+    ok(!$profile_item_from_file->is_current, 'profile item is NOT current');
+
+    is($analysis_project->status('Completed'), 'Completed', 'analysis project status is Completed');
+    ok(!$analysis_project->is_current, 'AnP is NOT current');
+    is($profile_item_from_file->status('inactive'), 'inactive', 'profile item status is inactive');
+    ok(!$profile_item_from_file->is_current, 'profile item is current');
+
+};
 
 sub _create_file_with_contents {
     my $contents = shift;


### PR DESCRIPTION
Extract the process model get/create from CQID into config profile so that both CQID and the replace model command can use it.