### PR TITLE
Allow apipe-builder to use AbandonAndQueue.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Abandon.pm
+++ b/lib/perl/Genome/Model/Build/Command/Abandon.pm
@@ -77,6 +77,3 @@ sub successfully_abandoned_callback {
 }
 
 1;
-
-#$HeadURL$
-#$Id$

--- a/lib/perl/Genome/Model/Build/Command/Base.pm
+++ b/lib/perl/Genome/Model/Build/Command/Base.pm
@@ -34,14 +34,7 @@ sub _limit_results_for_builds {
             push @run_by_builds, $build;
         }
         elsif ($user eq 'apipe-builder') {
-            if ( $class =~ /::Stop$/    ||
-                 $class =~ /::Abandon$/ ||
-                 $class =~ /::AbandonAndQueue$/ ) {
-                    push @apipe_builder_builds, $build;
-            }
-            else {
-                next;
-            }
+            push @apipe_builder_builds, $build;
         }
         else {
             next;

--- a/lib/perl/Genome/Model/Build/Command/Base.pm
+++ b/lib/perl/Genome/Model/Build/Command/Base.pm
@@ -35,7 +35,8 @@ sub _limit_results_for_builds {
         }
         elsif ($user eq 'apipe-builder') {
             if ( $class =~ /::Stop$/    || $class =~ /::Remove$/ ||
-                 $class =~ /::Abandon$/ || $class =~ /::Start$/   ) {
+                 $class =~ /::Abandon$/ || $class =~ /::Start$/  ||
+                 $class =~ /::AbandonAndQueue$/ ) {
                     push @apipe_builder_builds, $build;
             }
             else {

--- a/lib/perl/Genome/Model/Build/Command/Base.pm
+++ b/lib/perl/Genome/Model/Build/Command/Base.pm
@@ -35,7 +35,7 @@ sub _limit_results_for_builds {
         }
         elsif ($user eq 'apipe-builder') {
             if ( $class =~ /::Stop$/    ||
-                 $class =~ /::Abandon$/ || $class =~ /::Start$/  ||
+                 $class =~ /::Abandon$/ ||
                  $class =~ /::AbandonAndQueue$/ ) {
                     push @apipe_builder_builds, $build;
             }

--- a/lib/perl/Genome/Model/Build/Command/Base.pm
+++ b/lib/perl/Genome/Model/Build/Command/Base.pm
@@ -34,7 +34,7 @@ sub _limit_results_for_builds {
             push @run_by_builds, $build;
         }
         elsif ($user eq 'apipe-builder') {
-            if ( $class =~ /::Stop$/    || $class =~ /::Remove$/ ||
+            if ( $class =~ /::Stop$/    ||
                  $class =~ /::Abandon$/ || $class =~ /::Start$/  ||
                  $class =~ /::AbandonAndQueue$/ ) {
                     push @apipe_builder_builds, $build;


### PR DESCRIPTION
This used to inspect to see which of its subclasses it was, which is not ideal.  I wanted to add support for "AbandonAndQueue", but it turned out this made the list match all known subclasses, so it's easier to remove the check.