### PR TITLE
New ClinSeq blessed build

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
@@ -1,7 +1,7 @@
 ---
 apipe-test-amplicon-assembly: 133133151
 apipe-test-clinseq-v1: 133114501
-apipe-test-clinseq-wer: b11e803ca7c048e29ec8ba42cd364a06
+apipe-test-clinseq-wer: 0bc8c6ff5d4c4fc0ae645335f738a29d
 apipe-test-de-novo-soap: 137388725
 apipe-test-de-novo-velvet: 79a406fcf18c46e090dec62342b2c4ae
 apipe-test-gene-prediction-bacterial: 4ddaecaa52364dd09b3a4d7709ddfc3b


### PR DESCRIPTION
PR #1392 changed some file contents from 'Somatic Variation' to 'Somatic'

`vimdiff <(sort /gscmnt/gc9022/info/model_data/8a175224cae14b80ab36d749216efb2b/buildb11e803ca7c048e29ec8ba42cd364a06/AML109/input/summary/Stats.tsv) <(sort /gscmnt/gc9026/test/model_data/8a175224cae14b80ab36d749216efb2b/build0bc8c6ff5d4c4fc0ae645335f738a29d/AML109/input/summary/Stats.tsv)`