### PR TITLE
Stop using "server_dispatch => 'inline'" feature.

### DIFF
--- a/lib/perl/Genome/Model/Command/Define/ReferenceSequence.t
+++ b/lib/perl/Genome/Model/Command/Define/ReferenceSequence.t
@@ -15,6 +15,8 @@ use File::Spec;
 
 Genome::Report::Email->silent();
 
+my $guard = Genome::Config::set_env('workflow_builder_backend', 'inline');
+
 if(Genome::Sys->arch_os() =~ '64') {
     plan tests => 27;
 } else {
@@ -38,8 +40,6 @@ my $first_define_command = Genome::Model::Command::Define::ImportedReferenceSequ
     prefix => 'imported_reference_testsuite',
     species_name => 'none',
     on_warning => 'exit',
-    job_dispatch => 'inline', # can't spawn off LSF jobs with UR_DBI_NO_COMMIT enabled
-    server_dispatch => 'inline',
     version => '42mb',
     sequence_uri => 'http://foo.bar.com',
     skip_bases_files => 0, # force creation of bases files
@@ -123,8 +123,6 @@ my $second_define_command = Genome::Model::Command::Define::ImportedReferenceSeq
     prefix => 'imported_reference_testsuite',
     species_name => 'none',
     on_warning => 'exit',
-    job_dispatch => 'inline', #can't spawn off LSF jobs with UR_DBI_NO_COMMIT enabled
-    server_dispatch => 'inline',
     version => 't1',
     sequence_uri => 'http://foo.bar.com',
     skip_bases_files => 0,
@@ -162,8 +160,6 @@ my $third_define_command = Genome::Model::Command::Define::ImportedReferenceSequ
     prefix => 'imported_reference_testsuite',
     species_name => 'none',
     on_warning => 'exit',
-    job_dispatch => 'inline', #can't spawn off LSF jobs with UR_DBI_NO_COMMIT enabled
-    server_dispatch => 'inline',
     version => 't1',
     sequence_uri => 'http://foo.bar.com',
 );
@@ -176,8 +172,6 @@ my $fourth_define_command = Genome::Model::Command::Define::ImportedReferenceSeq
     prefix => 'imported_reference_testsuite',
     species_name => 'nonexistent_species_name_for_testcase',
     on_warning => 'exit',
-    job_dispatch => 'inline', #can't spawn off LSF jobs with UR_DBI_NO_COMMIT enabled
-    server_dispatch => 'inline',
     version => 't4',
     sequence_uri => 'http://foo.bar.com',
 );
@@ -191,8 +185,6 @@ my $fifth_define_command = Genome::Model::Command::Define::ImportedReferenceSequ
     prefix => 'apipe',
     species_name => 'none',
     on_warning => 'exit',
-    job_dispatch => 'inline', #can't spawn off LSF jobs with UR_DBI_NO_COMMIT enabled
-    server_dispatch => 'inline',
     model_name => 'apipe-test-somatic-variation',
     sequence_uri => 'http://foo.bar.com',
 );

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateLargeIndels/CreateAssembledContigReference.pm
@@ -133,13 +133,13 @@ sub execute {
         version => '500bp_assembled_contigs',
         fasta_file => $contigs_file,
         prefix => $sample_id,
-        server_dispatch => 'inline',
         is_rederivable => 1,
     );
     if ($self->build->model->analysis_project) {
         $import_params{analysis_project} = $self->build->model->analysis_project;
     }
 
+    my $guard = Genome::Config::set_env('workflow_builder_backend', 'inline');
     my $new_ref_cmd = Genome::Model::Command::Define::ImportedReferenceSequence->create(%import_params);
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.pm
@@ -109,10 +109,11 @@ sub execute {
         version => $version,
         fasta_file => $contigs_file,
         prefix => $prefix,
-        server_dispatch => 'inline',
         is_rederivable => 1,
         analysis_project => $build->model->analysis_project,
     );
+
+    my $guard = Genome::Config::set_env('workflow_builder_backend', 'inline');
     unless ($new_ref_cmd->execute) {
         $self->error_message('Failed to execute the definition of the new reference sequence with added contigs.');
         return;


### PR DESCRIPTION
The inline workflow_builder_backend takes care of most use cases.  A future PR will remove this feature from Build entirely.