### PR TITLE
WorkflowBuilder supports references to other XML files

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/Detail/Operation.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Detail/Operation.pm
@@ -94,8 +94,8 @@ sub from_xml_file {
 sub from_xml_filename {
     my ($class, $filename) = @_;
 
-    my $fh = Genome::Sys->open_file_for_reading($filename);
-    return $class->from_xml_file($fh);
+    my $doc = XML::LibXML->load_xml(location => $filename);
+    return $class->from_xml_element($doc->documentElement);
 }
 
 sub operation_type {

--- a/lib/perl/Genome/WorkflowBuilder/Detail/Operation.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Detail/Operation.pm
@@ -12,7 +12,7 @@ use Carp qw(confess);
 use Data::Dumper qw();
 use List::MoreUtils qw(firstval);
 use Params::Validate qw(validate_pos :types);
-
+use Path::Class qw();
 
 class Genome::WorkflowBuilder::Detail::Operation {
     is => 'Genome::WorkflowBuilder::Detail::Element',
@@ -59,8 +59,18 @@ sub from_xml_element {
                 "from_xml_element not implemented in subclass %s", $class));
     }
 
-    my $subclass = $class->_get_subclass_from_element($element);
-    return $subclass->from_xml_element($element, @rest);
+    my $has_file = $element->hasAttribute('workflowFile');
+    if ($has_file) {
+        my $file = $class->_find_inner_workflow_file_for_element($element);
+        my $result = $class->from_xml_filename($file);
+        if ($element->hasAttribute('name')) {
+            $result->name($element->getAttribute('name'));
+        }
+        return $result;
+    } else {
+        my $subclass = $class->_get_subclass_from_element($element);
+        return $subclass->from_xml_element($element, @rest);
+    }
 }
 
 sub input_properties {}
@@ -220,6 +230,35 @@ sub _add_property_xml_element {
     $element->addChild($inner_element);
 
     return;
+}
+
+sub _find_inner_workflow_file_for_element {
+    my ($class, $element) = @_;
+
+    my $file = $element->getAttribute('workflowFile');
+    unless ($file) {
+        $class->fatal_message('No workflow file set on element.');
+    }
+
+    my $path = Path::Class::file($file);
+
+    unless ($path->is_absolute()) {
+        #relative paths should be relative to the current WF file, rather than the CWD.
+        my $current_file = $element->ownerDocument->URI;
+        if (defined $current_file and -e $current_file) {
+            my $current_path = Path::Class::file($current_file);
+            $path = $current_path->dir->file($file);
+            $file = $path->stringify();
+        } else {
+            $class->fatal_message('Cannot resolve relative path <%s> in inner workflow.', $file);
+        }
+    }
+
+    unless (-e $file) {
+        $class->fatal_message('Inner workflow file <%s> not found!', $file);
+    }
+
+    return $file;
 }
 
 sub _get_subclass_from_element {

--- a/lib/perl/Genome/WorkflowBuilder/Test/XmlReferences.t
+++ b/lib/perl/Genome/WorkflowBuilder/Test/XmlReferences.t
@@ -1,0 +1,53 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+
+use Sub::Install qw();
+
+use Test::More tests => 6;
+
+my $test_dir = __FILE__ . '.d';
+
+use Genome::WorkflowBuilder::Test::DummyCommand;
+
+my $count = 0;
+my $expected = 'expected output';
+Sub::Install::install_sub({
+    code => sub {
+        my $self = shift;
+        $self->single_output($expected);
+
+        return ++$count;
+    },
+    into => 'Genome::WorkflowBuilder::Test::DummyCommand',
+    as   => '_execute_body',
+});
+
+#Since the outputs are "required" properties, set defaults here
+my $meta = Genome::WorkflowBuilder::Test::DummyCommand->__meta__;
+$meta->property(property_name => 'single_output')->default_value('unexpected output');
+$meta->property(property_name => 'many_output')->default_value([qw(not used)]);
+
+my $xml = File::Spec->join($test_dir, 'outer.xml');
+my $dag = Genome::WorkflowBuilder::DAG->from_xml_filename($xml);
+isa_ok($dag, 'Genome::WorkflowBuilder::DAG', 'constructed DAG from XML');
+
+my $inner = $dag->operation_named('inner');
+isa_ok($inner, 'Genome::WorkflowBuilder::DAG', 'created inner DAG with name from outer DAG');
+
+my $dummy = $inner->operation_named('dummy');
+is($dummy->command, 'Genome::WorkflowBuilder::Test::DummyCommand', 'created operation');
+
+my $outputs = $dag->execute_inline({input => 'test'});
+ok($outputs, 'executed DAG');
+is($outputs->{single_output}, $expected, 'got output expected');
+is($count, 1, 'command was executed as expected');
+
+done_testing();

--- a/lib/perl/Genome/WorkflowBuilder/Test/XmlReferences.t.d/inner.xml
+++ b/lib/perl/Genome/WorkflowBuilder/Test/XmlReferences.t.d/inner.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' standalone='yes'?>
+<workflow name="test inner pipeline" executor="Workflow::Executor::SerialDeferred" logDir="/tmp/">
+    <operation name="dummy">
+         <operationtype commandClass="Genome::WorkflowBuilder::Test::DummyCommand" typeClass="Workflow::OperationType::Command"/>
+    </operation>
+
+    <link fromOperation="input connector" fromProperty="input" toOperation="dummy" toProperty="input" />
+    <link fromOperation="dummy" fromProperty="single_output" toOperation="output connector" toProperty="single_output" />
+
+     <operationtype typeClass="Workflow::OperationType::Model">
+        <inputproperty>input</inputproperty>
+        <outputproperty>single_output</outputproperty>
+    </operationtype>
+</workflow>

--- a/lib/perl/Genome/WorkflowBuilder/Test/XmlReferences.t.d/outer.xml
+++ b/lib/perl/Genome/WorkflowBuilder/Test/XmlReferences.t.d/outer.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' standalone='yes'?>
+<workflow name="test outer pipeline" executor="Workflow::Executor::SerialDeferred" logDir="/tmp/">
+    <operation name="inner" workflowFile="inner.xml" />
+
+    <link fromOperation="input connector" fromProperty="input" toOperation="inner" toProperty="input" />
+    <link fromOperation="inner" fromProperty="single_output" toOperation="output connector" toProperty="single_output" />
+
+     <operationtype typeClass="Workflow::OperationType::Model">
+        <inputproperty>input</inputproperty>
+        <outputproperty>single_output</outputproperty>
+    </operationtype>
+</workflow>


### PR DESCRIPTION
One smaller feature `Workflow` has is that the definition of an operation can be in a separate file.  This brings that feature to `WorkflowBuilder`.