### PR TITLE
New chr_md5 reference converter

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -911,7 +911,7 @@ sub chromosomes_with_lengths {
     my $chr_data = $self->get_or_create_seqdict_hash_ref;
 
     for my $chr (keys %{$chr_data}) {
-        push @chr_lengths, [$chr, $chr_data->{$chr}->{length}];
+        push @chr_lengths, [$chr, $chr_data->{$chr}{length}];
     }
 
     return \@chr_lengths;
@@ -921,55 +921,74 @@ sub get_or_create_seqdict_hash_ref {
     my $self = shift;
 
     return $self->_seqdict if $self->_seqdict;
-    
+
     my $seqdict = $self->sequence_dictionary_path('sam');
-
     unless(-s $seqdict) {
-        die $self->error_message('No sequence dictionary found to create buckets');
+        $self->fatal_message('No sequence dictionary found!');
     }
-
+    my %seqdict_fields = (
+        'name' => {
+            key => 'SN',
+            position => 2,
+        },
+        'length' => {
+            key => 'LN',
+            position => 3,
+        },
+        'uri' => {
+            key => 'UR',
+            position => 4,
+        },
+        'assembly_name' => {
+            key => 'AS',
+            position => 5,
+        },
+        'md5' => {
+            key => 'M5',
+            position => 6,
+        },
+        species_name => {
+            key => 'SP',
+            position => 7,
+        },
+    );
+    my @field_names = sort {$seqdict_fields{$a}{position} <=> $seqdict_fields{$b}{position}} keys %seqdict_fields;
     my $parser = Genome::Utility::IO::SeparatedValueReader->create(
         separator => "\t",
         input => $seqdict,
-        headers => ['tag', 'name', 'length', 'uri', 'assembly_name', 'md5','species_name'],
+        headers => ['tag', @field_names],
         allow_extra_columns => 1,
         ignore_lines_starting_with => '(?!@SQ)',
     );
+
     my %seqdict;
     while (my $line = $parser->next) {
         unless ($line->{tag} eq '@SQ') {
             Carp::confess 'parser error';
         }
-
-        my ($sn, $chr) = split(':', $line->{name},2);
-        unless ($sn eq 'SN') {
-            die $self->error_message('Expected SN first in @SQ line but got %s', $sn);
+        my $chr;
+        for my $field_name (@field_names) {
+            my $value = $self->_parse_seqdict_field($seqdict_fields{$field_name}{key},$seqdict_fields{$field_name}{position},$line->{$field_name});
+            if ($field_name eq 'name') {
+                $chr = $value;
+            }
+            $seqdict{$chr}{$field_name} = $value;
         }
-
-        my ($ln, $length) = split(':', $line->{length},2);
-        unless ($ln eq 'LN') {
-            die $self->error_message('Expected LN second in @SQ line but got %s', $ln);
-        }
-
-        my ($ur, $uri) = split(':', $line->{uri},2);
-        unless ($ur eq 'UR') {
-            die $self->error_message('Expected UR third in @SQ line but got %s', $ur);
-        }
-
-        my ($m5, $md5) = split(':', $line->{md5},2);
-        unless ($m5 eq 'M5') {
-            die $self->error_message('Expected M5 fifth in @SQ line but got %s', $ln);
-        }
-        
-        $seqdict{$chr} = {
-            'length' => $length,
-            'uri' => $uri,
-            'md5' => $md5,
-        };
     }
-    $self->_seqdict(\%seqdict);
-    return $self->_seqdict;
 
+    $self->_seqdict(\%seqdict);
+
+    return $self->_seqdict;
+}
+
+sub _parse_seqdict_field {
+    my $self = shift;
+    my ($expected_key,$expected_pos,$field) = @_;
+    my ($observed_key,$value) = split(':',$field,2);
+    unless ($expected_key eq $observed_key) {
+        $self->fatal_message('Expected %s key as %s field but got %s',$expected_key,$expected_pos,$observed_key);
+    }
+    return $value;
 }
 
 sub is_superset_of {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/Buckets.t
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/Buckets.t
@@ -25,8 +25,8 @@ my (undef, $seqdict_dir) = File::Basename::fileparse($seqdict_file);
 Genome::Sys->create_directory($seqdict_dir);
 Genome::Sys->write_file($seqdict_file, <<'EOFILE'
 @HD	VN:1.0	SO:unsorted
-@SQ	SN:1	LN:100	UR:file:///dev/null
-@SQ	SN:2	LN:90	UR:file:///dev/null
+@SQ	SN:1	LN:100	UR:file:///dev/null	AS:test1.0	M5:fakeuuid1	SP:test
+@SQ	SN:2	LN:90	UR:file:///dev/null	AS:test1.0	M5:fakeuuid2	SP:test
 EOFILE
 );
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/Converter.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/Converter.pm
@@ -5,6 +5,7 @@ use warnings;
 use strict;
 use Sys::Hostname;
 use List::Util qw( first );
+use List::MoreUtils qw( each_array );
 
 class Genome::Model::Build::ReferenceSequence::Converter {
     is => ['Genome::SoftwareResult'],
@@ -253,13 +254,12 @@ sub get_or_create_chr_map_hash_ref {
     my $source_seqdict = $self->source_reference_build->get_or_create_seqdict_hash_ref;
     my $destination_seqdict = $self->destination_reference_build->get_or_create_seqdict_hash_ref;
 
-    my @sorted_source_chrs = sort { $source_seqdict->{$a}->{md5} cmp $source_seqdict->{$b}->{md5}} keys %{$source_seqdict};
-    my @sorted_destination_chrs = sort { $destination_seqdict->{$a}->{md5} cmp $destination_seqdict->{$b}->{md5}} keys %{$destination_seqdict};
-    for (my $i = 0; $i < scalar(@sorted_source_chrs); $i++) {
-        my $source_chr = $sorted_source_chrs[$i];
-        my $destination_chr = $sorted_destination_chrs[$i];
-        my $source_md5 = $source_seqdict->{$source_chr}->{md5};
-        my $destination_md5 = $destination_seqdict->{$destination_chr}->{md5};
+    my @sorted_source_chrs = sort { $source_seqdict->{$a}{md5} cmp $source_seqdict->{$b}{md5}} keys %{$source_seqdict};
+    my @sorted_destination_chrs = sort { $destination_seqdict->{$a}{md5} cmp $destination_seqdict->{$b}{md5}} keys %{$destination_seqdict};
+    my $each_array = each_array(@sorted_source_chrs,@sorted_destination_chrs);
+    while ( my ($source_chr,$destination_chr) = $each_array->()) {
+        my $source_md5 = $source_seqdict->{$source_chr}{md5};
+        my $destination_md5 = $destination_seqdict->{$destination_chr}{md5};
         if ($source_md5 eq $destination_md5) {
             $chr_map{$source_chr} = $destination_chr;
         } else {

--- a/lib/perl/Genome/Model/ReferenceSequence/Command/CreateBuckets.t
+++ b/lib/perl/Genome/Model/ReferenceSequence/Command/CreateBuckets.t
@@ -26,8 +26,8 @@ my (undef, $seqdict_dir) = File::Basename::fileparse($seqdict_file);
 Genome::Sys->create_directory($seqdict_dir);
 Genome::Sys->write_file($seqdict_file, <<'EOFILE'
 @HD	VN:1.0	SO:unsorted
-@SQ	SN:1	LN:100	UR:file:///dev/null
-@SQ	SN:2	LN:90	UR:file:///dev/null
+@SQ	SN:1	LN:100	UR:file:///dev/null	AS:test1.0	M5:fakeuuid1	SP:test
+@SQ	SN:2	LN:90	UR:file:///dev/null	AS:test1.0	M5:fakeuuid2	SP:test
 EOFILE
 );
 

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/PrepareReferenceBuckets.t
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/PrepareReferenceBuckets.t
@@ -27,8 +27,8 @@ my (undef, $seqdict_dir) = File::Basename::fileparse($seqdict_file);
 Genome::Sys->create_directory($seqdict_dir);
 Genome::Sys->write_file($seqdict_file, <<'EOFILE'
 @HD	VN:1.0	SO:unsorted
-@SQ	SN:1	LN:100	UR:file:///dev/null
-@SQ	SN:2	LN:90	UR:file:///dev/null
+@SQ	SN:1	LN:100	UR:file:///dev/null	AS:test1.0	M5:fakeuuid1	SP:test
+@SQ	SN:2	LN:90	UR:file:///dev/null	AS:test1.0	M5:fakeuuid1	SP:test
 EOFILE
 );
 


### PR DESCRIPTION
A new reference sequence converter that relies on matching the md5 in each build sequence dictionary to map chromosome names.