### PR TITLE
Don't worry about the value of NO_LSF variable in Build Start test.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Start.t
+++ b/lib/perl/Genome/Model/Build/Command/Start.t
@@ -15,8 +15,6 @@ Genome::Report::Email->silent();
 
 use_ok('Genome::Model::Build::Command::Start') or die;
 
-delete $ENV{NO_LSF};
-
 class Genome::Model::Tester { is => 'Genome::ModelDeprecated', };
 class Genome::Model::Build::Tester { is => 'Genome::Model::Build', };
 sub  Genome::Model::Build::Tester::start { return 1; };


### PR DESCRIPTION
After #1429, #1430, and #1431 this is the last reference to `NO_LSF` left in Genome.