### PR TITLE
Add LSF ID to the Ptero workflow display.

### DIFF
--- a/lib/perl/Genome/Command/PteroWorkflowMixin.pm
+++ b/lib/perl/Genome/Command/PteroWorkflowMixin.pm
@@ -113,10 +113,11 @@ sub _ptero_status_color {
 
 sub _format_line {
     my $self = shift;
-    my ($id, $stage, $status, $started, $duration, $pindex, $indent, $name) = @_;
+    my ($id, $lsf_job_id, $stage, $status, $started, $duration, $pindex, $indent, $name) = @_;
 
     return join("  ",
         justify($self->_color_dim($id), 'right', 10),
+        justify($lsf_job_id, 'right', 8),
         justify($self->_color_dim($stage), 'right', 8),
         justify($self->_ptero_status_color($status), 'right', 9),
         justify($self->_color_dim("$started"), 'right', 19),
@@ -131,6 +132,7 @@ sub _write_ptero_header {
 
     $handle->print($self->_color_dim(strip_color($self->_format_line(
         'ID',
+        'LSF ID',
         'STAGE',
         'STATUS',
         'STARTED',
@@ -150,6 +152,7 @@ sub _write_ptero_workflow {
         $handle->print($self->_format_line(
             '',
             '',
+            '',
             $execution->{status},
             $execution->datetime_started,
             $execution->duration,
@@ -158,6 +161,7 @@ sub _write_ptero_workflow {
             $workflow->{name}));
     } elsif (scalar(keys %{$workflow->{executions}}) == 0) {
         $handle->print($self->_format_line(
+            '',
             '',
             '',
             $workflow->{status},
@@ -185,6 +189,7 @@ sub _write_ptero_spawned_workflow {
     if ($execution) {
         $handle->print($self->_format_line(
             '',
+            '',
             'spawn',
             $execution->{status},
             $execution->datetime_started,
@@ -194,6 +199,7 @@ sub _write_ptero_spawned_workflow {
             $workflow->{name}));
     } elsif (scalar(keys %{$workflow->{executions}}) == 0) {
         $handle->print($self->_format_line(
+            '',
             '',
             'spawn',
             $workflow->{status},
@@ -272,6 +278,7 @@ sub _write_ptero_dag_details {
         $handle->print($self->_format_line(
             '',
             '',
+            '',
             $execution->{status},
             $execution->datetime_started,
             $execution->duration,
@@ -280,6 +287,7 @@ sub _write_ptero_dag_details {
             $method->{name}));
     } elsif (scalar(keys %{$method->{executions}}) == 0) {
         $handle->print($self->_format_line(
+            '',
             '',
             '',
             '',
@@ -354,6 +362,7 @@ sub _write_ptero_command_details_shortcut {
     if ($execution) {
         $handle->print($self->_format_line(
             $execution->{id},
+            '',
             'shortcut',
             $execution->{status},
             $execution->datetime_started,
@@ -380,6 +389,7 @@ sub _write_ptero_command_details_execute {
     if ($execution) {
         $handle->print($self->_format_line(
             $execution->{id},
+            ($execution->{data}{lsfJobId} // ''),
             'execute',
             $execution->{status},
             $execution->datetime_started,
@@ -400,7 +410,7 @@ sub _write_ptero_command_details_unstarted {
         $parallel_by_str = $self->_color_pair("parallel-by", $task->{parallel_by});
     }
 
-    $handle->printf("%s%s%s\n", justify($parallel_by_str, 'center', 78), $INDENTATION_STR x $indent, $task_name);
+    $handle->printf("%s%s%s\n", justify($parallel_by_str, 'center', 88), $INDENTATION_STR x $indent, $task_name);
     return;
 }
 
@@ -418,7 +428,7 @@ sub _write_ptero_task_summary {
             $statuses{$status});
     }
 
-    $handle->printf("%s%s%s\n", justify($status_str, 'center', 78), $INDENTATION_STR x $indent, $task_name);
+    $handle->printf("%s%s%s\n", justify($status_str, 'center', 88), $INDENTATION_STR x $indent, $task_name);
     return;
 }
 


### PR DESCRIPTION
Now that PTero is configured to pass the job ID back to the execution (per PR #1325), we can get this info without an additional API call per job.  Instead it's in the info we're already pulling back!

I promise I updated the `else` cases this time!  (cf. PR #1329)