### PR TITLE
SV realignment compatibility with SpeedSeq BAM headers

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/NovoRealign.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/NovoRealign.pm
@@ -95,10 +95,10 @@ sub _filter_variants {
     while (my $line = $fh->getline) {
         next unless $line =~ /\S+/;
         chomp $line;
-        my ($mean)   = $line =~ /mean\w*\:(\S+)\b/i;
-        my ($std)    = $line =~ /std\w*\:(\S+)\b/i;
-        my ($lib)    = $line =~ /lib\w*\:(\S+)\b/i;
-        my ($rd_len) = $line =~ /readlen\w*\:(\S+)\b/i;
+        my ($mean)   = $line =~ /mean\w*\:(\S+)\s+/i;
+        my ($std)    = $line =~ /std\w*\:(\S+)\s+/i;
+        my ($lib)    = $line =~ /lib\w*\:(\S+)\s+/i;
+        my ($rd_len) = $line =~ /readlen\w*\:(\S+)\s+/i;
 
         ($lib) = $line =~ /samp\w*\:(\S+)\b/i unless defined $lib;
         $mean_insertsize{$lib} = int($mean + 0.5);


### PR DESCRIPTION
Use whitespace to denote end of string rather than word-boundary.  Non-word characters are excluded from the end of the library string such as double quotation marks.  

The change is triggered by SpeedSeq passing the LIMS BAM header rather than recreating the header from sample meta-data.  I'm not sure why the LIMS BAM header has doube quotes around the library name, but that is the source of this issue.