### PR TITLE
Update blessed process object for Jenkins genome-process-test

### DIFF
--- a/lib/perl/Genome/Process/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Process/Command/DiffBlessed.pm.YAML
@@ -1,2 +1,2 @@
 ---
-trio_main: d119fb9806dd4c86a51bc6dc0af16bc4
+trio_main: e9475bebc3584a80a36e19fbb8b1acae


### PR DESCRIPTION
All diff is caused by the newly added c_posiotion column in report. Now update blessed object. Need merge this asap to make model/process test pass.