### PR TITLE
Specify a default job group for PTero-launched jobs.

### DIFF
--- a/etc/genome/spec/lsf_job_group.yaml
+++ b/etc/genome/spec/lsf_job_group.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_LSF_JOB_GROUP
+default_value: '/genome'

--- a/lib/perl/Genome/Ptero/ToJSON.t
+++ b/lib/perl/Genome/Ptero/ToJSON.t
@@ -46,6 +46,7 @@ for my $test_directory (glob test_data_directory('*')) {
             qr/^.*"postExecCmd" :.*$/,
             qr/^.*"outFile" :.*$/,
             qr/^.*"errFile" :.*$/,
+            qr/^.*"jobGroup" :.*$/,
         ],
     );
 }

--- a/lib/perl/Genome/Ptero/ToJSONForProcess.t
+++ b/lib/perl/Genome/Ptero/ToJSONForProcess.t
@@ -61,6 +61,7 @@ for my $test_directory (glob test_data_directory('*')) {
             qr/^.*"postExecCmd" :.*$/,
             qr/^.*"outFile" :.*$/,
             qr/^.*"errFile" :.*$/,
+            qr/^.*"jobGroup" :.*$/,
         ],
     );
 }

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -76,6 +76,7 @@
                   },
                   "options" : {
                      "errFile" : "/tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.err",
+                     "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 1,
                      "outFile" : "/tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.err --stdout /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
@@ -184,6 +185,7 @@
                                                 },
                                                 "options" : {
                                                    "errFile" : "/tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.err",
+                                                   "jobGroup" : "/genome/dmorton",
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.err --stdout /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -120,6 +120,7 @@
                                  },
                                  "options" : {
                                     "errFile" : "/tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.err",
+                                    "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.err --stdout /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
@@ -230,6 +231,7 @@
                                                                },
                                                                "options" : {
                                                                   "errFile" : "/tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.err",
+                                                                  "jobGroup" : "/genome/dmorton",
                                                                   "numProcessors" : 1,
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.err --stdout /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -123,6 +123,7 @@
                   },
                   "options" : {
                      "errFile" : "/tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.err",
+                     "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.err --stdout /tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.out",
@@ -185,6 +186,7 @@
                   },
                   "options" : {
                      "errFile" : "/tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.err",
+                     "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.err --stdout /tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.out",
@@ -247,6 +249,7 @@
                   },
                   "options" : {
                      "errFile" : "/tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.err",
+                     "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.err --stdout /tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.out",
@@ -309,6 +312,7 @@
                   },
                   "options" : {
                      "errFile" : "/tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.err",
+                     "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.err --stdout /tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -169,6 +169,7 @@
                                  },
                                  "options" : {
                                     "errFile" : "/tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.err",
+                                    "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.err --stdout /tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.out",
@@ -233,6 +234,7 @@
                                  },
                                  "options" : {
                                     "errFile" : "/tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.err",
+                                    "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.err --stdout /tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.out",
@@ -297,6 +299,7 @@
                                  },
                                  "options" : {
                                     "errFile" : "/tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.err",
+                                    "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.err --stdout /tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.out",
@@ -361,6 +364,7 @@
                                  },
                                  "options" : {
                                     "errFile" : "/tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.err",
+                                    "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.err --stdout /tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -107,6 +107,7 @@
                                                 },
                                                 "options" : {
                                                    "errFile" : "/tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.err",
+                                                   "jobGroup" : "/genome/dmorton",
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.err --stdout /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -148,6 +148,7 @@
                                                                },
                                                                "options" : {
                                                                   "errFile" : "/tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.err",
+                                                                  "jobGroup" : "/genome/dmorton",
                                                                   "numProcessors" : 1,
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.err --stdout /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
@@ -107,6 +107,7 @@
                                                 },
                                                 "options" : {
                                                    "errFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err",
+                                                   "jobGroup" : "/genome/dmorton",
                                                    "outFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err --stdout /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
                                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
@@ -148,6 +148,7 @@
                                                                },
                                                                "options" : {
                                                                   "errFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err",
+                                                                  "jobGroup" : "/genome/dmorton",
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err --stdout /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
                                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
@@ -107,6 +107,7 @@
                                                 },
                                                 "options" : {
                                                    "errFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err",
+                                                   "jobGroup" : "/genome/dmorton",
                                                    "outFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err --stdout /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
                                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
@@ -148,6 +148,7 @@
                                                                },
                                                                "options" : {
                                                                   "errFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err",
+                                                                  "jobGroup" : "/genome/dmorton",
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err --stdout /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
                                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -61,6 +61,7 @@
                   },
                   "options" : {
                      "errFile" : "/tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.err",
+                     "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 1,
                      "outFile" : "/tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.err --stdout /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -102,6 +102,7 @@
                                  },
                                  "options" : {
                                     "errFile" : "/tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.err",
+                                    "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.err --stdout /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -84,6 +84,7 @@
                                  },
                                  "options" : {
                                     "errFile" : "/tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.err",
+                                    "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.err --stdout /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -125,6 +125,7 @@
                                                 },
                                                 "options" : {
                                                    "errFile" : "/tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.err",
+                                                   "jobGroup" : "/genome/dmorton",
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.err --stdout /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",

--- a/lib/perl/Genome/Sys/LSF/ResourceParser.pm
+++ b/lib/perl/Genome/Sys/LSF/ResourceParser.pm
@@ -162,7 +162,7 @@ sub _formatters {
 my %valid_options = (
     'b' => 'beginTime',
     'e' => 'errFile',
-    'g' => 'group',
+    'g' => 'jobGroup',
     'i' => 'inFile',
     'J' => 'jobName',
     'u' => 'mail_user',

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -154,6 +154,12 @@ sub _get_ptero_lsf_parameters {
     $set_lsf_option->('queue', $attributes{lsfQueue});
     $set_lsf_option->('projectName', $attributes{lsfProject});
 
+    my $default_job_group = join('/',
+        Genome::Config::get('lsf_job_group'),
+        Genome::Sys->username,
+    );
+    $set_lsf_option->('jobGroup', $default_job_group);
+
     my ($stderr, $stdout, $postexec) = _get_lsf_log_paths();
     $lsf_params->{options}->{errFile} = $stderr;
     $lsf_params->{options}->{outFile} = $stdout;


### PR DESCRIPTION
This will allow the group owner (read: `apipe-builder`) to manipulate LSF jobs for any running `PTero` workflows launched from `Genome`.