### PR TITLE
igv session commands work with the build38 used by cancer genomics

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/DumpIgvXml.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/DumpIgvXml.pm
@@ -133,16 +133,22 @@ sub get_levels {
 
 sub determine_genome_build {
   my $self = shift;
-  my $ref_build_name1 = shift;
-  my $genome_build = "";
-  my $b37_build =
-    Genome::Model::Build::ReferenceSequence->get(name => "GRCh37-lite-build37");
-  my $ref_build1 = Genome::Model::Build::ReferenceSequence->get(name => $ref_build_name1);
-  if($b37_build->is_compatible_with($ref_build1)) {
-    return "b37";
+  my $supplied_build_name = shift;
+
+  my $canonical_b37_build = Genome::Model::Build::ReferenceSequence->get(name => "GRCh37-lite-build37");
+  my $canonical_b38_build = Genome::Model::Build::ReferenceSequence->get(name => "GRC-human-build38");
+  my $supplied_build = Genome::Model::Build::ReferenceSequence->get(name => $supplied_build_name);
+  my $igv_named_build = '';
+  if($canonical_b37_build->is_compatible_with($supplied_build)) {
+    $igv_named_build = "b37";
+  } elsif ($canonical_b38_build->is_compatible_with($supplied_build)){
+    $igv_named_build = "hg38";
+  }
+  if ($igv_named_build){
+    return($igv_named_build);
   } else {
     die $self->error_message("Unrecognized reference genome name " .
-      "($ref_build_name1) supplied to DumpIgvXml.pm");
+      "($supplied_build_name) supplied to DumpIgvXml.pm");
   }
 }
 

--- a/lib/perl/Genome/Model/SomaticVariation/Command/DumpIgvXml.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/DumpIgvXml.pm
@@ -181,13 +181,13 @@ sub execute {
     #Hardcoded list of allowed reference builds and their mappings to names used in IGV
     my $genome_build = "";
     my $gene_track_name = "";
-    my $starting_locus = "";
+    my $starting_locus = "12:25398182-25398361";
     if ($reference_genome_name eq 'GRCh37-lite-build37'){
       $genome_build = "b37";
-      $starting_locus = "12:25398182-25398361";
     }elsif($reference_genome_name eq 'UCSC-mouse-buildmm9'){
       $genome_build = "mm9";
-      $starting_locus = "12:25398182-25398361";
+    }elsif($reference_genome_name eq 'GRC-human-build38'){
+      $genome_build = "hg38";
     }else{
       $self->error_message("Unrecognized reference genome name ($reference_genome_name) supplied to DumpIgvXml.pm");
       return;
@@ -271,11 +271,6 @@ sub execute {
       my $outfile = IO::File->new(">$outfile_name");
       $outfile->print($final_xml);
     }
-
-
-
-
-
 
     #Copy any review files specified to new output build dir
     if ($self->review_files){


### PR DESCRIPTION
We are trying to make everything up to an including clin-seq builds work on either build37 or build38. This PR fixes two places where a build name translation needs to happen for automatic creation of an IGV session for a single tumor/case/patient.