### PR TITLE
Better Intermediate Result Deletion

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/WithIntermediateResults.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/WithIntermediateResults.pm
@@ -85,7 +85,7 @@ sub remove_intermediate_results {
 
         if($result_users) {
             while(my ($label, $user) = each %$result_users) {
-                my @using = $iar->users(user => $user, label => $label);
+                my @using = $iar->users(user => $user);
                 map $_->active(0), @using;
             }
         }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/WithIntermediateResults.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/WithIntermediateResults.pm
@@ -17,7 +17,7 @@ sub create {
     my $self = $class->SUPER::create(@_);
     return if not $self;
 
-    my $rm_iar_ok = $self->remove_intemediate_results;
+    my $rm_iar_ok = $self->remove_intermediate_results;
     return if not $rm_iar_ok;
 
     return $self;
@@ -73,7 +73,7 @@ sub get_or_create_intermediate_result_for_params {
     return $intermediate_result;
 }
 
-sub remove_intemediate_results {
+sub remove_intermediate_results {
     my $self = shift;
 
     my $result_users = $self->_user_data_for_nested_results;


### PR DESCRIPTION
The addition of the `shortcut` label as this is used by the main AR was preventing its subsequent deletion.  This change broadens the inactivation of users.

(An alternative might be to inactivate all users and forcibly remove the result.  That would eliminate any means of claiming intermediate results, though.)