### PR TITLE
Use Genome so test-tracker succeeds.

### DIFF
--- a/lib/perl/Genome/paths_case_insensitive.t
+++ b/lib/perl/Genome/paths_case_insensitive.t
@@ -7,6 +7,8 @@ use warnings;
 use Test::More;
 use IPC::System::Simple qw(capture);
 
+use above 'Genome'; #test-tracker wants each test to use at least one module in the namespace
+
 my %count;
 my @files = git('ls-files');
 


### PR DESCRIPTION
Although Jenkins hasn't noticed, this test has been failing under test-tracker since it doesn't load any Genome modules.  While it lasts, [here's an example](https://apipe-ci.gsc.wustl.edu/job/1-Genome-Perl-Tests/6403/PERL_VERSION=5.10/testReport/(root)/paths_case_insensitive_t/1___found_more_than_one_file/). 

Ideally this test would always run, since it tests every path in the repo, but I don't think making it duplicate the WebApp Core test by `use`ing the entire tree is worthwhile.