### PR TITLE
Revert "restored old quality converter resolution logic: fix on anoth…

### DIFF
--- a/lib/perl/Genome/InstrumentData.t
+++ b/lib/perl/Genome/InstrumentData.t
@@ -41,8 +41,7 @@ for my $platform (keys %seq_plats_and_ids) {
         
         if ( $platform eq 'solexa' ) {
             is($instrument_data->sample_type,'rna','got expected sample type');
-            is($instrument_data->resolve_quality_converter,'sol2sanger','got expected quality converter for ' . $instrument_data->native_qual_type . " this is WRONG FIXME!");
-            #is($instrument_data->resolve_quality_converter,'sol2phred','got expected quality converter for ' . $instrument_data->native_qual_type); # correct
+            is($instrument_data->resolve_quality_converter,'sol2phred','got expected quality converter for ' . $instrument_data->native_qual_type);
         }
     }
 }

--- a/lib/perl/Genome/InstrumentData/Solexa.pm
+++ b/lib/perl/Genome/InstrumentData/Solexa.pm
@@ -1042,14 +1042,6 @@ sub native_qual_type {
     return $analysis_software_versions{$analysis_software_version} || 'sanger';
 }
 
-sub resolve_quality_converter {
-    my $self = shift;
-    if ($self->native_qual_type eq 'illumina') {
-        return "sol2sanger";
-    }
-    return "sol2phred";
-}
-
 sub resolve_import_format {
     my $self = shift;
     if ($self->bam_path) {
@@ -1069,12 +1061,7 @@ sub resolve_import_format {
     }
 }
 
-sub NEW_resolve_quality_converter {
-    # TODO: this is the correct logic but it breaks tests,
-    # implying our tests are wrong.  Investigate and fix.
-    # This mirrors the ::Imported module which does the work correctly.
-    # We almost never use this method in production because we use BAMs
-    # for reads which were always sanger format.
+sub resolve_quality_converter {
     my $self = shift;
     if ($self->native_qual_type eq 'solexa') {
         return "sol2sanger";
@@ -1334,5 +1321,4 @@ sub target_region_set {
 }
 
 1;
-
 


### PR DESCRIPTION
…er commit which is not pure refactoring"

This reverts commit e934176c1a886b61bd4da1730472d91816e92949.

Conflicts:
	lib/perl/Genome/InstrumentData/Solexa.pm
Because someone had later added a method between the two that were originally
split from one.

Thomas figured this would be an easy revert today.  Passed tests.