### PR TITLE
Use new 'service_data_to_save' feature of PTero

### DIFF
--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -63,6 +63,10 @@
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error"
+               ],
                "serviceUrl" : "http://example.com/v1"
             },
             {
@@ -89,6 +93,11 @@
                   "user" : "dmorton"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error",
+                  "lsfJobId"
+               ],
                "serviceUrl" : "http://lsf.example.com/v1"
             }
          ],
@@ -171,6 +180,10 @@
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error"
+                                             ],
                                              "serviceUrl" : "http://example.com/v1"
                                           },
                                           {
@@ -197,6 +210,11 @@
                                                 "user" : "dmorton"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error",
+                                                "lsfJobId"
+                                             ],
                                              "serviceUrl" : "http://lsf.example.com/v1"
                                           }
                                        ],

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -106,6 +106,10 @@
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error"
+                              ],
                               "serviceUrl" : "http://example.com/v1"
                            },
                            {
@@ -133,6 +137,11 @@
                                  "user" : "dmorton"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error",
+                                 "lsfJobId"
+                              ],
                               "serviceUrl" : "http://lsf.example.com/v1"
                            }
                         ],
@@ -216,6 +225,10 @@
                                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                                             },
                                                             "service" : "job",
+                                                            "serviceDataToSave" : [
+                                                               "error_message",
+                                                               "error"
+                                                            ],
                                                             "serviceUrl" : "http://example.com/v1"
                                                          },
                                                          {
@@ -243,6 +256,11 @@
                                                                "user" : "dmorton"
                                                             },
                                                             "service" : "job",
+                                                            "serviceDataToSave" : [
+                                                               "error_message",
+                                                               "error",
+                                                               "lsfJobId"
+                                                            ],
                                                             "serviceUrl" : "http://lsf.example.com/v1"
                                                          }
                                                       ],

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -110,6 +110,10 @@
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error"
+               ],
                "serviceUrl" : "http://example.com/v1"
             },
             {
@@ -137,6 +141,11 @@
                   "user" : "dmorton"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error",
+                  "lsfJobId"
+               ],
                "serviceUrl" : "http://lsf.example.com/v1"
             }
          ]
@@ -172,6 +181,10 @@
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error"
+               ],
                "serviceUrl" : "http://example.com/v1"
             },
             {
@@ -199,6 +212,11 @@
                   "user" : "dmorton"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error",
+                  "lsfJobId"
+               ],
                "serviceUrl" : "http://lsf.example.com/v1"
             }
          ]
@@ -234,6 +252,10 @@
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error"
+               ],
                "serviceUrl" : "http://example.com/v1"
             },
             {
@@ -261,6 +283,11 @@
                   "user" : "dmorton"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error",
+                  "lsfJobId"
+               ],
                "serviceUrl" : "http://lsf.example.com/v1"
             }
          ]
@@ -296,6 +323,10 @@
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error"
+               ],
                "serviceUrl" : "http://example.com/v1"
             },
             {
@@ -323,6 +354,11 @@
                   "user" : "dmorton"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error",
+                  "lsfJobId"
+               ],
                "serviceUrl" : "http://lsf.example.com/v1"
             }
          ]

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -155,6 +155,10 @@
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error"
+                              ],
                               "serviceUrl" : "http://example.com/v1"
                            },
                            {
@@ -183,6 +187,11 @@
                                  "user" : "dmorton"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error",
+                                 "lsfJobId"
+                              ],
                               "serviceUrl" : "http://lsf.example.com/v1"
                            }
                         ]
@@ -219,6 +228,10 @@
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error"
+                              ],
                               "serviceUrl" : "http://example.com/v1"
                            },
                            {
@@ -247,6 +260,11 @@
                                  "user" : "dmorton"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error",
+                                 "lsfJobId"
+                              ],
                               "serviceUrl" : "http://lsf.example.com/v1"
                            }
                         ]
@@ -283,6 +301,10 @@
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error"
+                              ],
                               "serviceUrl" : "http://example.com/v1"
                            },
                            {
@@ -311,6 +333,11 @@
                                  "user" : "dmorton"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error",
+                                 "lsfJobId"
+                              ],
                               "serviceUrl" : "http://lsf.example.com/v1"
                            }
                         ]
@@ -347,6 +374,10 @@
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error"
+                              ],
                               "serviceUrl" : "http://example.com/v1"
                            },
                            {
@@ -375,6 +406,11 @@
                                  "user" : "dmorton"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error",
+                                 "lsfJobId"
+                              ],
                               "serviceUrl" : "http://lsf.example.com/v1"
                            }
                         ]

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -94,6 +94,10 @@
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error"
+                                             ],
                                              "serviceUrl" : "http://example.com/v1"
                                           },
                                           {
@@ -120,6 +124,11 @@
                                                 "user" : "dmorton"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error",
+                                                "lsfJobId"
+                                             ],
                                              "serviceUrl" : "http://lsf.example.com/v1"
                                           }
                                        ],

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -134,6 +134,10 @@
                                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                                             },
                                                             "service" : "job",
+                                                            "serviceDataToSave" : [
+                                                               "error_message",
+                                                               "error"
+                                                            ],
                                                             "serviceUrl" : "http://example.com/v1"
                                                          },
                                                          {
@@ -161,6 +165,11 @@
                                                                "user" : "dmorton"
                                                             },
                                                             "service" : "job",
