### PR TITLE
Set a default empty value for parent_workflow_log_directory.

### DIFF
--- a/etc/genome/spec/parent_workflow_log_directory.yaml
+++ b/etc/genome/spec/parent_workflow_log_directory.yaml
@@ -1,2 +1,3 @@
 ---
 env: XGENOME_PARENT_WORKFLOW_LOG_DIRECTORY
+default_value: ''

--- a/lib/perl/Genome/Config/Command/List.t
+++ b/lib/perl/Genome/Config/Command/List.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Genome qw();
+use above 'Genome';
 use Genome::Test::Config qw(setup_config);
 
 use Test::More tests => 4;


### PR DESCRIPTION
This fixes `genome config list`, which chokes on undefined values.