### PR TITLE
Make FilterFalsePositives not die on empty input.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Somatic/FilterFalsePositives.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/FilterFalsePositives.pm
@@ -304,6 +304,12 @@ sub run_filter {
     } else {
         $self->debug_message('Running BAM Readcounts...');
 
+        #Check for an empty variant file
+        if(-z $self->variant_file) {
+            $self->warning_message("Variant file is empty. Returning.");
+            return 1;
+        }
+
         #First, need to create a variant list file to use for generating the readcounts.
         my $input = Genome::Sys->open_file_for_reading($self->variant_file) or
           die $self->error_message("Unable to open " . $self->variant_file . ".");


### PR DESCRIPTION
The FilterFalsePositives module is run as a part of the LOH pipeline. Currently
if the variant file that is passed to this module is empty,
the workflow crashes with an error message (bam-readcount is invoked
with an empty file which causes it to die). Instead I think
we'd like this module to spit out a warning and not attempt to
filter if the input is empty.