### PR TITLE
Skip mutation spectrum on empty input

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/CreateMutationSpectrum.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/CreateMutationSpectrum.pm
@@ -251,6 +251,13 @@ sub get_mutation_spectrum_sequence_context_result {
   my $final_name = shift;
   my $tier1_snvs = shift;
   my $sub_outdir2 = shift;
+
+  #Check for tier1 variants
+  if(-z $tier1_snvs) {
+      $self->status_message("Tier1 SNVs file empty. Skipping mutation spectrum" .
+                            "sequence context for tier1.");
+      return;
+  }
   my $somvar_build = $self->somvar_build;
   my $reference_sequence_build = $somvar_build->tumor_model->reference_sequence_build;
   my $reference_fasta_path = $reference_sequence_build->full_consensus_path('fa');


### PR DESCRIPTION
Currently clinseq attempts to run mutation spectrum sequence
context on an empty input which causes the downstream R module
to die unpredictably. We'd like to skip running this analysis
when the tier1 variant file is empty instead.