### PR TITLE
Add c_position to variant report

### DIFF
--- a/lib/perl/Genome/File/Vcf/VepConsequenceParser.pm
+++ b/lib/perl/Genome/File/Vcf/VepConsequenceParser.pm
@@ -5,7 +5,7 @@ package Genome::File::Vcf::VepConsequenceParser;
 
 use Data::Dumper;
 use Carp qw/confess/;
-use URI::Escape;
+use URI::Escape qw/uri_unescape/;
 
 use strict;
 use warnings;

--- a/lib/perl/Genome/File/Vcf/VepConsequenceParser.pm
+++ b/lib/perl/Genome/File/Vcf/VepConsequenceParser.pm
@@ -5,7 +5,7 @@ package Genome::File::Vcf::VepConsequenceParser;
 
 use Data::Dumper;
 use Carp qw/confess/;
-use CGI qw/unescape/;
+use URI::Escape;
 
 use strict;
 use warnings;
@@ -85,7 +85,7 @@ sub process_entry {
     my $value = $entry->info($self->{tag_name});
     return unless $value;
 
-    $value = CGI::unescape($value);
+    $value = uri_unescape($value);
     my @annotations = split(",", $value);
 
     my %allele_map = resolve_alleles($entry);

--- a/lib/perl/Genome/VariantReporting/Report/FullReport.pm
+++ b/lib/perl/Genome/VariantReporting/Report/FullReport.pm
@@ -61,6 +61,7 @@ sub headers {
         transcript_name
         trv_type
         trv_type_category
+        c_position
         amino_acid_change
         default_gene_name
         ensembl_gene_id

--- a/lib/perl/Genome/VariantReporting/Report/SimpleReport.pm
+++ b/lib/perl/Genome/VariantReporting/Report/SimpleReport.pm
@@ -27,6 +27,7 @@ sub headers {
         variant_type
         transcript_name
         trv_type
+        c_position
         amino_acid_change
         default_gene_name
         ensembl_gene_id

--- a/lib/perl/Genome/VariantReporting/Report/SimpleReport.t
+++ b/lib/perl/Genome/VariantReporting/Report/SimpleReport.t
@@ -42,6 +42,7 @@ my $interpretations = {
             amino_acid_change => '',
             default_gene_name => 'RP5-857K21.5',
             ensembl_gene_id   => 'ENSG00000223659',
+            c_position        => '',
         },
         G => {
             transcript_name   => 'ENST00000452176',
@@ -49,6 +50,7 @@ my $interpretations = {
             amino_acid_change => '',
             default_gene_name => 'RP5-857K22.5',
             ensembl_gene_id   => 'ENSG00000223695',
+            c_position        => '',
         },
     },
     'variant-type' => {

--- a/lib/perl/Genome/VariantReporting/Report/SimpleReport.t.d/expected/report.txt
+++ b/lib/perl/Genome/VariantReporting/Report/SimpleReport.t.d/expected/report.txt
@@ -1,3 +1,3 @@
-chromosome_name	start	stop	reference	variant	variant_type	transcript_name	trv_type	amino_acid_change	default_gene_name	ensembl_gene_id
-1	1	1	A	T	snv	ENST00000452176	DOWNSTREAM		RP5-857K21.5	ENSG00000223659
-1	1	1	A	G	snv	ENST00000452176	DOWNSTREAM		RP5-857K22.5	ENSG00000223695
+chromosome_name	start	stop	reference	variant	variant_type	transcript_name	trv_type	c_position	amino_acid_change	default_gene_name	ensembl_gene_id
+1	1	1	A	T	snv	ENST00000452176	DOWNSTREAM			RP5-857K21.5	ENSG00000223659
+1	1	1	A	G	snv	ENST00000452176	DOWNSTREAM			RP5-857K22.5	ENSG00000223695

--- a/lib/perl/Genome/VariantReporting/Report/SimpleReport.t.d/expected/report.txt.legend
+++ b/lib/perl/Genome/VariantReporting/Report/SimpleReport.t.d/expected/report.txt.legend
@@ -7,6 +7,7 @@ variant	The variant called at this position
 variant_type	The type of variant: snp, ins (insertion), del (deletion), other
 transcript_name	Ensembl stable ID of feature
 trv_type	Consequence type of this variation
+c_position	The HGVS coding sequence name
 amino_acid_change	The HGVS protein sequence name
 default_gene_name	The gene symbol
 ensembl_gene_id	Ensembl stable ID of affected gene


### PR DESCRIPTION
c_position column from vep output need to be added to report. This PR also replaces the obsolete CGI with URI::Escape, which fixes a bug that unescapes + into space with CGI.