### PR TITLE
RefAlign Summary Test Doesn't Lock

### DIFF
--- a/lib/perl/Genome/Model/ReferenceAlignment/Report/Summary.t
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Report/Summary.t
@@ -3,9 +3,14 @@
 use strict;
 use warnings;
 
+use File::Temp;
+
+
 BEGIN {
     #use locks local to this test--must be set before Genome is loaded
-    $ENV{XGENOME_SITE_LOCK_DIR} = '/tmp';
+    my $lock_tempdir = File::Temp::tempdir(CLEANUP => 1);
+    $ENV{XGENOME_SITE_LOCK_DIR} = $lock_tempdir;
+
     $ENV{UR_DBI_NO_COMMIT} = 1;
 }
 

--- a/lib/perl/Genome/Model/ReferenceAlignment/Report/Summary.t
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Report/Summary.t
@@ -3,6 +3,11 @@
 use strict;
 use warnings;
 
+BEGIN {
+    #use locks local to this test--must be set before Genome is loaded
+    $ENV{XGENOME_SITE_LOCK_DIR} = '/tmp';
+}
+
 use above "Genome";
 use Test::More tests => 8;
 use Genome::Sys;

--- a/lib/perl/Genome/Model/ReferenceAlignment/Report/Summary.t
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Report/Summary.t
@@ -6,6 +6,7 @@ use warnings;
 BEGIN {
     #use locks local to this test--must be set before Genome is loaded
     $ENV{XGENOME_SITE_LOCK_DIR} = '/tmp';
+    $ENV{UR_DBI_NO_COMMIT} = 1;
 }
 
 use above "Genome";


### PR DESCRIPTION
More accurately, it doesn't use the real lock location so multiple test runs don't collide.

I'd be swell to use `Genome::Config::set_env('site_lock_dir', Genome::Sys->create_temp_directory)` instead, but using `Genome` already takes us past the point where this value gets examined.