### PR TITLE
SingleSampleGenotype Can Be Checked Out; Uses Said Checkout for Diffs

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -810,6 +810,26 @@ sub all_results {
     return uniq @results, @ancestors;
 }
 
+sub symlink_results {
+    my $self = shift;
+    my $destination = shift;
+
+    Genome::Sys->validate_directory_for_read_write_access($destination);
+
+    my $dir = $self->_symlink_results($destination);
+    $self->status_message('Results for build %s symlinked to %s', $self->__display_name__, $dir);
+
+    return $dir;
+}
+
+sub _symlink_results {
+    my $self = shift;
+    my $destination = shift;
+
+    #override in subclasses that implement this feature
+    $self->fatal_message('Symlinking results is unavailable for builds of type "%s"', $self->type_name);
+}
+
 
 sub symlinked_allocations {
     my $self = shift;

--- a/lib/perl/Genome/Model/Build/Command/SymlinkResults.pm
+++ b/lib/perl/Genome/Model/Build/Command/SymlinkResults.pm
@@ -7,7 +7,7 @@ use Genome;
 
 class Genome::Model::Build::Command::SymlinkResults {
     is => ['Command::V2'],
-    has => [
+    has_input => [
         build => {
             is => 'Genome::Model::Build',
             shell_args_position => 1,
@@ -18,6 +18,12 @@ class Genome::Model::Build::Command::SymlinkResults {
             shell_args_position => 2,
             doc => 'The desired location under which to make a directory of symlink(s)',
         }
+    ],
+    has_transient_output => [
+        output_directory => {
+            is => 'DirectoryPath',
+            doc => 'The directory of symlinks that was created',
+        },
     ],
     doc => 'Creates symlinks to the results of a build.',
 };
@@ -35,14 +41,8 @@ sub execute {
     my $build = $self->build;
     my $destination = $self->destination;
 
-    Genome::Sys->validate_directory_for_read_write_access($destination);
-
-    unless($build->can('symlink_results')) {
-        $self->fatal_message('Symlinking results is unavailable for builds of type "%s"', $build->type_name);
-    }
-
     my $dir = $build->symlink_results($destination);
-    $self->status_message('Results for build %s symlinked to %s', $build->__display_name__, $dir);
+    $self->output_directory($dir);
 
     return 1;
 }

--- a/lib/perl/Genome/Model/Build/Command/SymlinkResults.pm
+++ b/lib/perl/Genome/Model/Build/Command/SymlinkResults.pm
@@ -1,0 +1,50 @@
+package Genome::Model::Build::Command::SymlinkResults;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::Build::Command::SymlinkResults {
+    is => ['Command::V2'],
+    has => [
+        build => {
+            is => 'Genome::Model::Build',
+            shell_args_position => 1,
+            doc => "The builds that has results you'd like to create symlinks to",
+        },
+        destination => {
+            is => 'DirectoryPath',
+            shell_args_position => 2,
+            doc => 'The desired location under which to make a directory of symlink(s)',
+        }
+    ],
+    doc => 'Creates symlinks to the results of a build.',
+};
+
+sub help_detail {
+    my $self = shift;
+    return <<EOP;
+Creates symlinks to the results of a build.  The <destination> option should
+be an existing directory.
+EOP
+}
+
+sub execute {
+    my $self = shift;
+    my $build = $self->build;
+    my $destination = $self->destination;
+
+    Genome::Sys->validate_directory_for_read_write_access($destination);
+
+    unless($build->can('symlink_results')) {
+        $self->fatal_message('Symlinking results is unavailable for builds of type "%s"', $build->type_name);
+    }
+
+    my $dir = $build->symlink_results($destination);
+    $self->status_message('Results for build %s symlinked to %s', $build->__display_name__, $dir);
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/Build/Command/SymlinkResults_SingleSampleGenotype.t
+++ b/lib/perl/Genome/Model/Build/Command/SymlinkResults_SingleSampleGenotype.t
@@ -1,0 +1,96 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+
+use Genome::Test::Factory::Build;
+use Genome::Test::Factory::Model::SingleSampleGenotype;
+
+use File::Spec;
+use Test::More tests => 8;
+
+my $class = 'Genome::Model::Build::Command::SymlinkResults';
+
+use_ok($class, 'the class can be used');
+
+my $build = setup_build();
+my $destination = Genome::Sys->create_temp_directory();
+
+my $cmd = $class->create(
+    build => $build,
+    destination => $destination,
+);
+isa_ok($cmd, $class, 'created a command');
+ok($cmd->execute, 'command runs successfully');
+
+my @destination_contents = glob(File::Spec->join($destination, '*'));
+is(scalar(@destination_contents), 1, 'found a directory for the build');
+
+my @build_contents = glob(File::Spec->join($destination_contents[0], '*'));
+is(scalar(@build_contents), 3, 'created a directory for each type of results');
+my $symlink_count = grep { -l $_ } @build_contents;
+is($symlink_count, 2, 'found expected symlinks');
+my ($dir) = grep { !-l $_ } @build_contents;
+ok(-d $dir, 'found directory for HC results');
+
+my @hc_contents = glob(File::Spec->join($dir, '*'));
+my @intervals = test_intervals();
+is(scalar(@hc_contents), scalar(@intervals), 'found expected number of HC results');
+
+
+sub test_intervals {
+    return (1..3, 'X', 'GL2000.1');
+}
+
+sub setup_build {
+    my $test_model = Genome::Test::Factory::Model::SingleSampleGenotype->setup_object;
+    my $test_build = Genome::Test::Factory::Build->setup_object(model_id => $test_model->id);
+
+    my $id = -1;
+
+    my $ss_result = Genome::InstrumentData::AlignmentResult::Merged::Speedseq->__define__(
+        output_dir => Genome::Sys->create_temp_directory(),
+        id => $id--,
+    );
+    Genome::SoftwareResult::User->create(
+        software_result => $ss_result,
+        user => $test_build,
+        label => 'merged_alignment_result',
+    );
+
+    my $qc_result = Genome::Qc::Result->__define__(
+        output_dir => Genome::Sys->create_temp_directory(),
+        id => $id--,
+    );
+    Genome::SoftwareResult::User->create(
+        software_result => $qc_result,
+        user => $test_build,
+        label => 'qc_result',
+    );
+
+    for my $interval (test_intervals()) {
+        my $hc_result = Genome::Model::SingleSampleGenotype::Result::HaplotypeCaller->__define__(
+            output_dir => Genome::Sys->create_temp_directory(),
+            id => $id--,
+        );
+        $hc_result->add_input(name => 'intervals-0', value_id => $interval);
+        Genome::SoftwareResult::User->create(
+            software_result => $hc_result,
+            user => $test_build,
+            label => 'haplotype_caller_result',
+        );
+    }
+
+    return $test_build;
+}
+
+
+
+
+

--- a/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
+++ b/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
@@ -102,4 +102,19 @@ sub symlink_results {
     return $top_directory;
 }
 
+sub _compare_output_files {
+    my ($self, $other_build) = @_;
+
+    my $temp = Genome::Sys->create_temp_directory();
+    my $directory = $self->symlink_results($temp);
+    my $other_directory = $other_build->symlink_results($temp);
+
+    return $self->_compare_output_directories(
+        $directory,
+        $other_directory,
+        $self->id,
+        $other_build->id,
+    );
+}
+
 1;

--- a/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
+++ b/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
@@ -81,12 +81,29 @@ sub _symlink_results {
     Genome::Sys->create_directory($top_directory);
 
     my $alignment = $self->merged_alignment_result;
-    my $alignment_dir = File::Spec->join($top_directory, 'alignments');
-    Genome::Sys->create_symlink($alignment->output_dir, $alignment_dir);
+    $self->_symlink_result($alignment, $top_directory, 'alignments');
 
     my $qc = $self->qc_result;
-    my $qc_dir = File::Spec->join($top_directory, 'qc');
-    Genome::Sys->create_symlink($qc->output_dir, $qc_dir);
+    $self->_symlink_result($qc, $top_directory, 'qc');
+
+    $self->_symlink_haplotype_caller_results($top_directory);
+
+    return $top_directory;
+}
+
+sub _symlink_result {
+    my $self = shift;
+    my $result = shift;
+    my $location = shift;
+    my $symlink_name = shift;
+
+    my $symlink_location = File::Spec->join($location, $symlink_name);
+    Genome::Sys->create_symlink($result->output_dir, $symlink_location);
+}
+
+sub _symlink_haplotype_caller_results {
+    my $self = shift;
+    my $top_directory = shift;
 
     my $variant_dir = File::Spec->join($top_directory, 'variants');
     Genome::Sys->create_directory($variant_dir);
@@ -95,11 +112,10 @@ sub _symlink_results {
         my $hc_basename = Genome::Utility::Text::sanitize_string_for_filesystem(
             join('-', $hc_result->intervals, $hc_result->id)
         );
-        my $hc_dir = File::Spec->join($variant_dir, $hc_basename);
-        Genome::Sys->create_symlink($hc_result->output_dir, $hc_dir);
+        $self->_symlink_result($hc_result, $variant_dir, $hc_basename);
     }
 
-    return $top_directory;
+    return $variant_dir;
 }
 
 sub _compare_output_files {

--- a/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
+++ b/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
@@ -73,7 +73,7 @@ sub reference_being_replaced_for_input {
     return;
 }
 
-sub symlink_results {
+sub _symlink_results {
     my $self = shift;
     my $destination = shift;
 

--- a/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
+++ b/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
@@ -93,7 +93,7 @@ sub symlink_results {
 
     for my $hc_result ($self->haplotype_caller_result) {
         my $hc_basename = Genome::Utility::Text::sanitize_string_for_filesystem(
-            join('-', $hc_result->id, $hc_result->intervals)
+            join('-', $hc_result->intervals, $hc_result->id)
         );
         my $hc_dir = File::Spec->join($variant_dir, $hc_basename);
         Genome::Sys->create_symlink($hc_result->output_dir, $hc_dir);


### PR DESCRIPTION
* New command `genome model build symlink-results` (like `genome process symlink-results`) to create a build-directory like structure of results for a build...currently only implemented for SSG.
* SSG uses one of these build-directory like checkouts to do its diff-ing, since the diff logic is primarily based on directories of results.

(This PR is offered as an alternative to #1288.)