### PR TITLE
Keep logs around when Ptero's post-exec fails.

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -10,6 +10,7 @@ use Data::UUID;
 use Carp qw();
 use Data::Dump qw(pp);
 use Try::Tiny;
+use File::Spec;
 
 
 class Genome::WorkflowBuilder::Command {
@@ -164,7 +165,7 @@ sub _get_ptero_lsf_parameters {
     );
     $set_lsf_option->('jobGroup', $default_job_group);
 
-    my ($stderr, $stdout, $postexec) = _get_lsf_log_paths();
+    my ($stderr, $stdout, $postexec) = $self->_get_lsf_log_paths();
     $lsf_params->{options}->{errFile} = $stderr;
     $lsf_params->{options}->{outFile} = $stdout;
 
@@ -186,11 +187,14 @@ sub _get_ptero_lsf_parameters {
 
 #FIXME This is not unique within parallel_by operations.
 sub _get_lsf_log_paths {
+    my $self = shift;
+    my $log_dir = $self->log_dir();
+
     my $ug = Data::UUID->new();
     my $uuid = $ug->create();
     my $uuid_str = $ug->to_string($uuid);
 
-    my $base = sprintf("/tmp/ptero-lsf-logfile-%s", $uuid_str);
+    my $base = File::Spec->join($log_dir, sprintf("ptero-lsf-logfile-%s", $uuid_str));
     return ($base . '.err', $base . '.out', $base . "-postexec.log");
 }
 

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -184,6 +184,7 @@ sub _get_ptero_lsf_parameters {
     return $lsf_params;
 }
 
+#FIXME This is not unique within parallel_by operations.
 sub _get_lsf_log_paths {
     my $ug = Data::UUID->new();
     my $uuid = $ug->create();

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -120,7 +120,7 @@ sub _get_ptero_execute_method {
 
     local $ENV{LSB_SUB_ADDITIONAL} = Genome::Config::get('lsb_sub_additional') || $ENV{LSB_SUB_ADDITIONAL};
 
-    my $ptero_lsf_parameters = $self->_get_ptero_lsf_parameters();
+    my $ptero_lsf_parameters = $self->_get_ptero_lsf_parameters($log_dir);
     $ptero_lsf_parameters->{command} = sprintf(
         'genome ptero wrapper --command-class %s '
         .'--method execute --log-directory %s',
@@ -145,6 +145,8 @@ sub _get_ptero_execute_method {
 
 sub _get_ptero_lsf_parameters {
     my $self = shift;
+    my $log_dir = shift;
+
     my %attributes = $self->operation_type_attributes;
     my $lsf_params = parse_lsf_params( $attributes{lsfResource} );
 
@@ -165,7 +167,7 @@ sub _get_ptero_lsf_parameters {
     );
     $set_lsf_option->('jobGroup', $default_job_group);
 
-    my ($stderr, $stdout, $postexec) = $self->_get_lsf_log_paths();
+    my ($stderr, $stdout, $postexec) = $self->_get_lsf_log_paths($log_dir);
     $lsf_params->{options}->{errFile} = $stderr;
     $lsf_params->{options}->{outFile} = $stdout;
 
@@ -188,7 +190,7 @@ sub _get_ptero_lsf_parameters {
 #FIXME This is not unique within parallel_by operations.
 sub _get_lsf_log_paths {
     my $self = shift;
-    my $log_dir = $self->log_dir();
+    my $log_dir = shift;
 
     my $ug = Data::UUID->new();
     my $uuid = $ug->create();


### PR DESCRIPTION
If Ptero's post-exec fails, these logs are never copied out of /tmp/ and into Ptero's DB, so they are lost  exactly when we'd be most interested in them!  This writes them to the Workflow's log directory, so in case of trouble they'll stick around for inspection.  Otherwise our post-exec should clean them up as usual.