+                                                            "serviceDataToSave" : [
+                                                               "error_message",
+                                                               "error",
+                                                               "lsfJobId"
+                                                            ],
                                                             "serviceUrl" : "http://lsf.example.com/v1"
                                                          }
                                                       ],

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
@@ -94,6 +94,10 @@
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error"
+                                             ],
                                              "serviceUrl" : "http://example.com/v1"
                                           },
                                           {
@@ -116,6 +120,11 @@
                                                 "user" : "dmorton"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error",
+                                                "lsfJobId"
+                                             ],
                                              "serviceUrl" : "http://lsf.example.com/v1"
                                           }
                                        ]

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
@@ -134,6 +134,10 @@
                                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                                             },
                                                             "service" : "job",
+                                                            "serviceDataToSave" : [
+                                                               "error_message",
+                                                               "error"
+                                                            ],
                                                             "serviceUrl" : "http://example.com/v1"
                                                          },
                                                          {
@@ -157,6 +161,11 @@
                                                                "user" : "dmorton"
                                                             },
                                                             "service" : "job",
+                                                            "serviceDataToSave" : [
+                                                               "error_message",
+                                                               "error",
+                                                               "lsfJobId"
+                                                            ],
                                                             "serviceUrl" : "http://lsf.example.com/v1"
                                                          }
                                                       ]

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
@@ -94,6 +94,10 @@
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error"
+                                             ],
                                              "serviceUrl" : "http://example.com/v1"
                                           },
                                           {
@@ -116,6 +120,11 @@
                                                 "user" : "dmorton"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error",
+                                                "lsfJobId"
+                                             ],
                                              "serviceUrl" : "http://lsf.example.com/v1"
                                           }
                                        ]

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
@@ -134,6 +134,10 @@
                                                                "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                                             },
                                                             "service" : "job",
+                                                            "serviceDataToSave" : [
+                                                               "error_message",
+                                                               "error"
+                                                            ],
                                                             "serviceUrl" : "http://example.com/v1"
                                                          },
                                                          {
@@ -157,6 +161,11 @@
                                                                "user" : "dmorton"
                                                             },
                                                             "service" : "job",
+                                                            "serviceDataToSave" : [
+                                                               "error_message",
+                                                               "error",
+                                                               "lsfJobId"
+                                                            ],
                                                             "serviceUrl" : "http://lsf.example.com/v1"
                                                          }
                                                       ]

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -48,6 +48,10 @@
                   "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error"
+               ],
                "serviceUrl" : "http://example.com/v1"
             },
             {
@@ -74,6 +78,11 @@
                   "user" : "dmorton"
                },
                "service" : "job",
+               "serviceDataToSave" : [
+                  "error_message",
+                  "error",
+                  "lsfJobId"
+               ],
                "serviceUrl" : "http://lsf.example.com/v1"
             }
          ],

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -88,6 +88,10 @@
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error"
+                              ],
                               "serviceUrl" : "http://example.com/v1"
                            },
                            {
@@ -115,6 +119,11 @@
                                  "user" : "dmorton"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error",
+                                 "lsfJobId"
+                              ],
                               "serviceUrl" : "http://lsf.example.com/v1"
                            }
                         ],

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -71,6 +71,10 @@
                                  "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error"
+                              ],
                               "serviceUrl" : "http://example.com/v1"
                            },
                            {
@@ -97,6 +101,11 @@
                                  "user" : "dmorton"
                               },
                               "service" : "job",
+                              "serviceDataToSave" : [
+                                 "error_message",
+                                 "error",
+                                 "lsfJobId"
+                              ],
                               "serviceUrl" : "http://lsf.example.com/v1"
                            }
                         ]

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -111,6 +111,10 @@
                                                 "workingDirectory" : "/home/archive/dmorton/genome/lib/perl/Genome"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error"
+                                             ],
                                              "serviceUrl" : "http://example.com/v1"
                                           },
                                           {
@@ -138,6 +142,11 @@
                                                 "user" : "dmorton"
                                              },
                                              "service" : "job",
+                                             "serviceDataToSave" : [
+                                                "error_message",
+                                                "error",
+                                                "lsfJobId"
+                                             ],
                                              "serviceUrl" : "http://lsf.example.com/v1"
                                           }
                                        ]

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -92,6 +92,7 @@ sub _get_ptero_shortcut_method {
     my %job_args = (
         name => 'shortcut',
         service_url => Genome::Config::get('ptero_shell_command_service_url'),
+        service_data_to_save => ['error_message', 'error'],
         parameters => {
             commandLine => [
                 'genome', 'ptero', 'wrapper',
@@ -135,6 +136,7 @@ sub _get_ptero_execute_method {
     return Ptero::Builder::Job->new(
         name => 'execute',
         service_url => Genome::Config::get('ptero_lsf_service_url'),
+        service_data_to_save => ['error_message', 'error', 'lsfJobId'],
         parameters => $ptero_lsf_parameters);
 }
 


### PR DESCRIPTION
This cannot pass tests until genome-snapshot-deps has been updated via this PR: https://github.com/genome/genome-snapshot-deps/pull/67

This will put data from the Job services on the PTero execution's data
field saving us from querying the Job service.