### PR TITLE
Use correct accessor to get FASTA for bsmap tests.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Bsmap/MethRatio.t
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethRatio.t
@@ -18,7 +18,7 @@ sub fasta_for_reference {
     my ($name, $version) = @_;
     return Genome::Model::ImportedReferenceSequence->get(
         name => $name
-    )->build_by_version($version)->fasta_file();
+    )->build_by_version($version)->full_consensus_path('fa');
 }
 
 sub create_test_object {

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.t
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethylationRatio.t
@@ -19,7 +19,7 @@ sub fasta_for_reference {
     my ($name, $version) = @_;
     return Genome::Model::ImportedReferenceSequence->get(
         name => $name
-    )->build_by_version($version)->fasta_file();
+    )->build_by_version($version)->full_consensus_path('fa');
 }
 
 sub create_test_object {


### PR DESCRIPTION
`fasta_file` is the original import location of the file, not the current location.