### PR TITLE
Epitope length needs to be of Integer data type instead of Text

### DIFF
--- a/lib/perl/Genome/Model/Tools/EpitopePrediction/NetmhcPipeline.pm
+++ b/lib/perl/Genome/Model/Tools/EpitopePrediction/NetmhcPipeline.pm
@@ -28,7 +28,7 @@ class Genome::Model::Tools::EpitopePrediction::NetmhcPipeline {
             is_many => 1,
         },
         epitope_length => {
-            is => 'Text',
+            is => 'Integer',
             doc => 'Length of subpeptides to predict with NetMHC',
         },
         netmhc_version => {

--- a/lib/perl/Genome/Model/Tools/EpitopePrediction/NewPipeline.pm
+++ b/lib/perl/Genome/Model/Tools/EpitopePrediction/NewPipeline.pm
@@ -21,7 +21,7 @@ class Genome::Model::Tools::EpitopePrediction::NewPipeline {
             is_many => 1,
         },
         epitope_length => {
-            is => 'Text',
+            is => 'Integer',
             doc => 'Length of subpeptides to predict with NetMHC',
         },
         netmhc_version => {

--- a/lib/perl/Genome/Model/Tools/EpitopePrediction/Pipeline.pm
+++ b/lib/perl/Genome/Model/Tools/EpitopePrediction/Pipeline.pm
@@ -45,7 +45,7 @@ class Genome::Model::Tools::EpitopePrediction::Pipeline {
             is_many => 1,
         },
         epitope_length => {
-            is => 'Text',
+            is => 'Integer',
             doc => 'Length of subpeptides to predict with NetMHC',
         },
         netmhc_version => {

--- a/lib/perl/Genome/Model/Tools/EpitopePrediction/RunNetmhc.pm
+++ b/lib/perl/Genome/Model/Tools/EpitopePrediction/RunNetmhc.pm
@@ -24,7 +24,7 @@ class Genome::Model::Tools::EpitopePrediction::RunNetmhc {
             doc => 'Location of the output',
         },
         epitope_length => {
-            is => 'Text',
+            is => 'Integer',
             doc => 'Length of subpeptides to predict',
         },
         netmhc_version => {

--- a/lib/perl/Genome/Model/Tools/EpitopePrediction/RunNetmhcpan.pm
+++ b/lib/perl/Genome/Model/Tools/EpitopePrediction/RunNetmhcpan.pm
@@ -21,7 +21,7 @@ class Genome::Model::Tools::EpitopePrediction::RunNetmhcpan {
             doc => 'Output file containing raw output from NetmhcPan epitope prediction',
         },
         epitope_length => {
-            is => 'Text',
+            is => 'Integer',
             doc => 'Length of subpeptides to predict',
         },
     ],


### PR DESCRIPTION
Jasreet tried to run the epitope predicition command with epitope_length set to "8,9,10" expecting this to be an is_many property. Because the data type was set to Text she was able to successfully dispatch the workflow but it failed down the line because the underlying tool expects this to be a single integer. Setting the data type to Integer would throw an error if this parameter was set to something like the above.

Down the line we might want to consider making this an is_many property and running this workflow as a parallel by.