### PR TITLE
Use inline workflow backend instead of NO_LSF environment variable.

### DIFF
--- a/lib/perl/Genome/Db/Ensembl/Command/Run/Base.pm
+++ b/lib/perl/Genome/Db/Ensembl/Command/Run/Base.pm
@@ -296,7 +296,7 @@ sub execute {
         my $workflow = $self->workflow;
         my $workflow_inputs = $self->workflow_inputs;
         $workflow_inputs->{analysis_process} = $process;
-        local $ENV{NO_LSF} = 1;
+        my $guard = Genome::Config::set_env('workflow_builder_backend', 'inline');
         $process->run_and_wait(workflow_xml => $workflow->get_xml,
                                workflow_inputs => $workflow_inputs);
     }


### PR DESCRIPTION
The `NO_LSF` variable is dependent on Workflow to succeed.  (This was the only place outside of a test where it was still being used.)