### PR TITLE
Support Multiple Merge Groups for AlignAndMerge in the AlignmentDispatcher

### DIFF
--- a/lib/perl/Genome/InstrumentData/Composite/Workflow.t
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow.t
@@ -11,6 +11,7 @@ BEGIN {
 
 use Sub::Override;
 use Test::More;
+use Test::Deep qw(cmp_bag);
 use above "Genome";
 
 use Genome::Utility::Test;
@@ -98,11 +99,11 @@ my $clip_overlap_result_two_inst_data = construct_clip_overlap_result(
 );
 
 my $speedseq_result = construct_speedseq_result($ref, @two_instrument_data);
+my $second_speedseq_result = construct_speedseq_result($ref, @one_instrument_data);
 
 my $result_users = Genome::Test::Factory::SoftwareResult::User->setup_user_hash(
     reference_sequence_build => $ref,
 );
-
 
 subtest 'simple alignments' => sub {
     my $log_directory = Genome::Sys->create_temp_directory();
@@ -196,6 +197,35 @@ subtest 'simple align_and_merge strategy' => sub {
     my @ad_result_ids = $ad->_result_ids;
     my @ad_results = Genome::SoftwareResult->get(\@ad_result_ids);
     is_deeply([$speedseq_result], [sort @ad_results], 'found speedseq result');
+    check_result_bam(@ad_results);
+};
+
+subtest 'simple align_and_merge strategy with multiple samples' => sub {
+    use Genome::InstrumentData::AlignmentResult::Merged::Speedseq;
+    my $gtmp_override = Sub::Override->new(
+        'Genome::InstrumentData::AlignmentResult::Merged::Speedseq::estimated_gtmp_for_instrument_data',
+        sub { return 1; },
+    );
+
+    my $ad = Genome::InstrumentData::Composite::Workflow->create(
+        inputs => {
+            instrument_data => \@three_instrument_data,
+            reference_sequence_build => $ref,
+            force_fragment => 0,
+            result_users => $result_users,
+        },
+        strategy => 'instrument_data both aligned to reference_sequence_build and merged using speedseq 0.0.3a-gms [sort_memory => 8] api v1',
+    );
+    isa_ok(
+        $ad,
+        'Genome::InstrumentData::Composite::Workflow',
+        'created dispatcher for simple align_and_merge strategy'
+    );
+
+    ok($ad->execute, 'executed dispatcher for simple align_and_merge');
+    my @ad_result_ids = $ad->_result_ids;
+    my @ad_results = Genome::SoftwareResult->get(\@ad_result_ids);
+    cmp_bag([$speedseq_result, $second_speedseq_result], [@ad_results], 'found speedseq results');
     check_result_bam(@ad_results);
 };
 

--- a/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
+++ b/lib/perl/Genome/InstrumentData/Composite/Workflow/Generator/AlignAndMerge.pm
@@ -21,8 +21,9 @@ sub generate {
     #Make a workflow with its input and output connectors
     my $input_properties = [$class->_general_workflow_input_properties];
     my $tree_properties = ['name', 'params', 'version'];
+    my $dag_number = $class->next_counter_value;
     my $workflow = Genome::WorkflowBuilder::DAG->create(
-        name => $aligner_name,
+        name => join(' ', $aligner_name, $dag_number),
     );
     my $workflows = {};
     map { $workflows->{$_} = $workflow } @$alignment_objects;
@@ -56,37 +57,40 @@ sub generate {
         push @$inputs, ( 'm_' . $input_property => $input_data->{$input_property} );
     }
     for my $input_property (@$tree_properties) {
+        my $op_input_name = $class->_operation_specific_name($workflow, $input_property);
         $workflow->connect_input(
-            input_property => $input_property,
+            input_property => $op_input_name,
             destination => $operation,
             destination_property => $input_property,
             is_optional => 1,
         );
-        push @$inputs, ( 'm_' . $input_property => $tree->{'action'}->[0]->{$input_property} );
+        push @$inputs, ( 'm_' . $op_input_name => $tree->{'action'}->[0]->{$input_property} );
     }
 
     my $reference_input_name = $tree->{'action'}->[0]->{reference};
+    my $op_reference_input_name = $class->_operation_specific_name($workflow, 'reference_sequence_build');
     $workflow->connect_input(
-        input_property => 'reference_sequence_build',
+        input_property => $op_reference_input_name,
         destination => $operation,
         destination_property => 'reference_sequence_build',
         is_optional => 1,
     );
-    push @$inputs, ( 'm_reference_sequence_build' => $input_data->{$reference_input_name} );
+    push @$inputs, ( 'm_' . $op_reference_input_name => $input_data->{$reference_input_name} );
 
+    my $op_instrument_data_input_name = $class->_operation_specific_name($workflow, 'instrument_data');
     $workflow->connect_input(
-        input_property => 'instrument_data',
+        input_property => $op_instrument_data_input_name,
         destination => $operation,
         destination_property => 'instrument_data',
         is_optional => 1,
     );
-    push @$inputs, ( 'm_instrument_data' => \@instrument_data );
+    push @$inputs, ( 'm_' . $op_instrument_data_input_name => \@instrument_data );
 
     #Connect output connectors to the operation
     $workflow->connect_output(
         source => $operation,
         source_property => 'result_id',
-        output_property => 'result_id',
+        output_property => $class->_operation_specific_name($workflow, 'result_id'),
     );
 
     if (exists $tree->{'action'}->[0]->{decoration}) {
@@ -134,6 +138,14 @@ sub _wire_object_workflow_to_master_workflow {
     }
 
     return 1;
+}
+
+sub _operation_specific_name {
+    my $class = shift;
+    my $op = shift;
+    my $name = shift;
+
+    return join('-', $name, $op->name);
 }
 
 1;


### PR DESCRIPTION
There were previous assumptions baked into this implementation that meant only one AlignAndMerge could appear within a run of the dispatcher.  The step would also not work properly if meant to only run on a subset of the data.  This PR addresses both of these shortcomings.