### PR TITLE
Add a base for the SSG command tree.

### DIFF
--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command.pm
@@ -1,0 +1,16 @@
+package Genome::Model::SingleSampleGenotype::Command;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::SingleSampleGenotype::Command {
+    is => 'Command::Tree',
+    doc => 'operate on single-sample-genotype models and builds',
+};
+
+sub sub_command_category { 'type specific' }
+
+1;
+


### PR DESCRIPTION
This should fix tab-completion and the commands showing up in `genome model --help`.