### PR TITLE
Get E-Mail Address from User Object

### DIFF
--- a/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CompareSnpsBuildLanes.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CompareSnpsBuildLanes.pm
@@ -36,7 +36,7 @@ sub execute {
     my $self=shift;
     my $build_id = "";
     my $dir = $self->analysis_dir;
-    my $user = getlogin || getpwuid($<); #get current user name
+    my $user = Genome::Sys->current_user;
     my $sample_name ="";
     my $genotype_file ="";	 
     my $wgs_model_id = $self->model_id;
@@ -123,7 +123,8 @@ sub execute {
 
 # find reference sequences
     my $reference_file=$model->reference_sequence_build->full_consensus_path('fa') ;
-    print "reference: $reference_file User: $user\n";
+    my $username = $user->username;
+    print "reference: $reference_file User: $username\n";
     for my $data (@instrument_data) {
         my @alignments = $build->alignment_results_for_instrument_data($data);
         for my $alignment (@alignments) {
@@ -143,8 +144,8 @@ sub execute {
 samtools pileup -vc -f $reference_file $alignment_file | perl -pe '\@F = split /\\t/; \\\$_=q{} unless(\\\$F[7] > 2);' > $dir/$lane_name.var
 gmt analysis lane-qc compare-snps --genotype-file $genotype_file --variant-file $dir/$lane_name.var > $dir/$lane_name.var.compare_snps
 COMMANDS
-                my $email_domain = Genome::Config::get('email_domain');
-                print `bsub -N -u $user\@$email_domain "$command"`;
+                my $email = $user->email;
+                print `bsub -N -u $email "$command"`;
             }else{
                 $self->error_message("No alignment object for $lane_name");
                 return;

--- a/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CopyNumber.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/LaneQc/CopyNumber.pm
@@ -102,7 +102,7 @@ sub execute {
                 return;
             }
 
-            my $user = Genome::Sys->username;
+            my $user = Genome::Sys->current_user;
 
             my $lane_outfile = $outfile_prefix . $alignment_id . ".cnqc";
 
@@ -122,13 +122,13 @@ sub execute {
 
             my $rv;
             if ($self->lsf) {
-                my $email_domain = Genome::Config::get('email_domain');
-                $rv = system("bsub -N -u $user\@$email_domain -J $job1_name \"$cmd1\"");
+                my $email = $user->email;
+                $rv = system("bsub -N -u $email -J $job1_name \"$cmd1\"");
                 if ($rv) {
                     $self->error_message("Failed to bsub $job1_name");
                     return;
                 }
-                $rv = system("bsub -N -u $user\@$email_domain -J $job2_name -w \"$dependency\" \"$cmd2\"");
+                $rv = system("bsub -N -u $email -J $job2_name -w \"$dependency\" \"$cmd2\"");
                 if ($rv) {
                     $self->error_message("Failed to bsub $job2_name");
                     return;

--- a/lib/perl/Genome/Model/Tools/Analysis/LaneQc/EntireBuild.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/LaneQc/EntireBuild.pm
@@ -95,14 +95,14 @@ sub execute {
                 return;
             }
             my $dir = $self->analysis_dir;
-            my $user = Genome::Sys->username;
+            my $user = Genome::Sys->current_user;
             if(-z "$dir/$lane_name.var" || !-e "$dir/$lane_name.var") {
                 my $command .= <<"COMMANDS";
 samtools pileup -vc -f $reference $alignment_file | perl -pe '\@F = split /\\t/; \\\$_=q{} unless(\\\$F[7] > 2);' > $dir/$lane_name.var
 gmt analysis lane-qc compare-snps --genotype-file $genotype_file --variant-file $dir/$lane_name.var > $dir/$lane_name.var.compare_snps
 COMMANDS
-                my $email_domain = Genome::Config::get('email_domain');
-                print `bsub -N -u $user\@$email_domain "$command"`;
+                my $email = $user->email;
+                print `bsub -N -u $email "$command"`;
                 #print $command,"\n";
             }
         }

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -428,7 +428,8 @@ This is the last warning you will receive about this process.
 MESSAGE
 
                 undef $w;
-                my $from = '"' . __PACKAGE__ . sprintf('" <%s@%s>', Genome::Sys->username, Genome::Config::get('email_domain'));
+                my $user = Genome::Sys->current_user;
+                my $from = '"' . __PACKAGE__ . sprintf('" <%s>', $user->email);
 
                 my @to = map { Genome::Utility::Email::construct_address($_) }
                             split(' ', $self->_monitor_mail_to);

--- a/lib/perl/Genome/Model/Tools/Varscan/PullOneTwoBpIndels.pm
+++ b/lib/perl/Genome/Model/Tools/Varscan/PullOneTwoBpIndels.pm
@@ -376,21 +376,21 @@ sub execute {
 
     # put several jobs into array @cmds
     my @cmds;
-    my $user = $ENV{USER};
-    my $email_domain = Genome::Config::get('email_domain');
+    my $user = Genome::Sys->current_user;
+    my $email = $user->email;
     if ($skip_if_output_present && -e $realigned_normal_bam_file && -e $realigned_tumor_bam_file) {
         if ($self->relapse_bam){
             push(@cmds,"$bsub -J varscan_validation_tumnor \'gmt varscan validation --normal-bam $realigned_normal_bam_file --tumor-bam $realigned_tumor_bam_file --output-indel $output_indel.tumnor --output-snp $output_snp.tumnor --reference $reference --varscan-params \"$varscan_params\"\'");
             push(@cmds, "$bsub -J varscan_validation_relnor \'gmt varscan validation --normal-bam $realigned_normal_bam_file --tumor-bam $realigned_relapse_bam_file --output-indel $output_indel.relnor --output-snp $output_snp.relnor --reference $reference --varscan-params \"$varscan_params\"\'");
             push(@cmds,"$bsub -J varscan_validation_reltum \'gmt varscan validation --normal-bam $realigned_tumor_bam_file --tumor-bam $realigned_relapse_bam_file --output-indel $output_indel.reltum --output-snp $output_snp.reltum --reference $reference --varscan-params \"$varscan_params\"\'");
-            push(@cmds,"$bsub -N -u $user\@$email_domain -J varscan_process_validation_tumnor -w \'ended(JOB0))\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.tumnor --validation-snp-file $output_snp.tumnor --variants-file $small_indel_list_nobed --output-file $final_output_file.tumnor\'");
-            push(@cmds,"$bsub -N -u $user\@$email_domain -J varscan_process_validation_relnor -w \'ended(JOB1)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.relnor --validation-snp-file $output_snp.relnor --variants-file $small_indel_list_nobed --output-file $final_output_file.relnor\'");
-            push(@cmds,"$bsub -N -u $user\@$email_domain -J varscan_process_validation_reltum -w \'ended(JOB2)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.reltum --validation-snp-file $output_snp.reltum --variants-file $small_indel_list_nobed --output-file $final_output_file.reltum\'");
+            push(@cmds,"$bsub -N -u $email -J varscan_process_validation_tumnor -w \'ended(JOB0))\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.tumnor --validation-snp-file $output_snp.tumnor --variants-file $small_indel_list_nobed --output-file $final_output_file.tumnor\'");
+            push(@cmds,"$bsub -N -u $email -J varscan_process_validation_relnor -w \'ended(JOB1)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.relnor --validation-snp-file $output_snp.relnor --variants-file $small_indel_list_nobed --output-file $final_output_file.relnor\'");
+            push(@cmds,"$bsub -N -u $email -J varscan_process_validation_reltum -w \'ended(JOB2)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.reltum --validation-snp-file $output_snp.reltum --variants-file $small_indel_list_nobed --output-file $final_output_file.reltum\'");
         }
         else {
             push(@cmds,"$bsub -J varscan_validation \'gmt varscan validation --normal-bam $realigned_normal_bam_file --tumor-bam $realigned_tumor_bam_file --output-indel $output_indel --output-snp $output_snp --reference $reference --varscan-params \"$varscan_params\"\'");
 
-            push(@cmds,"$bsub -N -u $user\@$email_domain -J varscan_process_validation -w \'ended(JOB0)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel --validation-snp-file $output_snp --variants-file $small_indel_list_nobed --output-file $final_output_file\'");
+            push(@cmds,"$bsub -N -u $email -J varscan_process_validation -w \'ended(JOB0)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel --validation-snp-file $output_snp --variants-file $small_indel_list_nobed --output-file $final_output_file\'");
         }
     }
     elsif ($self->relapse_bam) {
@@ -414,9 +414,9 @@ sub execute {
         push(@cmds,"$bsub -J varscan_validation_relnor -w \'ended(JOB3) && ended(JOB5)\' \'gmt varscan validation --normal-bam $realigned_normal_bam_file --tumor-bam $realigned_relapse_bam_file --output-indel $output_indel.relnor --output-snp $output_snp.relnor --reference $reference --varscan-params \"$default_varscan_params\"\'");
         push(@cmds,"$bsub -J varscan_validation_reltum -w \'ended(JOB4) && ended(JOB5)\' \'gmt varscan validation --normal-bam $realigned_tumor_bam_file --tumor-bam $realigned_relapse_bam_file --output-indel $output_indel.reltum --output-snp $output_snp.reltum --reference $reference --varscan-params \"$default_varscan_params\"\'");
 
-        push(@cmds,"$bsub -N -u $user\@$email_domain -J varscan_process_validation_tumnor -w \'ended(JOB6)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.tumnor --validation-snp-file $output_snp.tumnor --variants-file $small_indel_list_nobed --output-file $final_output_file.tumnor\'");
-        push(@cmds,"$bsub -N -u $user\@$email_domain -J varscan_process_validation_relnor -w \'ended(JOB7)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.relnor --validation-snp-file $output_snp.relnor --variants-file $small_indel_list_nobed --output-file $final_output_file.relnor\'");
-        push(@cmds,"$bsub -N -u $user\@$email_domain -J varscan_process_validation_reltum -w \'ended(JOB8)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.reltum --validation-snp-file $output_snp.reltum --variants-file $small_indel_list_nobed --output-file $final_output_file.reltum\'");
+        push(@cmds,"$bsub -N -u $email -J varscan_process_validation_tumnor -w \'ended(JOB6)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.tumnor --validation-snp-file $output_snp.tumnor --variants-file $small_indel_list_nobed --output-file $final_output_file.tumnor\'");
+        push(@cmds,"$bsub -N -u $email -J varscan_process_validation_relnor -w \'ended(JOB7)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.relnor --validation-snp-file $output_snp.relnor --variants-file $small_indel_list_nobed --output-file $final_output_file.relnor\'");
+        push(@cmds,"$bsub -N -u $email -J varscan_process_validation_reltum -w \'ended(JOB8)\' \'gmt varscan process-validation-indels --validation-indel-file $output_indel.reltum --validation-snp-file $output_snp.reltum --variants-file $small_indel_list_nobed --output-file $final_output_file.reltum\'");
     }
     else{
         if (-z $small_indel_list) {

--- a/lib/perl/Genome/Utility/Email.pm
+++ b/lib/perl/Genome/Utility/Email.pm
@@ -92,10 +92,14 @@ sub _validate_attachment {
 }
 
 sub construct_address {
-    my $user = shift;
-    $user = defined($user) ? $user : $ENV{USER};
+    my $username = shift;
 
-    return join('@', $user, Genome::Config::get('email_domain'));
+    my $user = defined($username)?
+        Genome::Sys::User->get(username => $username) :
+        Genome::Sys->current_user;
+
+
+    return $user->email;
 }
 
 1;

--- a/lib/perl/Genome/Utility/Email.t
+++ b/lib/perl/Genome/Utility/Email.t
@@ -21,7 +21,7 @@ use Genome::Utility::Email;
 }
 
 {
-    my $someone_else = Genome::Sys::User->create(
+    my $someone_else = Genome::Sys::User->__define__(
         username => join('-', 'fake', Genome::Sys->username, time()),
         email => join('@', 'fake-test-email', Genome::Config::get('email_domain')),
     );

--- a/lib/perl/Genome/Utility/Email.t
+++ b/lib/perl/Genome/Utility/Email.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
 use above "Genome";
 
 use Test::More tests => 2;
@@ -10,15 +14,18 @@ use Test::More tests => 2;
 use Genome::Utility::Email;
 
 {
+    my $me = Genome::Sys->current_user;
     my $addr = Genome::Utility::Email::construct_address();
-    my $expected = sprintf('%s@%s', $ENV{USER}, Genome::Config::get('email_domain'));
+    my $expected = $me->email;
     is($addr, $expected, 'construct_address with no params');
 }
 
 {
-    my $name = 'bob';
-    $name++ while ($name eq $ENV{USER});
-    my $addr = Genome::Utility::Email::construct_address($name);
-    my $expected = sprintf('%s@%s', $name, Genome::Config::get('email_domain'));
+    my $someone_else = Genome::Sys::User->create(
+        username => join('-', 'fake', Genome::Sys->username, time()),
+        email => join('@', 'fake-test-email', Genome::Config::get('email_domain')),
+    );
+    my $addr = Genome::Utility::Email::construct_address($someone_else->username);
+    my $expected = $someone_else->email;
     is($addr, $expected, 'construct_address given a name');
 }


### PR DESCRIPTION
Since we now have users spanning multiple domains with possibly inconsistent usernames, we can't assume the `username` plus the configured `email_domain` equals the desired address.