### PR TITLE
Path for BER has moved.

### DIFF
--- a/lib/perl/Genome/Model/Build/GenePrediction/Bacterial.pm
+++ b/lib/perl/Genome/Model/Build/GenePrediction/Bacterial.pm
@@ -133,7 +133,7 @@ sub create_config_file {
         seq_file_name    => $self->sequence_file_name,
         skip_acedb_parse => $model->skip_acedb_parse,
         workflowxml      => __FILE__.'.noblastp.outer.xml',
-        ber_base_directory => '/gscmnt/gc9002/info/annotation/BER/autoannotate_v2.5' #FIXME This should be a parameter!
+        ber_base_directory => '/gscmnt/gc3009/info/annotation/personal_dirs/jmartin/BER/autoannotate_v2.5' #FIXME This should be a parameter!
     );
 
     my $rv = YAML::DumpFile($config_file_path, \%params);

--- a/lib/perl/Genome/Model/Tools/Predictor/Ber.pm
+++ b/lib/perl/Genome/Model/Tools/Predictor/Ber.pm
@@ -38,7 +38,7 @@ class Genome::Model::Tools::Predictor::Ber {
         },
         ber_source_path => {
             is => 'DirectoryPath',
-            value => '/gscmnt/gc9002/info/annotation/BER/autoannotate_v2.5',
+            value => '/gscmnt/gc3009/info/annotation/personal_dirs/jmartin/BER/autoannotate_v2.5',
             doc => 'Source of BER',
         },
         lsf_queue => {


### PR DESCRIPTION
These modules are slated for eventual removal... but the contents of the allocation on `/gscmnt/gc9002/` are slated for earlier removal than that.