### PR TITLE
Port ClinSeq to use WorkflowBuilder

### DIFF
--- a/lib/perl/Genome/Model/Build/ClinSeq/InputBuilds.pm
+++ b/lib/perl/Genome/Model/Build/ClinSeq/InputBuilds.pm
@@ -30,4 +30,9 @@ sub resolve_rnaseq_builds {
   $rnaseq_builds->{$normal_build->id}{type} = 'rnaseq' if $normal_build;
 }
 
+sub wgs_exome_build {
+    my $clinseq_build = shift;
+    return ($clinseq_build->wgs_build and $clinseq_build->exome_build);
+}
+
 1;

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -690,38 +690,7 @@ sub _resolve_workflow_for_build {
     #GenerateClonalityPlots - Run clonality analysis and produce clonality plots
     my $clonality_op;
     if ($build->wgs_build) {
-        $clonality_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Run clonality analysis and produce clonality plots',
-            command => 'Genome::Model::ClinSeq::Command::GenerateClonalityPlots',
-        );
-        $workflow->add_operation($clonality_op);
-        $workflow->connect_input(
-            input_property       => 'misc_annotation_db',
-            destination          => $clonality_op,
-            destination_property => 'misc_annotation_db',
-        );
-        $workflow->connect_input(
-            input_property       => 'wgs_build',
-            destination          => $clonality_op,
-            destination_property => 'somatic_var_build',
-        );
-        $workflow->connect_input(
-            input_property       => 'clonality_dir',
-            destination          => $clonality_op,
-            destination_property => 'output_dir',
-        );
-        for my $property (qw(common_name bam_readcount_version)) {
-            $workflow->connect_input(
-                input_property       => $property,
-                destination          => $clonality_op,
-                destination_property => $property,
-            );
-        }
-        $workflow->connect_output(
-            output_property => 'clonality_result',
-            source          => $clonality_op,
-            source_property => 'result',
-        );
+        $clonality_op = $self->clonality_op($workflow);
     }
 
     #RunCnView - Produce copy number results with run-cn-view.  Relies on clonality step already having been run
@@ -2193,6 +2162,46 @@ sub igv_session_op {
     );
 
     return $igv_session_op;
+}
+
+sub clonality_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $clonality_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Run clonality analysis and produce clonality plots',
+        command => 'Genome::Model::ClinSeq::Command::GenerateClonalityPlots',
+    );
+    $workflow->add_operation($clonality_op);
+    $workflow->connect_input(
+        input_property       => 'misc_annotation_db',
+        destination          => $clonality_op,
+        destination_property => 'misc_annotation_db',
+    );
+    $workflow->connect_input(
+        input_property       => 'wgs_build',
+        destination          => $clonality_op,
+        destination_property => 'somatic_var_build',
+    );
+    $workflow->connect_input(
+        input_property       => 'clonality_dir',
+        destination          => $clonality_op,
+        destination_property => 'output_dir',
+    );
+    for my $property (qw(common_name bam_readcount_version)) {
+        $workflow->connect_input(
+            input_property       => $property,
+            destination          => $clonality_op,
+            destination_property => $property,
+        );
+    }
+    $workflow->connect_output(
+        output_property => 'clonality_result',
+        source          => $clonality_op,
+        source_property => 'result',
+    );
+
+    return $clonality_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -655,72 +655,13 @@ sub _resolve_workflow_for_build {
     }
 
     #CufflinksExpressionAbsolute - Run cufflinks expression absolute analysis on normal
-    my $normal_cufflinks_expression_absolute_op;
     if ($build->normal_rnaseq_build) {
-        $normal_cufflinks_expression_absolute_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Performing cufflinks expression absolute analysis for normal sample',
-            command => 'Genome::Model::ClinSeq::Command::CufflinksExpressionAbsolute',
-        );
-        $workflow->add_operation($normal_cufflinks_expression_absolute_op);
-        $workflow->connect_input(
-            input_property       => 'cancer_annotation_db',
-            destination          => $normal_cufflinks_expression_absolute_op,
-            destination_property => 'cancer_annotation_db',
-        );
-        $workflow->connect_input(
-            input_property       => 'normal_rnaseq_build',
-            destination          => $normal_cufflinks_expression_absolute_op,
-            destination_property => 'build',
-        );
-        $workflow->connect_input(
-            input_property       => 'normal_cufflinks_expression_absolute_dir',
-            destination          => $normal_cufflinks_expression_absolute_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_input(
-            input_property       => 'cufflinks_percent_cutoff',
-            destination          => $normal_cufflinks_expression_absolute_op,
-            destination_property => 'percent_cutoff',
-        );
-        $workflow->connect_output(
-            output_property => 'normal_cufflinks_expression_absolute_result',
-            source          => $normal_cufflinks_expression_absolute_op,
-            source_property => 'result',
-        );
+        my $normal_cufflinks_expression_absolute_op = $self->cufflinks_expression_absolute_op($workflow, 'normal');
     }
     #CufflinksExpressionAbsolute - Run cufflinks expression absolute analysis on tumor
     my $tumor_cufflinks_expression_absolute_op;
     if ($build->tumor_rnaseq_build) {
-        $tumor_cufflinks_expression_absolute_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Performing cufflinks expression absolute analysis for tumor sample',
-            command => 'Genome::Model::ClinSeq::Command::CufflinksExpressionAbsolute',
-        );
-        $workflow->add_operation($tumor_cufflinks_expression_absolute_op);
-        $workflow->connect_input(
-            input_property       => 'cancer_annotation_db',
-            destination          => $tumor_cufflinks_expression_absolute_op,
-            destination_property => 'cancer_annotation_db',
-        );
-        $workflow->connect_input(
-            input_property       => 'tumor_rnaseq_build',
-            destination          => $tumor_cufflinks_expression_absolute_op,
-            destination_property => 'build',
-        );
-        $workflow->connect_input(
-            input_property       => 'tumor_cufflinks_expression_absolute_dir',
-            destination          => $tumor_cufflinks_expression_absolute_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_input(
-            input_property       => 'cufflinks_percent_cutoff',
-            destination          => $tumor_cufflinks_expression_absolute_op,
-            destination_property => 'percent_cutoff',
-        );
-        $workflow->connect_output(
-            output_property => 'tumor_cufflinks_expression_absolute_result',
-            source          => $tumor_cufflinks_expression_absolute_op,
-            source_property => 'result',
-        );
+        $tumor_cufflinks_expression_absolute_op = $self->cufflinks_expression_absolute_op($workflow, 'tumor');
     }
 
     #CufflinksDifferentialExpression - Run cufflinks differential expression
@@ -2189,6 +2130,44 @@ sub tophat_junctions_absolute_op {
     return $tophat_junctions_absolute_op;
 }
 
