### PR TITLE
Production No Longer Hardcoded to "apipe-builder".

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
@@ -100,7 +100,7 @@ sub _resolve_properties_for_environment {
         }
         when ('production') {
             return (
-                run_as => 'apipe-builder',
+                run_as => 'prod-builder',
                 is_cle => 0,
             );
         }

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -854,8 +854,7 @@ sub default_model_name {
 
     my $name = ($self->subject->name).'.';
 
-    my $run_as_user = Genome::Sys::User->get(username => $self->run_as);
-    $name .= 'prod-' if (($run_as_user && $run_as_user->has_role_by_name('production')) || $params{prod});
+    $name .= 'prod-' if (Genome::Sys->user_has_role($self->run_as, 'production') || $params{prod});
 
     my $type_name = $self->processing_profile->type_name;
     my %short_names = (

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -853,7 +853,9 @@ sub default_model_name {
     my ($self, %params) = @_;
 
     my $name = ($self->subject->name).'.';
-    $name .= 'prod-' if (($self->run_as && $self->run_as eq 'apipe-builder') || $params{prod});
+
+    my $run_as_user = Genome::Sys::User->get(username => $self->run_as);
+    $name .= 'prod-' if (($run_as_user && $run_as_user->has_role_by_name('production')) || $params{prod});
 
     my $type_name = $self->processing_profile->type_name;
     my %short_names = (

--- a/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FailedModelTickets.pm
@@ -56,13 +56,17 @@ sub execute {
 sub get_builds {
     my $self = shift;
 
+    my $production_role = Genome::Sys::User::Role->get(name => 'production');
+    my @prod_users = $production_role->users;
+    my @usernames = map $_->username, @prod_users;
+
     # Find cron models by failed build events
     my @builds;
     if ($self->include_failed) {
         $self->status_message('Looking for failed builds...');
         @builds = Genome::Model::Build->get(
             status => 'Failed',
-            run_by => 'apipe-builder',
+            'model.run_as' => \@usernames,
         );
     }
 
@@ -71,7 +75,7 @@ sub get_builds {
         $self->status_message('Looking for unstartable builds...');
         my @unstartable_builds = Genome::Model::Build->get(
             status => 'Unstartable',
-            run_by => 'apipe-builder',
+            'model.run_as' => \@usernames,
         );
         @builds = (@builds, @unstartable_builds);
     }

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -73,7 +73,8 @@ sub execute {
         }
 
         my $max_running = $self->running_max;
-        if($run_as eq 'apipe-builder') {
+        my $run_as_user = Genome::Sys::User->get(username => $run_as);
+        if($run_as_user->has_role_by_name('production')) {
             $max_running *= 5;
         }
         my $running_count = $scheduled_count + builds_for($run_as, 'Running');

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -73,8 +73,7 @@ sub execute {
         }
 
         my $max_running = $self->running_max;
-        my $run_as_user = Genome::Sys::User->get(username => $run_as);
-        if($run_as_user->has_role_by_name('production')) {
+        if(Genome::Sys->user_has_role($run_as, 'production')) {
             $max_running *= 5;
         }
         my $running_count = $scheduled_count + builds_for($run_as, 'Running');

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -266,7 +266,8 @@ sub check_and_update_genotype_input {
     return 1 unless $default_genotype_model;
 
     if (defined $self->genotype_microarray_model_id and $self->genotype_microarray_model_id ne $default_genotype_model->id) {
-        if (defined $self->run_as and $self->run_as eq 'apipe-builder') {
+        my $run_as_user = Genome::Sys::User->get(username => $self->run_as);
+        if($run_as_user && $run_as_user->has_role_by_name('production')) {
             $self->warning_message("Sample " . $self->subject_id . " points to genotype model " . $default_genotype_model->id .
                 ", which disagrees with the genotype model input of this model (" . $self->genotype_microarray_model_id .
                 "), overwriting!");

--- a/lib/perl/Genome/Model/ReferenceAlignment.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment.pm
@@ -266,8 +266,7 @@ sub check_and_update_genotype_input {
     return 1 unless $default_genotype_model;
 
     if (defined $self->genotype_microarray_model_id and $self->genotype_microarray_model_id ne $default_genotype_model->id) {
-        my $run_as_user = Genome::Sys::User->get(username => $self->run_as);
-        if($run_as_user && $run_as_user->has_role_by_name('production')) {
+        if(Genome::Sys->user_has_role($self->run_as, 'production')) {
             $self->warning_message("Sample " . $self->subject_id . " points to genotype model " . $default_genotype_model->id .
                 ", which disagrees with the genotype model input of this model (" . $self->genotype_microarray_model_id .
                 "), overwriting!");

--- a/lib/perl/Genome/Model/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation.pm
@@ -368,8 +368,7 @@ sub default_model_name {
         push @parts, $self->subject->name;
     }
 
-    my $run_as_user = Genome::Sys::User->get(username => $self->run_as);
-    if($run_as_user && $run_as_user->has_role_by_name('production')) {
+    if(Genome::Sys->user_has_role($self->run_as, 'production')) {
         push @parts, 'prod-somatic_validation';
     } else {
         push @parts, 'somatic_validation';

--- a/lib/perl/Genome/Model/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation.pm
@@ -368,7 +368,8 @@ sub default_model_name {
         push @parts, $self->subject->name;
     }
 
-    if($self->run_as && $self->run_as eq 'apipe-builder') {
+    my $run_as_user = Genome::Sys::User->get(username => $self->run_as);
+    if($run_as_user && $run_as_user->has_role_by_name('production')) {
         push @parts, 'prod-somatic_validation';
     } else {
         push @parts, 'somatic_validation';

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1396,6 +1396,20 @@ sub current_user_is_admin {
 sub current_user_has_role {
     my ($class, $role_name) = @_;
     my $user = $class->current_user;
+
+    return $class->_user_has_role($user, $role_name);
+}
+
+sub user_has_role {
+    my ($class, $username, $role_name) = @_;
+    my $user = Genome::Sys::User->get(username => $username);
+
+    return $class->_user_has_role($user, $role_name);
+}
+
+sub _user_has_role {
+    my ($class, $user, $role_name) = @_;
+
     return 0 unless $user;
     return $user->has_role_by_name($role_name);
 }

--- a/lib/perl/Genome/Sys.t
+++ b/lib/perl/Genome/Sys.t
@@ -77,6 +77,30 @@ subtest change_rollback_removes_symlink_for_create_symlink_and_log_change => sub
     return 1;
 };
 
+subtest 'user roles' => sub {
+    plan tests => 4;
+
+    my $test_user = Genome::Sys::User->__define__(
+        username => 'user-for-testing-Sys.t',
+        email => join('@', 'testing-for-Sys.t', Genome::Config::get('email_domain')),
+    );
+    my $current_user = Genome::Sys->current_user;
+
+    my $test_role = Genome::Sys::User::Role->__define__( name => 'role-for-testing-Sys.t' );
+    Genome::Sys::User::RoleMember->__define__(role => $test_role, user => $test_user);
+    Genome::Sys::User::RoleMember->__define__(role => $test_role, user => $current_user);
+
+    my $other_test_role = Genome::Sys::User::Role->__define__( name => 'another-role-for-testing-Sys.t' );
+
+    for my $user ($test_user, $current_user) {
+        ok(Genome::Sys->user_has_role($user->username, $test_role->name), 'user has role');
+        ok(
+            !Genome::Sys->user_has_role($user->username, $other_test_role->name),
+            'user does not have another role'
+        );
+    }
+};
+
 subtest test_sudo_username => sub {
     plan tests => 4;
 
@@ -292,6 +316,7 @@ subtest create_symlink => sub {
             qr($expected_error),
             'symlink() failing throws an exception';
     };
+
 };
 
 done_testing();


### PR DESCRIPTION
Now there's a `Genome::Sys::User::Role` named `production` when deciding to act.

* The default user for new `production` projects has been changed to `prod-builder`.
* `apipe-builder` remains the user with the power to manipulate others' builds.
* The old heuristic for LIMS to find non-project-based data (in `Genome::InstrumentData::Solexa`) is explicitly not being updated.