### PR TITLE
Grch38 support for alts (experimental)

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/ReliesOnBwa.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/ReliesOnBwa.pm
@@ -23,7 +23,7 @@ sub prepare_reference_sequence_index {
 
     Genome::Sys->create_symlink($refindex->reference_build->get_sequence_dictionary('sam'), File::Spec->join($staging_dir, 'all_sequences.dict'));
 
-    if (-e File::Spec->join($staging_dir, 'all_sequences.fa.alt')) {
+    if (-e $refindex->reference_build->full_consensus_path('fa.alt')) {
         # An alt file exists so BWA-mem post 0.7.11 can perform alt-aware mapping
         Genome::Sys->create_symlink($refindex->reference_build->full_consensus_path('fa.alt'), File::Spec->join($staging_dir, 'all_sequences.fa.alt'));
     }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/ReliesOnBwa.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/ReliesOnBwa.pm
@@ -23,6 +23,11 @@ sub prepare_reference_sequence_index {
 
     Genome::Sys->create_symlink($refindex->reference_build->get_sequence_dictionary('sam'), File::Spec->join($staging_dir, 'all_sequences.dict'));
 
+    if (-e File::Spec->join($staging_dir, 'all_sequences.fa.alt')) {
+        # An alt file exists so BWA-mem post 0.7.11 can perform alt-aware mapping
+        Genome::Sys->create_symlink($refindex->reference_build->full_consensus_path('fa.alt'), File::Spec->join($staging_dir, 'all_sequences.fa.alt'));
+    }
+
     my $users = $refindex->_user_data_for_nested_results;
     $users->{uses} = $refindex;
     my $bwa_index = Genome::Model::Build::ReferenceSequence::AlignerIndex->get_or_create(
@@ -37,6 +42,7 @@ sub prepare_reference_sequence_index {
         my $filename = File::Basename::fileparse($filepath);
         next if $filename eq 'all_sequences.fa';
         next if $filename eq 'all_sequences.dict';
+        next if $filename eq 'all_sequences.fa.alt';
         Genome::Sys->create_symlink($filepath, File::Spec->join($staging_dir, $filename));
     }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.pm
@@ -177,6 +177,7 @@ sub bwa_version {
         'test' => '0.7.10',
         '0.0.3a-gms' => '0.7.10',
         '0.1.0-gms' => '0.7.10',
+        '0.1.1-gms-test' => '0.7.12', #hacky version where the only difference from 0.1.1 is that bwa is upgraded to 0.7.12
     );
     my $bwa_version = $speedseq_version_to_bwa_version{$speedseq_version};
     unless ($bwa_version) {

--- a/lib/perl/Genome/Model/Tools/Speedseq/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Speedseq/Base.pm
@@ -62,6 +62,7 @@ my %TOOL_VERSIONS = (
     'test'     => '/gscmnt/sata849/info/speedseq_freeze/v1/speedseq/bin/speedseq',
     '0.0.3a-gms' => '/gscmnt/sata849/info/speedseq_freeze/v2/speedseq/bin/speedseq',
     '0.1.0-gms' => '/gscmnt/sata849/info/speedseq_freeze/v3/speedseq/bin/speedseq',
+    '0.1.1-gms-test' => '/gscmnt/sata849/info/speedseq_testing/v0.1.1-gms-testing/speedseq/bin/speedseq',
 );
 
 sub available_versions {


### PR DESCRIPTION
These are small changes in and around aligning to the alts using BWA mem. I added a test speedseq version that utilizes a newer version of Sambamba and BWA so that we can align to both the primary reference and the alts for Build38. This requires a minimum BWA version of 0.7.11 and an additional file (provided for specific references in bwakit). I added this extra file to reference sequence 8741b5363c634ee19fad676157a132de. The test version of speedseq uses BWA mem 0.7.12. See https://github.com/lh3/bwa/blob/master/README-alt.md for more information on BWA behavior and requirements.

This may not be how we want to proceed, but I wanted to put this forwards so that we could discuss the proper way to proceed. We have been testing in CCDG informatics using these changes and the alignments appear to be working as intended.