### PR TITLE
Make LSF resource for SomaticVariation report step configurable.

### DIFF
--- a/etc/genome/spec/lsf_resource_somvar_reports.yaml
+++ b/etc/genome/spec/lsf_resource_somvar_reports.yaml
@@ -1,0 +1,3 @@
+---
+default_value: "-R 'select[tmp>2000] rusage[tmp=2000]'"
+env: XGENOME_LSF_RESOURCE_SOMVAR_REPORTS

--- a/lib/perl/Genome/Model/SomaticVariation/Command/CreateReport.pm
+++ b/lib/perl/Genome/Model/SomaticVariation/Command/CreateReport.pm
@@ -87,7 +87,7 @@ class Genome::Model::SomaticVariation::Command::CreateReport {
     ],
     has_param => [
         lsf_resource => {
-            default => "-R 'select[tmp>2000] rusage[tmp=2000]'",
+            default => Genome::Config::get('lsf_resource_somvar_reports'),
         },
     ],
 };


### PR DESCRIPTION
We had this get `TERM_MEMLIMIT`ed recently.