### PR TITLE
Add wgs/exome only if input builds exist

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -943,11 +943,10 @@ sub _resolve_workflow_for_build {
             exome => $exome_variant_sources_op,
             wgs   => $wgs_variant_sources_op,
         );
-        my $sequencing_types = $self->_get_sequencing_types($build);
         #Create a report for each $bq $mq combo.
         for my $i (1..@$mqs) {
             my $converge_snv_indel_report_op = $self->converge_snv_indel_report_op($workflow, $i);
-            for my $sequencing_type (@$sequencing_types) {
+            for my $sequencing_type (qw(exome wgs)) {
                 my $build_accessor = "${sequencing_type}_build";
                 if ($build->$build_accessor) {
                     for my $variant_type (qw(snv indel)) {
@@ -2191,15 +2190,6 @@ sub has_microarray_build {
     else {
         return 0;
     }
-}
-
-sub _get_sequencing_types {
-    my $self = shift;
-    my $build = shift;
-    my @sequencing_types;
-    push @sequencing_types, "wgs" if $build->wgs_build;
-    push @sequencing_types, "exome" if $build->exome_build;
-    return \@sequencing_types;
 }
 
 sub _get_docm_variants_file {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -943,10 +943,11 @@ sub _resolve_workflow_for_build {
             exome => $exome_variant_sources_op,
             wgs   => $wgs_variant_sources_op,
         );
+        my $sequencing_types = $self->_get_sequencing_types($build);
         #Create a report for each $bq $mq combo.
         for my $i (1..@$mqs) {
             my $converge_snv_indel_report_op = $self->converge_snv_indel_report_op($workflow, $i);
-            for my $sequencing_type (qw(exome wgs)) {
+            for my $sequencing_type (@$sequencing_types) {
                 my $build_accessor = "${sequencing_type}_build";
                 if ($build->$build_accessor) {
                     for my $variant_type (qw(snv indel)) {
@@ -2190,6 +2191,15 @@ sub has_microarray_build {
     else {
         return 0;
     }
+}
+
+sub _get_sequencing_types {
+    my $self = shift;
+    my $build = shift;
+    my @sequencing_types;
+    push @sequencing_types, "wgs" if $build->wgs_build;
+    push @sequencing_types, "exome" if $build->exome_build;
+    return \@sequencing_types;
 }
 
 sub _get_docm_variants_file {

--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -957,14 +957,14 @@ sub _resolve_workflow_for_build {
                             destination_property => "_${sequencing_type}_${variant_type}_variant_sources_file",
                         );
                     }
+                    my $create_mutation_spectrum_op = $self->create_mutation_spectrum_op($workflow, $sequencing_type, $i);
+                    $workflow->create_link(
+                        source               => $converge_snv_indel_report_op,
+                        source_property      => 'result',
+                        destination          => $create_mutation_spectrum_op,
+                        destination_property => 'converge_snv_indel_report_result',
+                    );
                 }
-                my $create_mutation_spectrum_op = $self->create_mutation_spectrum_op($workflow, $sequencing_type, $i);
-                $workflow->create_link(
-                    source               => $converge_snv_indel_report_op,
-                    source_property      => 'result',
-                    destination          => $create_mutation_spectrum_op,
-                    destination_property => 'converge_snv_indel_report_result',
-                );
             }
             if ($build->wgs_build or $build->should_run_exome_cnv) {
                 my $sciclone_op = $self->sciclone_op($workflow, $i);


### PR DESCRIPTION
Currently if a clin-seq build only has a exome_model as an input,
the wgs version of create-mutation-spectrum is still added as a
step in the workflow. This pull-request hopes to fix that.