### PR TITLE
MergeAlignments: Specify an LSF queue configuration.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/MergeAlignments.pm
+++ b/lib/perl/Genome/InstrumentData/Command/MergeAlignments.pm
@@ -67,6 +67,9 @@ class Genome::InstrumentData::Command::MergeAlignments {
         lsf_resource => {
             default_value => &bsub_rusage,
         },
+        lsf_queue => {
+            default_value => Genome::Config::get('lsf_queue_build_worker'),
+        },
     ],
 };
 


### PR DESCRIPTION
Production jobs were ending up in the default queue, which is suboptimal.