+sub cufflinks_expression_absolute_op {
+    my $self = shift;
+    my $workflow = shift;
+    my $type = shift;
+
+    my $cufflinks_expression_absolute_op = Genome::WorkflowBuilder::Command->create(
+        name => "Performing cufflinks expression absolute analysis for $type sample",
+        command => 'Genome::Model::ClinSeq::Command::CufflinksExpressionAbsolute',
+    );
+    $workflow->add_operation($cufflinks_expression_absolute_op);
+    $workflow->connect_input(
+        input_property       => 'cancer_annotation_db',
+        destination          => $cufflinks_expression_absolute_op,
+        destination_property => 'cancer_annotation_db',
+    );
+    $workflow->connect_input(
+        input_property       => "${type}_rnaseq_build",
+        destination          => $cufflinks_expression_absolute_op,
+        destination_property => 'build',
+    );
+    $workflow->connect_input(
+        input_property       => "${type}_cufflinks_expression_absolute_dir",
+        destination          => $cufflinks_expression_absolute_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_input(
+        input_property       => 'cufflinks_percent_cutoff',
+        destination          => $cufflinks_expression_absolute_op,
+        destination_property => 'percent_cutoff',
+    );
+    $workflow->connect_output(
+        output_property => "${type}_cufflinks_expression_absolute_result",
+        source          => $cufflinks_expression_absolute_op,
+        source_property => 'result',
+    );
+
+    return $cufflinks_expression_absolute_op;
+}
 
 sub _infer_candidate_subjects_from_input_models {
     my $self = shift;

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -577,36 +577,7 @@ sub _resolve_workflow_for_build {
     );
 
     #SummarizeBuilds - Summarize build inputs using SummarizeBuilds.pm
-    my $summarize_builds_op = Genome::WorkflowBuilder::Command->create(
-        name => 'Creating a summary of input builds using summarize-builds',
-        command => 'Genome::Model::ClinSeq::Command::SummarizeBuilds',
-    );
-    $workflow->add_operation($summarize_builds_op);
-    $workflow->connect_input(
-        input_property       => 'build',
-        destination          => $summarize_builds_op,
-        destination_property => 'builds',
-    );
-    $workflow->connect_input(
-        input_property       => 'summarize_builds_outdir',
-        destination          => $summarize_builds_op,
-        destination_property => 'outdir',
-    );
-    $workflow->connect_input(
-        input_property       => 'summarize_builds_skip_lims_reports',
-        destination          => $summarize_builds_op,
-        destination_property => 'skip_lims_reports',
-    );
-    $workflow->connect_input(
-        input_property       => 'summarize_builds_log_file',
-        destination          => $summarize_builds_op,
-        destination_property => 'log_file',
-    );
-    $workflow->connect_output(
-        output_property => 'summarize_builds_result',
-        source          => $summarize_builds_op,
-        source_property => 'result',
-    );
+    my $summarize_builds_op = $self->summarize_builds_op($workflow);
 
     #ImportSnvsIndels - Import SNVs and Indels
     my $import_snvs_indels_op;
@@ -2179,6 +2150,44 @@ sub _resolve_workflow_for_build {
     # }
 
     return $workflow;
+}
+
+sub summarize_builds_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $summarize_builds_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Creating a summary of input builds using summarize-builds',
+        command => 'Genome::Model::ClinSeq::Command::SummarizeBuilds',
+    );
+    $workflow->add_operation($summarize_builds_op);
+    $workflow->connect_input(
+        input_property       => 'build',
+        destination          => $summarize_builds_op,
+        destination_property => 'builds',
+    );
+    $workflow->connect_input(
+        input_property       => 'summarize_builds_outdir',
+        destination          => $summarize_builds_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_input(
+        input_property       => 'summarize_builds_skip_lims_reports',
+        destination          => $summarize_builds_op,
+        destination_property => 'skip_lims_reports',
+    );
+    $workflow->connect_input(
+        input_property       => 'summarize_builds_log_file',
+        destination          => $summarize_builds_op,
+        destination_property => 'log_file',
+    );
+    $workflow->connect_output(
+        output_property => 'summarize_builds_result',
+        source          => $summarize_builds_op,
+        source_property => 'result',
+    );
+
+    return $summarize_builds_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -645,62 +645,13 @@ sub _resolve_workflow_for_build {
     }
 
     #TophatJunctionsAbsolute - Run tophat junctions absolute analysis on normal
-    my $normal_tophat_junctions_absolute_op;
     if ($build->normal_rnaseq_build) {
-        $normal_tophat_junctions_absolute_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Performing tophat junction expression absolute analysis for normal sample',
-            command => 'Genome::Model::ClinSeq::Command::TophatJunctionsAbsolute',
-        );
-        $workflow->add_operation($normal_tophat_junctions_absolute_op);
-        $workflow->connect_input(
-            input_property       => 'cancer_annotation_db',
-            destination          => $tumor_tophat_junctions_absolute_op,
-            destination_property => 'cancer_annotation_db',
-        );
-        $workflow->connect_input(
-            input_property       => 'normal_rnaseq_build',
-            destination          => $normal_tophat_junctions_absolute_op,
-            destination_property => 'build',
-        );
-        $workflow->connect_input(
-            input_property       => 'normal_tophat_junctions_absolute_dir',
-            destination          => $normal_tophat_junctions_absolute_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_output(
-            output_property => 'normal_tophat_junctions_absolute_result',
-            source          => $normal_tophat_junctions_absolute_op,
-            source_property => 'result',
-        );
+        my $normal_tophat_junctions_absolute_op = $self->tophat_junctions_absolute_op($workflow, 'normal');
     }
     #TophatJunctionsAbsolute - Run tophat junctions absolute analysis on tumor
     my $tumor_tophat_junctions_absolute_op;
     if ($build->tumor_rnaseq_build) {
-        $tumor_tophat_junctions_absolute_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Performing tophat junction expression absolute analysis for tumor sample',
-            command => 'Genome::Model::ClinSeq::Command::TophatJunctionsAbsolute',
-        );
-        $workflow->add_operation($tumor_tophat_junctions_absolute_op);
-        $workflow->connect_input(
-            input_property       => 'cancer_annotation_db',
-            destination          => $tumor_tophat_junctions_absolute_op,
-            destination_property => 'cancer_annotation_db',
-        );
-        $workflow->connect_input(
-            input_property       => 'tumor_rnaseq_build',
-            destination          => $tumor_tophat_junctions_absolute_op,
-            destination_property => 'build',
-        );
-        $workflow->connect_input(
-            input_property       => 'tumor_tophat_junctions_absolute_dir',
-            destination          => $tumor_tophat_junctions_absolute_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_output(
-            output_property => 'tumor_tophat_junctions_absolute_result',
-            source          => $tumor_tophat_junctions_absolute_op,
-            source_property => 'result',
-        );
+        $tumor_tophat_junctions_absolute_op = $self->tophat_junctions_absolute_op($workflow, 'tumor');
     }
 
     #CufflinksExpressionAbsolute - Run cufflinks expression absolute analysis on normal
@@ -2203,6 +2154,41 @@ sub wgs_exome_build_converge_op {
 
     return $wgs_exome_build_converge_op;
 }
+
+sub tophat_junctions_absolute_op {
+    my $self = shift;
+    my $workflow = shift;
+    my $type = shift;
+
+    my $tophat_junctions_absolute_op = Genome::WorkflowBuilder::Command->create(
+        name => "Performing tophat junction expression absolute analysis for $type sample",
+        command => 'Genome::Model::ClinSeq::Command::TophatJunctionsAbsolute',
+    );
+    $workflow->add_operation($tophat_junctions_absolute_op);
+    $workflow->connect_input(
+        input_property       => 'cancer_annotation_db',
+        destination          => $tophat_junctions_absolute_op,
+        destination_property => 'cancer_annotation_db',
+    );
+    $workflow->connect_input(
+        input_property       => "${type}_rnaseq_build",
+        destination          => $tophat_junctions_absolute_op,
+        destination_property => 'build',
+    );
+    $workflow->connect_input(
+        input_property       => "${type}_tophat_junctions_absolute_dir",
+        destination          => $tophat_junctions_absolute_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_output(
+        output_property => "${type}tophat_junctions_absolute_result",
+        source          => $tophat_junctions_absolute_op,
+        source_property => 'result',
+    );
+
+    return $tophat_junctions_absolute_op;
+}
+
 
 sub _infer_candidate_subjects_from_input_models {
     my $self = shift;

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -2090,35 +2090,18 @@ sub snv_variant_source_file {
 
 sub copy_fusion_files {
     my ($self, $build) = @_;
-    my $rnaseq_build_dir             = $build->tumor_rnaseq_build->data_directory;
-    my $tumor_unfiltered_fusion_file = $rnaseq_build_dir
-        . '/fusions/Genome_Model_RnaSeq_DetectFusionsResult_Chimerascan_VariableReadLength_Result/chimeras.bedpe';
-    my $tumor_filtered_fusion_file           = $rnaseq_build_dir . '/fusions/filtered_chimeras.bedpe';
-    my $tumor_filtered_annotated_fusion_file = $rnaseq_build_dir . '/fusions/filtered_chimeras.catanno.bedpe';
-    my $clinseq_tumor_unfiltered_fusion_file = $self->patient_dir($build) . '/rnaseq/tumor/fusions/chimeras.bedpe';
-    my $clinseq_tumor_filtered_fusion_file =
-        $self->patient_dir($build) . '/rnaseq/tumor/fusions/filtered_chimeras.bedpe';
-    my $clinseq_tumor_filtered_annotated_fusion_file =
-        $self->patient_dir($build) . '/rnaseq/tumor/fusions/filtered_chimeras.catanno.bedpe';
-
-    if (-e $tumor_unfiltered_fusion_file) {
-        unless (Genome::Sys->copy_file($tumor_unfiltered_fusion_file, $clinseq_tumor_unfiltered_fusion_file)) {
-            die "unable to copy $tumor_unfiltered_fusion_file";
+    my $origin_dir = File::Spec->join($build->tumor_rnaseq_build->data_directory, 'fusions');
+    my $target_dir = File::Spec->join($self->patient_dir($build), 'rnaseq', 'tumor', 'fusions');
+    for my $file_name (qw(chimeras.bedpe filtered_chimeras.bedpe filtered_chimeras.catanno.bedpe)) {
+        my $origin_file;
+        if ($file_name eq 'chimeras.bedpe') {
+            $origin_file = File::Spec->join($origin_dir, 'Genome_Model_RnaSeq_DetectFusionsResult_Chimerascan_VariableReadLength_Result', $file_name);
         }
-    }
-    if (-e $tumor_filtered_fusion_file) {
-        unless (Genome::Sys->copy_file($tumor_filtered_fusion_file, $clinseq_tumor_filtered_fusion_file)) {
-            die "unable to copy $tumor_filtered_fusion_file";
+        else {
+            $origin_file = File::Spec->join($origin_dir, $file_name);
         }
-    }
-    if (-e $tumor_filtered_annotated_fusion_file) {
-        unless (
-            Genome::Sys->copy_file(
-                $tumor_filtered_annotated_fusion_file, $clinseq_tumor_filtered_annotated_fusion_file
-            )
-            )
-        {
-            die "unable to copy $tumor_filtered_annotated_fusion_file";
+        if (-e $origin_file) {
+            Genome::Sys->copy_file($origin_file, File::Spec->join($target_dir, $file_name));
         }
     }
 }

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -944,8 +944,7 @@ sub _resolve_workflow_for_build {
             wgs   => $wgs_variant_sources_op,
         );
         #Create a report for each $bq $mq combo.
-        my $iterator = List::MoreUtils::each_arrayref([1 .. @$mqs], $mqs, $bqs);
-        while (my ($i, $mq, $bq) = $iterator->()) {
+        for my $i (1..@$mqs) {
             my $converge_snv_indel_report_op = $self->converge_snv_indel_report_op($workflow, $i);
             for my $sequencing_type (qw(exome wgs)) {
                 my $build_accessor = "${sequencing_type}_build";

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -992,53 +992,25 @@ sub _resolve_workflow_for_build {
     #SummarizeTier1SnvSupport - For each of the following: WGS SNVs, Exome SNVs, and WGS+Exome SNVs, do the following:
     #Get BAM readcounts for WGS (tumor/normal), Exome (tumor/normal), RNAseq (tumor), RNAseq (normal) - as available of course
     #TODO: Break this down to do direct calls to GetBamReadCounts instead of wrapping it.
-    my $summarize_tier1_snv_support_op;
-    for my $run (qw/wgs exome wgs_exome/) {
-        if ($run eq 'wgs' and not $build->wgs_build) {
-            next;
-        }
-        if ($run eq 'exome' and not $build->exome_build) {
-            next;
-        }
-        if ($run eq 'wgs_exome' and not($build->wgs_build and $build->exome_build)) {
-            next;
-        }
-        my $txt_name = $run;
-        $txt_name =~ s/_/ plus /g;
-        $txt_name =~ s/wgs/WGS/;
-        $txt_name =~ s/exome/Exome/;
-        $summarize_tier1_snv_support_op = Genome::WorkflowBuilder::Command->create(
-            name => "$txt_name Summarize Tier 1 SNV Support (BAM read counts)",
-            command => 'Genome::Model::ClinSeq::Command::SummarizeTier1SnvSupport',
-        );
-        $workflow->add_operation($summarize_tier1_snv_support_op);
-        for my $property (qw(wgs_build exome_build tumor_rnaseq_build normal_rnaseq_build verbose cancer_annotation_db)) {
-            $workflow->connect_input(
-                input_property       => $property,
-                destination          => $summarize_tier1_snv_support_op,
-                destination_property => $property,
-            );
-        }
-        $workflow->create_link(
-            source               => $import_snvs_indels_op,
-            source_property      => $run . "_snv_file",
-            destination          => $summarize_tier1_snv_support_op,
-            destination_property => $run . "_positions_file",
-        );
-
-        if ($build->tumor_rnaseq_build) {
+    for my $sequencing_type (qw(wgs exome wgs_exome)) {
+        my $build_accessor = "${sequencing_type}_build";
+        if ($build->$build_accessor) {
+            my $summarize_tier1_snv_support_op = $self->summarize_tier1_snv_support_op($workflow, $sequencing_type);
             $workflow->create_link(
-                source               => $tumor_cufflinks_expression_absolute_op,
-                source_property      => 'tumor_fpkm_file',
+                source               => $import_snvs_indels_op,
+                source_property      => "${sequencing_type}_snv_file",
                 destination          => $summarize_tier1_snv_support_op,
-                destination_property => 'tumor_fpkm_file',
+                destination_property => "${sequencing_type}_positions_file",
             );
+            if ($build->tumor_rnaseq_build) {
+                $workflow->create_link(
+                    source               => $tumor_cufflinks_expression_absolute_op,
+                    source_property      => 'tumor_fpkm_file',
+                    destination          => $summarize_tier1_snv_support_op,
+                    destination_property => 'tumor_fpkm_file',
+                );
+            }
         }
-        $workflow->connect_output(
-            output_property => "summarize_${run}_tier1_snv_support_result",
-            source          => $summarize_tier1_snv_support_op,
-            source_property => 'result',
-        );
     }
 
     #MakeCircosPlot - Creates a Circos plot to summarize the data using MakeCircosPlot.pm
@@ -2015,6 +1987,38 @@ sub _annotate_genes_by_category_op {
     );
 
     return $annotate_genes_by_category_op;
+}
+
+sub summarize_tier1_snv_support_op {
+    my $self = shift;
+    my $workflow = shift;
+    my $sequencing_type = shift;
+
+    my %sequencing_types = (
+        wgs       => 'WGS',
+        exome     => 'Exome',
+        wgs_exome => 'WGS and Exome'
+    );
+    my $txt_name = $sequencing_types{$sequencing_type};
+    my $summarize_tier1_snv_support_op = Genome::WorkflowBuilder::Command->create(
+        name => "$txt_name Summarize Tier 1 SNV Support (BAM read counts)",
+        command => 'Genome::Model::ClinSeq::Command::SummarizeTier1SnvSupport',
+    );
+    $workflow->add_operation($summarize_tier1_snv_support_op);
+    for my $property (qw(wgs_build exome_build tumor_rnaseq_build normal_rnaseq_build verbose cancer_annotation_db)) {
+        $workflow->connect_input(
+            input_property       => $property,
+            destination          => $summarize_tier1_snv_support_op,
+            destination_property => $property,
+        );
+    }
+    $workflow->connect_output(
+        output_property => "summarize_${sequencing_type}_tier1_snv_support_result",
+        source          => $summarize_tier1_snv_support_op,
+        source_property => 'result',
+    );
+
+    return $summarize_tier1_snv_support_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -685,26 +685,7 @@ sub _resolve_workflow_for_build {
 
     #DumpIgvXml - Create IGV xml session files with increasing numbers of tracks and store in a single (WGS and Exome BAM files, RNA-seq BAM files, junctions.bed, SNV bed files, etc.)
     #genome model clin-seq dump-igv-xml --outdir=/gscuser/mgriffit/ --builds=119971814
-    my $igv_session_op = Genome::WorkflowBuilder::Command->create(
-        name => 'Create IGV XML session files for varying levels of detail using the input builds',
-        command => 'Genome::Model::ClinSeq::Command::DumpIgvXml',
-    );
-    $workflow->add_operation($igv_session_op);
-    $workflow->connect_input(
-        input_property       => 'build',
-        destination          => $igv_session_op,
-        destination_property => 'builds',
-    );
-    $workflow->connect_input(
-        input_property       => 'igv_session_dir',
-        destination          => $igv_session_op,
-        destination_property => 'outdir',
-    );
-    $workflow->connect_output(
-        output_property => 'igv_session_result',
-        source          => $igv_session_op,
-        source_property => 'result',
-    );
+    my $igv_session_op = $self->igv_session_op($workflow);
 
     #GenerateClonalityPlots - Run clonality analysis and produce clonality plots
     my $clonality_op;
@@ -2184,6 +2165,34 @@ sub intersect_tumor_fusion_sv_op {
     );
 
     return $intersect_tumor_fusion_sv_op;
+}
+
+sub igv_session_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $igv_session_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Create IGV XML session files for varying levels of detail using the input builds',
+        command => 'Genome::Model::ClinSeq::Command::DumpIgvXml',
+    );
+    $workflow->add_operation($igv_session_op);
+    $workflow->connect_input(
+        input_property       => 'build',
+        destination          => $igv_session_op,
+        destination_property => 'builds',
+    );
+    $workflow->connect_input(
+        input_property       => 'igv_session_dir',
+        destination          => $igv_session_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_output(
+        output_property => 'igv_session_result',
+        source          => $igv_session_op,
+        source_property => 'result',
+    );
+
+    return $igv_session_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -716,31 +716,7 @@ sub _resolve_workflow_for_build {
     #RunExomeCNV - produce cnv plots using WEx results
     my $exome_cnv_op;
     if ($build->should_run_exome_cnv) {
-        $exome_cnv_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Call somatic copy number changes using exome data',
-            command => 'Genome::Model::Tools::CopyNumber::Cnmops',
-        );
-        $workflow->add_operation($exome_cnv_op);
-        $workflow->connect_input(
-            input_property       => 'exome_cnv_dir',
-            destination          => $exome_cnv_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_input(
-            input_property       => 'model',
-            destination          => $exome_cnv_op,
-            destination_property => 'clinseq_model',
-        );
-        $workflow->connect_input(
-            input_property       => 'annotation_build',
-            destination          => $exome_cnv_op,
-            destination_property => 'annotation_build_id',
-        );
-        $workflow->connect_output(
-            output_property => 'exome_cnv_result',
-            source          => $exome_cnv_op,
-            source_property => 'result',
-        );
+        $exome_cnv_op = $self->exome_cnv_op($workflow);
     }
 
     #RunDOCMReport
@@ -2220,6 +2196,39 @@ sub microarray_cnv_op {
     );
 
     return $microarray_cnv_op;
+}
+
+sub exome_cnv_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $exome_cnv_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Call somatic copy number changes using exome data',
+        command => 'Genome::Model::Tools::CopyNumber::Cnmops',
+    );
+    $workflow->add_operation($exome_cnv_op);
+    $workflow->connect_input(
+        input_property       => 'exome_cnv_dir',
+        destination          => $exome_cnv_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_input(
+        input_property       => 'model',
+        destination          => $exome_cnv_op,
+        destination_property => 'clinseq_model',
+    );
+    $workflow->connect_input(
+        input_property       => 'annotation_build',
+        destination          => $exome_cnv_op,
+        destination_property => 'annotation_build_id',
+    );
+    $workflow->connect_output(
+        output_property => 'exome_cnv_result',
+        source          => $exome_cnv_op,
+        source_property => 'result',
+    );
+
+    return $exome_cnv_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -2046,8 +2046,31 @@ sub annotate_genes_by_category_op {
     my $sequencing_type = shift;
     my $variant_type = shift;
 
+    my $name = "Add gene category annotations to ${variant_type}s identified by $sequencing_type";
+    my $output_property = "gene_category_${sequencing_type}_${variant_type}_result";
+
+    return $self->_annotate_genes_by_category_op($workflow, $name, $output_property);
+}
+
+sub annotate_genes_by_category_cnv_op {
+    my $self = shift;
+    my $workflow = shift;
+    my $type = shift;
+
+    my $name = "Add gene category annotations to CNV ${type} genes";
+    my $output_property = "gene_category_cnv_${type}_result";
+
+    return $self->_annotate_genes_by_category_op($workflow, $name, $output_property);
+}
+
+sub _annotate_genes_by_category_op {
+    my $self = shift;
+    my $workflow = shift;
+    my $name = shift;
+    my $output_property = shift;
+
     my $annotate_genes_by_category_op = Genome::WorkflowBuilder::Command->create(
-        name => "Add gene category annotations to ${variant_type}s identified by $sequencing_type",
+        name => $name,
         command => 'Genome::Model::ClinSeq::Command::AnnotateGenesByCategory',
     );
     $workflow->add_operation($annotate_genes_by_category_op);
@@ -2058,40 +2081,13 @@ sub annotate_genes_by_category_op {
             destination_property => $property,
         );
     }
-
     $workflow->connect_output(
-        output_property => "gene_category_${sequencing_type}_${variant_type}_result",
+        output_property => $output_property,
         source          => $annotate_genes_by_category_op,
         source_property => 'result',
     );
 
     return $annotate_genes_by_category_op;
-}
-
-sub annotate_genes_by_category_cnv_op {
-    my $self = shift;
-    my $workflow = shift;
-    my $type = shift;
-
-    my $annotate_genes_by_category_cnv_op = Genome::WorkflowBuilder::Command->create(
-        name => "Add gene category annotations to CNV ${type} genes",
-        command => 'Genome::Model::ClinSeq::Command::AnnotateGenesByCategory',
-    );
-    $workflow->add_operation($annotate_genes_by_category_cnv_op);
-    for my $property (qw(gene_name_columns cancer_annotation_db)) {
-        $workflow->connect_input(
-            input_property       => $property,
-            destination          => $annotate_genes_by_category_cnv_op,
-            destination_property => $property,
-        );
-    }
-    $workflow->connect_output(
-        output_property => "gene_category_cnv_${type}_result",
-        source          => $annotate_genes_by_category_cnv_op,
-        source_property => 'result',
-    );
-
-    return $annotate_genes_by_category_cnv_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -667,31 +667,7 @@ sub _resolve_workflow_for_build {
     #CufflinksDifferentialExpression - Run cufflinks differential expression
     my $cufflinks_differential_expression_op;
     if ($build->normal_rnaseq_build and $build->tumor_rnaseq_build) {
-        $cufflinks_differential_expression_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Performing cufflinks differential expression analysis for case vs. control (e.g. tumor vs. normal)',
-            command => 'Genome::Model::ClinSeq::Command::CufflinksDifferentialExpression',
-        );
-        $workflow->add_operation($cufflinks_differential_expression_op);
-        $workflow->connect_input(
-            input_property       => 'normal_rnaseq_build',
-            destination          => $cufflinks_differential_expression_op,
-            destination_property => 'control_build',
-        );
-        $workflow->connect_input(
-            input_property       => 'tumor_rnaseq_build',
-            destination          => $cufflinks_differential_expression_op,
-            destination_property => 'case_build',
-        );
-        $workflow->connect_input(
-            input_property       => 'cufflinks_differential_expression_dir',
-            destination          => $cufflinks_differential_expression_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_output(
-            output_property => 'cufflinks_differential_expression_result',
-            source          => $cufflinks_differential_expression_op,
-            source_property => 'result',
-        );
+        $cufflinks_differential_expression_op = $self->cufflinks_differential_expression_op($workflow);
     }
 
     #Intersect filtered fusion calls with WGS SV calls.
@@ -2167,6 +2143,39 @@ sub cufflinks_expression_absolute_op {
     );
 
     return $cufflinks_expression_absolute_op;
+}
+
+sub cufflinks_differential_expression_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $cufflinks_differential_expression_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Performing cufflinks differential expression analysis for case vs. control (e.g. tumor vs. normal)',
+        command => 'Genome::Model::ClinSeq::Command::CufflinksDifferentialExpression',
+    );
+    $workflow->add_operation($cufflinks_differential_expression_op);
+    $workflow->connect_input(
+        input_property       => 'normal_rnaseq_build',
+        destination          => $cufflinks_differential_expression_op,
+        destination_property => 'control_build',
+    );
+    $workflow->connect_input(
+        input_property       => 'tumor_rnaseq_build',
+        destination          => $cufflinks_differential_expression_op,
+        destination_property => 'case_build',
+    );
+    $workflow->connect_input(
+        input_property       => 'cufflinks_differential_expression_dir',
+        destination          => $cufflinks_differential_expression_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_output(
+        output_property => 'cufflinks_differential_expression_result',
+        source          => $cufflinks_differential_expression_op,
+        source_property => 'result',
+    );
+
+    return $cufflinks_differential_expression_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -593,7 +593,7 @@ sub _resolve_workflow_for_build {
     );
 
     #SummarizeBuilds - Summarize build inputs using SummarizeBuilds.pm
-    my $summarize_builds_op = $self->summarize_builds_op($workflow);
+    $self->summarize_builds_op($workflow);
 
     #ImportSnvsIndels - Import SNVs and Indels
     my $import_snvs_indels_op;
@@ -662,8 +662,8 @@ sub _resolve_workflow_for_build {
     #TophatJunctionsAbsolute - Run tophat junctions absolute analysis on normal
     #CufflinksExpressionAbsolute - Run cufflinks expression absolute analysis on normal
     if ($build->normal_rnaseq_build) {
-        my $normal_tophat_junctions_absolute_op = $self->tophat_junctions_absolute_op($workflow, 'normal');
-        my $normal_cufflinks_expression_absolute_op = $self->cufflinks_expression_absolute_op($workflow, 'normal');
+        $self->tophat_junctions_absolute_op($workflow, 'normal');
+        $self->cufflinks_expression_absolute_op($workflow, 'normal');
     }
     #TophatJunctionsAbsolute - Run tophat junctions absolute analysis on tumor
     #CufflinksExpressionAbsolute - Run cufflinks expression absolute analysis on tumor
@@ -677,7 +677,7 @@ sub _resolve_workflow_for_build {
             $self->copy_fusion_files($build);
             if ($build->wgs_build) {
                 if (-e $build->wgs_build->data_directory . '/effects/svs.hq.annotated') {
-                    my $intersect_tumor_fusion_sv_op = $self->intersect_tumor_fusion_sv_op($workflow);
+                    $self->intersect_tumor_fusion_sv_op($workflow);
                 }
             }
         }
@@ -691,7 +691,7 @@ sub _resolve_workflow_for_build {
 
     #DumpIgvXml - Create IGV xml session files with increasing numbers of tracks and store in a single (WGS and Exome BAM files, RNA-seq BAM files, junctions.bed, SNV bed files, etc.)
     #genome model clin-seq dump-igv-xml --outdir=/gscuser/mgriffit/ --builds=119971814
-    my $igv_session_op = $self->igv_session_op($workflow);
+    $self->igv_session_op($workflow);
 
     #GenerateClonalityPlots - Run clonality analysis and produce clonality plots
     #RunCnView - Produce copy number results with run-cn-view.
@@ -743,7 +743,7 @@ sub _resolve_workflow_for_build {
     if (($build->exome_build or $build->wgs_build)
         and $self->_get_docm_variants_file($self->cancer_annotation_db))
     {
-        my $docm_report_op = $self->docm_report_op($workflow);
+        $self->docm_report_op($workflow);
     }
 
     #SummarizeSvs - Generate a summary of SV results from the WGS SV results
@@ -1006,7 +1006,7 @@ sub _resolve_workflow_for_build {
     #IdentifyLoh - Run identify-loh tool for exome or WGS data
     #genome model clin-seq identify-loh --clinseq-build=fafd219665d54462893fbacfe6639f70 --outdir=/Documents/GTB11/ --bamrc-version=0.7
     if ($build->wgs_build or $build->exome_build) {
-        my $identify_loh_op = $self->identify_loh_op($workflow);
+        $self->identify_loh_op($workflow);
     }
 
     return $workflow;

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -710,31 +710,7 @@ sub _resolve_workflow_for_build {
     #RunMicroarrayCNV - produce cnv plots using microarray results
     my $microarray_cnv_op;
     if ($self->has_microarray_build()) {
-        $microarray_cnv_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Call somatic copy number changes using microarray calls',
-            command => 'Genome::Model::ClinSeq::Command::MicroarrayCnv',
-        );
-        $workflow->add_operation($microarray_cnv_op);
-        $workflow->connect_input(
-            input_property       => 'microarray_cnv_dir',
-            destination          => $microarray_cnv_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_input(
-            input_property       => 'model',
-            destination          => $microarray_cnv_op,
-            destination_property => 'clinseq_model',
-        );
-        $workflow->connect_input(
-            input_property       => 'annotation_build',
-            destination          => $microarray_cnv_op,
-            destination_property => 'annotation_build_id',
-        );
-        $workflow->connect_output(
-            output_property => 'microarray_cnv_result',
-            source          => $microarray_cnv_op,
-            source_property => 'result',
-        );
+        $microarray_cnv_op = $self->microarray_cnv_op($workflow);
     }
 
     #RunExomeCNV - produce cnv plots using WEx results
@@ -2211,6 +2187,39 @@ sub run_cn_view_op {
     );
 
     return $run_cn_view_op;
+}
+
+sub microarray_cnv_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $microarray_cnv_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Call somatic copy number changes using microarray calls',
+        command => 'Genome::Model::ClinSeq::Command::MicroarrayCnv',
+    );
+    $workflow->add_operation($microarray_cnv_op);
+    $workflow->connect_input(
+        input_property       => 'microarray_cnv_dir',
+        destination          => $microarray_cnv_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_input(
+        input_property       => 'model',
+        destination          => $microarray_cnv_op,
+        destination_property => 'clinseq_model',
+    );
+    $workflow->connect_input(
+        input_property       => 'annotation_build',
+        destination          => $microarray_cnv_op,
+        destination_property => 'annotation_build_id',
+    );
+    $workflow->connect_output(
+        output_property => 'microarray_cnv_result',
+        source          => $microarray_cnv_op,
+        source_property => 'result',
+    );
+
+    return $microarray_cnv_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -645,33 +645,18 @@ sub _resolve_workflow_for_build {
     }
 
     #TophatJunctionsAbsolute - Run tophat junctions absolute analysis on normal
-    if ($build->normal_rnaseq_build) {
-        my $normal_tophat_junctions_absolute_op = $self->tophat_junctions_absolute_op($workflow, 'normal');
-    }
-    #TophatJunctionsAbsolute - Run tophat junctions absolute analysis on tumor
-    my $tumor_tophat_junctions_absolute_op;
-    if ($build->tumor_rnaseq_build) {
-        $tumor_tophat_junctions_absolute_op = $self->tophat_junctions_absolute_op($workflow, 'tumor');
-    }
-
     #CufflinksExpressionAbsolute - Run cufflinks expression absolute analysis on normal
     if ($build->normal_rnaseq_build) {
+        my $normal_tophat_junctions_absolute_op = $self->tophat_junctions_absolute_op($workflow, 'normal');
         my $normal_cufflinks_expression_absolute_op = $self->cufflinks_expression_absolute_op($workflow, 'normal');
     }
+    #TophatJunctionsAbsolute - Run tophat junctions absolute analysis on tumor
     #CufflinksExpressionAbsolute - Run cufflinks expression absolute analysis on tumor
-    my $tumor_cufflinks_expression_absolute_op;
-    if ($build->tumor_rnaseq_build) {
-        $tumor_cufflinks_expression_absolute_op = $self->cufflinks_expression_absolute_op($workflow, 'tumor');
-    }
-
-    #CufflinksDifferentialExpression - Run cufflinks differential expression
-    my $cufflinks_differential_expression_op;
-    if ($build->normal_rnaseq_build and $build->tumor_rnaseq_build) {
-        $cufflinks_differential_expression_op = $self->cufflinks_differential_expression_op($workflow);
-    }
-
     #Intersect filtered fusion calls with WGS SV calls.
+    my ($tumor_tophat_junctions_absolute_op, $tumor_cufflinks_expression_absolute_op);
     if ($build->tumor_rnaseq_build) {
+        $tumor_tophat_junctions_absolute_op = $self->tophat_junctions_absolute_op($workflow, 'tumor');
+        $tumor_cufflinks_expression_absolute_op = $self->cufflinks_expression_absolute_op($workflow, 'tumor');
         if (-e $build->tumor_rnaseq_build->data_directory . '/fusions/filtered_chimeras.bedpe') {
             #copy over fusion files
             $self->copy_fusion_files($build);
@@ -681,6 +666,12 @@ sub _resolve_workflow_for_build {
                 }
             }
         }
+    }
+
+    #CufflinksDifferentialExpression - Run cufflinks differential expression
+    my $cufflinks_differential_expression_op;
+    if ($build->normal_rnaseq_build and $build->tumor_rnaseq_build) {
+        $cufflinks_differential_expression_op = $self->cufflinks_differential_expression_op($workflow);
     }
 
     #DumpIgvXml - Create IGV xml session files with increasing numbers of tracks and store in a single (WGS and Exome BAM files, RNA-seq BAM files, junctions.bed, SNV bed files, etc.)

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -1748,10 +1748,10 @@ sub make_circos_plot_op {
 sub converge_snv_indel_report_op {
     my $self = shift;
     my $workflow = shift;
-    my $iterator = shift;
+    my $index = shift;
 
     my $converge_snv_indel_report_op = Genome::WorkflowBuilder::Command->create(
-        name => "Generate SnvIndel Report$iterator",
+        name => "Generate SnvIndel Report$index",
         command => 'Genome::Model::ClinSeq::Command::Converge::SnvIndelReport',
     );
     $workflow->add_operation($converge_snv_indel_report_op);
@@ -1768,7 +1768,7 @@ sub converge_snv_indel_report_op {
         );
     }
     $workflow->connect_input(
-        input_property       => "snv_indel_report_dir$iterator",
+        input_property       => "snv_indel_report_dir$index",
         destination          => $converge_snv_indel_report_op,
         destination_property => 'outdir',
     );
@@ -1788,7 +1788,7 @@ sub converge_snv_indel_report_op {
     }
     for my $property (qw(bq mq)) {
         $workflow->connect_input(
-            input_property       => "sireport_min_$property$iterator",
+            input_property       => "sireport_min_$property$index",
             destination          => $converge_snv_indel_report_op,
             destination_property => $property,
         );
@@ -1802,7 +1802,7 @@ sub converge_snv_indel_report_op {
         );
     }
     $workflow->connect_output(
-        output_property => "converge_snv_indel_report_result$iterator",
+        output_property => "converge_snv_indel_report_result$index",
         source          => $converge_snv_indel_report_op,
         source_property => 'result',
     );
@@ -1814,10 +1814,10 @@ sub create_mutation_spectrum_op {
     my $self = shift;
     my $workflow = shift;
     my $sequencing_type = shift;
-    my $iterator = shift;
+    my $index = shift;
 
     my $create_mutation_spectrum_op = Genome::WorkflowBuilder::Command->create(
-        name => "Creating mutation spectrum results for $sequencing_type snvs using create-mutation-spectrum$iterator",
+        name => "Creating mutation spectrum results for $sequencing_type snvs using create-mutation-spectrum$index",
         command => 'Genome::Model::ClinSeq::Command::CreateMutationSpectrum',
     );
     $workflow->add_operation($create_mutation_spectrum_op);
@@ -1832,27 +1832,27 @@ sub create_mutation_spectrum_op {
         destination_property => 'somvar_build',
     );
     $workflow->connect_input(
-        input_property       => "${sequencing_type}_mutation_spectrum_outdir$iterator",
+        input_property       => "${sequencing_type}_mutation_spectrum_outdir$index",
         destination          => $create_mutation_spectrum_op,
         destination_property => 'outdir',
     );
     $workflow->connect_input(
-        input_property       => "${sequencing_type}_mutation_spectrum_datatype$iterator",
+        input_property       => "${sequencing_type}_mutation_spectrum_datatype$index",
         destination          => $create_mutation_spectrum_op,
         destination_property => 'datatype',
     );
     $workflow->connect_input(
-        input_property       => "sireport_min_bq$iterator",
+        input_property       => "sireport_min_bq$index",
         destination          => $create_mutation_spectrum_op,
         destination_property => 'min_base_quality',
     );
     $workflow->connect_input(
-        input_property       => "sireport_min_mq$iterator",
+        input_property       => "sireport_min_mq$index",
         destination          => $create_mutation_spectrum_op,
         destination_property => 'min_quality_score',
     );
     $workflow->connect_output(
-        output_property => "${sequencing_type}_mutation_spectrum_result$iterator",
+        output_property => "${sequencing_type}_mutation_spectrum_result$index",
         source          => $create_mutation_spectrum_op,
         source_property => 'result',
     );
@@ -1863,15 +1863,15 @@ sub create_mutation_spectrum_op {
 sub sciclone_op {
     my $self = shift;
     my $workflow = shift;
-    my $iterator = shift;
+    my $index = shift;
 
     my $sciclone_op = Genome::WorkflowBuilder::Command->create(
-        name => "Run clonality analysis and produce clonality plots using SciClone $iterator",
+        name => "Run clonality analysis and produce clonality plots using SciClone $index",
         command => 'Genome::Model::ClinSeq::Command::GenerateSciclonePlots',
     );
     $workflow->add_operation($sciclone_op);
     $workflow->connect_input(
-        input_property       => "sciclone_dir$iterator",
+        input_property       => "sciclone_dir$index",
         destination          => $sciclone_op,
         destination_property => 'outdir',
     );
@@ -1887,13 +1887,13 @@ sub sciclone_op {
     );
     for my $property (qw(min_mq min_bq)) {
         $workflow->connect_input(
-            input_property       => "sireport_$property$iterator",
+            input_property       => "sireport_$property$index",
             destination          => $sciclone_op,
             destination_property => $property,
         );
     }
     $workflow->connect_output(
-        output_property => "sciclone_result$iterator",
+        output_property => "sciclone_result$index",
         source          => $sciclone_op,
         source_property => 'result',
     );

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -743,31 +743,7 @@ sub _resolve_workflow_for_build {
     #SummarizeSvs - Generate a summary of SV results from the WGS SV results
     my $summarize_svs_op;
     if ($build->wgs_build) {
-        $summarize_svs_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Summarize SV results from WGS somatic variation',
-            command => 'Genome::Model::ClinSeq::Command::SummarizeSvs',
-        );
-        $workflow->add_operation($summarize_svs_op);
-        $workflow->connect_input(
-            input_property       => 'cancer_annotation_db',
-            destination          => $summarize_svs_op,
-            destination_property => 'cancer_annotation_db',
-        );
-        $workflow->connect_input(
-            input_property       => 'sv_dir',
-            destination          => $summarize_svs_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_input(
-            input_property       => 'wgs_build',
-            destination          => $summarize_svs_op,
-            destination_property => 'builds',
-        );
-        $workflow->connect_output(
-            output_property => 'summarize_svs_result',
-            source          => $summarize_svs_op,
-            source_property => 'result',
-        );
+        $summarize_svs_op = $self->summarize_svs_op($workflow);
     }
 
     #Add gene category annotations to some output files from steps above. (e.g. determine which SNV affected genes are kinases, ion channels, etc.)
@@ -2236,6 +2212,39 @@ sub summarize_cnvs_op {
     );
 
     return $summarize_cnvs_op;
+}
+
+sub summarize_svs_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $summarize_svs_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Summarize SV results from WGS somatic variation',
+        command => 'Genome::Model::ClinSeq::Command::SummarizeSvs',
+    );
+    $workflow->add_operation($summarize_svs_op);
+    $workflow->connect_input(
+        input_property       => 'cancer_annotation_db',
+        destination          => $summarize_svs_op,
+        destination_property => 'cancer_annotation_db',
+    );
+    $workflow->connect_input(
+        input_property       => 'sv_dir',
+        destination          => $summarize_svs_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_input(
+        input_property       => 'wgs_build',
+        destination          => $summarize_svs_op,
+        destination_property => 'builds',
+    );
+    $workflow->connect_output(
+        output_property => 'summarize_svs_result',
+        source          => $summarize_svs_op,
+        source_property => 'result',
+    );
+
+    return $summarize_svs_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -1130,52 +1130,8 @@ sub _resolve_workflow_for_build {
     #IdentifyLoh - Run identify-loh tool for exome or WGS data
     #genome model clin-seq identify-loh --clinseq-build=fafd219665d54462893fbacfe6639f70 --outdir=/Documents/GTB11/ --bamrc-version=0.7
     if ($build->wgs_build or $build->exome_build) {
-        my $identify_loh_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Identify regions of LOH and create plots',
-            command => 'Genome::Model::ClinSeq::Command::IdentifyLoh',
-        );
-        $workflow->add_operation($identify_loh_op);
-        $workflow->connect_input(
-            input_property       => 'build',
-            destination          => $identify_loh_op,
-            destination_property => 'clinseq_build',
-        );
-        $workflow->connect_input(
-            input_property       => 'loh_output_dir',
-            destination          => $identify_loh_op,
-            destination_property => 'outdir',
-        );
-        $workflow->connect_input(
-            input_property       => 'bam_readcount_version',
-            destination          => $identify_loh_op,
-            destination_property => 'bamrc_version',
-        );
-
-        if ($self->name =~ /^apipe\-test/) {
-            $workflow->connect_input(
-                input_property       => 'test',
-                destination          => $identify_loh_op,
-                destination_property => 'test',
-            );
-        }
-        $workflow->connect_output(
-            output_property => 'loh_result',
-            source          => $identify_loh_op,
-            source_property => 'result',
-        );
+        my $identify_loh_op = $self->identify_loh_op($workflow);
     }
-
-    # REMINDER:
-    # For new steps be sure to add their result to the output connector if they do not feed into another step.
-    # When you do that, expand the list of output properties above.
-
-    # my @errors = $workflow->validate();
-    # if (@errors) {
-        # for my $error (@errors) {
-            # $self->error_message($error);
-        # }
-        # die "Invalid workflow!";
-    # }
 
     return $workflow;
 }
@@ -2034,6 +1990,47 @@ sub sciclone_op {
     );
 
     return $sciclone_op;
+}
+
+sub identify_loh_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $identify_loh_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Identify regions of LOH and create plots',
+        command => 'Genome::Model::ClinSeq::Command::IdentifyLoh',
+    );
+    $workflow->add_operation($identify_loh_op);
+    $workflow->connect_input(
+        input_property       => 'build',
+        destination          => $identify_loh_op,
+        destination_property => 'clinseq_build',
+    );
+    $workflow->connect_input(
+        input_property       => 'loh_output_dir',
+        destination          => $identify_loh_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_input(
+        input_property       => 'bam_readcount_version',
+        destination          => $identify_loh_op,
+        destination_property => 'bamrc_version',
+    );
+
+    if ($self->name =~ /^apipe\-test/) {
+        $workflow->connect_input(
+            input_property       => 'test',
+            destination          => $identify_loh_op,
+            destination_property => 'test',
+        );
+    }
+    $workflow->connect_output(
+        output_property => 'loh_result',
+        source          => $identify_loh_op,
+        source_property => 'result',
+    );
+
+    return $identify_loh_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -696,26 +696,7 @@ sub _resolve_workflow_for_build {
     #RunCnView - Produce copy number results with run-cn-view.  Relies on clonality step already having been run
     my $run_cn_view_op;
     if ($build->wgs_build) {
-        $run_cn_view_op = Genome::WorkflowBuilder::Command->create(
-            name => 'Use gmt copy-number cn-view to produce copy number tables and images',
-            command => 'Genome::Model::ClinSeq::Command::RunCnView',
-        );
-        $workflow->add_operation($run_cn_view_op);
-        $workflow->connect_input(
-            input_property       => 'cancer_annotation_db',
-            destination          => $run_cn_view_op,
-            destination_property => 'cancer_annotation_db',
-        );
-        $workflow->connect_input(
-            input_property       => 'wgs_build',
-            destination          => $run_cn_view_op,
-            destination_property => 'build',
-        );
-        $workflow->connect_input(
-            input_property       => 'wgs_cnv_dir',
-            destination          => $run_cn_view_op,
-            destination_property => 'outdir',
-        );
+        $run_cn_view_op = $self->run_cn_view_op($workflow);
         for my $property (qw(cnv_hmm_file cnv_hq_file)) {
             $workflow->create_link(
                 source               => $clonality_op,
@@ -724,11 +705,6 @@ sub _resolve_workflow_for_build {
                 destination_property => $property,
             );
         }
-        $workflow->connect_output(
-            output_property => 'run_cn_view_result',
-            source          => $run_cn_view_op,
-            source_property => 'result',
-        );
     }
 
     #RunMicroarrayCNV - produce cnv plots using microarray results
@@ -2202,6 +2178,39 @@ sub clonality_op {
     );
 
     return $clonality_op;
+}
+
+sub run_cn_view_op {
+    my $self = shift;
+    my $workflow = shift;
+
+    my $run_cn_view_op = Genome::WorkflowBuilder::Command->create(
+        name => 'Use gmt copy-number cn-view to produce copy number tables and images',
+        command => 'Genome::Model::ClinSeq::Command::RunCnView',
+    );
+    $workflow->add_operation($run_cn_view_op);
+    $workflow->connect_input(
+        input_property       => 'cancer_annotation_db',
+        destination          => $run_cn_view_op,
+        destination_property => 'cancer_annotation_db',
+    );
+    $workflow->connect_input(
+        input_property       => 'wgs_build',
+        destination          => $run_cn_view_op,
+        destination_property => 'build',
+    );
+    $workflow->connect_input(
+        input_property       => 'wgs_cnv_dir',
+        destination          => $run_cn_view_op,
+        destination_property => 'outdir',
+    );
+    $workflow->connect_output(
+        output_property => 'run_cn_view_result',
+        source          => $run_cn_view_op,
+        source_property => 'result',
+    );
+
+    return $run_cn_view_op;
 }
 
 sub _infer_candidate_subjects_from_input_models {


### PR DESCRIPTION
This PR makes ClinSeq use WorkflowBuilder. It also includes some refactoring of the _resolve_workflow_for_build subroutine by split the various parts of the workflow into separate subroutines for clarity (hopefully).

I ran a ClinSeq test build in a custom checkout and the workflows look identical. @jasonwalker80, you mentioned that you were working on a ClinSeq model that would include all possible steps. It might be worthwhile to run a build of that model on this PR to make sure that all steps are still executed.

@acoffman, @gatoravi , @jasonwalker80 Feel free to push additional commits to this PR with any improvements that might be necessary while I'm on vacation.