### PR TITLE
ReferenceAlignment makes one BAM regardless of mixed sample assignment.

### DIFF
--- a/lib/perl/Genome/Model/ReferenceAlignment/Command/AlignReads.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Command/AlignReads.pm
@@ -44,6 +44,7 @@ sub execute {
         strategy => $strategy,
         log_directory => $build->log_directory,
         result_users => Genome::SoftwareResult::User->user_hash_for_build($build),
+        merge_group => 'all', #RefAlign should always produce one BAM regardless of data assignment
     );
 
     my @bams = $composite->bam_paths;


### PR DESCRIPTION
This fixes a regression found by the `refalign-germline-short` model test.

ReferenceAlignment should produce a single BAM regardless of how many different samples the instrument data came from.