### PR TITLE
Add a config variable for the LSF resource for annotation.

### DIFF
--- a/etc/genome/spec/lsf_resource_annotate_variants.yaml
+++ b/etc/genome/spec/lsf_resource_annotate_variants.yaml
@@ -1,0 +1,3 @@
+---
+default_value: "-M 4000000 -R 'select[mem>=4000 && tmp>=2000] rusage[mem=4000,tmp=2000]'"
+env: XGENOME_LSF_RESOURCE_ANNOTATE_VARIANTS

--- a/lib/perl/Genome/Model/ReferenceAlignment/Command/AnnotateVariants.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Command/AnnotateVariants.pm
@@ -13,6 +13,9 @@ class Genome::Model::ReferenceAlignment::Command::AnnotateVariants {
         lsf_queue => {
             default => Genome::Config::get('lsf_queue_build_worker_alt'),
         },
+        lsf_resource => {
+            default => Genome::Config::get('lsf_resource_annotate_variants'),
+        },
     ],
 };
 

--- a/lib/perl/Genome/Model/SomaticValidation/Command/AnnotateVariants.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AnnotateVariants.pm
@@ -35,6 +35,9 @@ class Genome::Model::SomaticValidation::Command::AnnotateVariants {
         lsf_queue => {
             default => Genome::Config::get('lsf_queue_build_worker_alt'),
         },
+        lsf_resource => {
+            default => Genome::Config::get('lsf_resource_annotate_variants'),
+        },
         snv_tiers_to_annotate => {
             is => 'Array',
             is_input => 1,


### PR DESCRIPTION
The default 4GB is normally sufficient here, but occasionally we have to increase it.