### PR TITLE
BamQC should only check instrument data for the result it will run on.

### DIFF
--- a/lib/perl/Genome/Model/ReferenceAlignment/Command/BamQc.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Command/BamQc.pm
@@ -65,12 +65,13 @@ sub params_for_result {
     my $self  = shift;
     my $build = $self->build;
     my $pp    = $build->processing_profile;
+    my $alignment_result = $self->alignment_result;
 
     my $result_users = Genome::SoftwareResult::User->user_hash_for_build($build);
     my $picard_version = $self->_select_picard_version($pp->picard_version);
 
 
-    my $instr_data  = $build->instrument_data;
+    my $instr_data  = $alignment_result->instrument_data;
     #read length takes long time to run and seems not useful for illumina/solexa data
     my $read_length = $instr_data->sequencing_platform =~ /^solexa$/i ? 0 : 1;
 
@@ -79,7 +80,7 @@ sub params_for_result {
     $result_users->{uses} = $build;
 
     return (
-        alignment_result_id => $self->alignment_result->id,
+        alignment_result_id => $alignment_result->id,
         picard_version      => $picard_version,
         samtools_version    => $pp->samtools_version,
         fastqc_version      => Genome::Model::Tools::Fastqc->default_fastqc_version,


### PR DESCRIPTION
This fixes a bug I introduced in #1270 (right [here](https://github.com/tmooney/genome/commit/26017071733a84e4f78094d7762f21c133558940#diff-d38dfe2f448c8bdee9ef7eb70b2eac68R73)).  That germline model test is coming in handy--the regular refalign test didn't catch these!