### PR TITLE
Fix ptero-lsf-{pre,post}-exec within docker

### DIFF
--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -83,8 +83,8 @@
                      "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 1,
                      "outFile" : "/tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
-                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.err --stdout /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                     "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-d8099e5e-1c8c-41c7-b174-a28b43b957e7.err --stdout /tmp/ptero-lsf-logfile-d8099e5e-1c8c-41c7-b174-a28b43b957e7.out' > /tmp/ptero-lsf-logfile-d8099e5e-1c8c-41c7-b174-a28b43b957e7-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-d8099e5e-1c8c-41c7-b174-a28b43b957e7-postexec.log",
+                     "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                      "queue" : "long",
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
@@ -202,8 +202,8 @@
                                                    "jobGroup" : "/genome/dmorton",
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
-                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.err --stdout /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-50f63610-176c-4717-a8d7-002161ccc5ba.err --stdout /tmp/ptero-lsf-logfile-50f63610-176c-4717-a8d7-002161ccc5ba.out' > /tmp/ptero-lsf-logfile-50f63610-176c-4717-a8d7-002161ccc5ba-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-50f63610-176c-4717-a8d7-002161ccc5ba-postexec.log",
+                                                   "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                    "queue" : "long",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -127,8 +127,8 @@
                                     "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
-                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.err --stdout /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b56a93d7-8691-44bc-ae2e-e63ed16e4a14.err --stdout /tmp/ptero-lsf-logfile-b56a93d7-8691-44bc-ae2e-e63ed16e4a14.out' > /tmp/ptero-lsf-logfile-b56a93d7-8691-44bc-ae2e-e63ed16e4a14-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-b56a93d7-8691-44bc-ae2e-e63ed16e4a14-postexec.log",
+                                    "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "long",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
@@ -248,8 +248,8 @@
                                                                   "jobGroup" : "/genome/dmorton",
                                                                   "numProcessors" : 1,
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
-                                                                  "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.err --stdout /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                                  "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-db854ac9-7779-4eb6-b675-1592c21041c3.err --stdout /tmp/ptero-lsf-logfile-db854ac9-7779-4eb6-b675-1592c21041c3.out' > /tmp/ptero-lsf-logfile-db854ac9-7779-4eb6-b675-1592c21041c3-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-db854ac9-7779-4eb6-b675-1592c21041c3-postexec.log",
+                                                                  "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                                   "queue" : "long",
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow.json
@@ -130,8 +130,8 @@
                      "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.out",
-                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.err --stdout /tmp/ptero-lsf-logfile-7ea07b15-32a8-4dd2-8027-060d320021e1.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                     "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4d81ce4e-850c-42d6-8b0c-25ca76bb22d7.err --stdout /tmp/ptero-lsf-logfile-4d81ce4e-850c-42d6-8b0c-25ca76bb22d7.out' > /tmp/ptero-lsf-logfile-4d81ce4e-850c-42d6-8b0c-25ca76bb22d7-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-4d81ce4e-850c-42d6-8b0c-25ca76bb22d7-postexec.log",
+                     "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -202,8 +202,8 @@
                      "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.out",
-                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.err --stdout /tmp/ptero-lsf-logfile-8ebb99c5-fe3a-4111-9e4d-817d308db9ea.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                     "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-cea6c9fd-e1c4-415b-855e-0e9abad765b0.err --stdout /tmp/ptero-lsf-logfile-cea6c9fd-e1c4-415b-855e-0e9abad765b0.out' > /tmp/ptero-lsf-logfile-cea6c9fd-e1c4-415b-855e-0e9abad765b0-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-cea6c9fd-e1c4-415b-855e-0e9abad765b0-postexec.log",
+                     "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -274,8 +274,8 @@
                      "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.out",
-                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.err --stdout /tmp/ptero-lsf-logfile-f7c4af76-6819-4476-82e9-0913c49ca92d.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                     "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4f5de04c-1795-4a63-a6b9-3721e487446b.err --stdout /tmp/ptero-lsf-logfile-4f5de04c-1795-4a63-a6b9-3721e487446b.out' > /tmp/ptero-lsf-logfile-4f5de04c-1795-4a63-a6b9-3721e487446b-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-4f5de04c-1795-4a63-a6b9-3721e487446b-postexec.log",
+                     "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },
@@ -346,8 +346,8 @@
                      "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 4,
                      "outFile" : "/tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.out",
-                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.err --stdout /tmp/ptero-lsf-logfile-0f7f699c-eed3-42de-bb92-df193cee8e08.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                     "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-10d1b125-56a2-4ee1-b364-26387ed1d567.err --stdout /tmp/ptero-lsf-logfile-10d1b125-56a2-4ee1-b364-26387ed1d567.out' > /tmp/ptero-lsf-logfile-10d1b125-56a2-4ee1-b364-26387ed1d567-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-10d1b125-56a2-4ee1-b364-26387ed1d567-postexec.log",
+                     "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                      "queue" : "short",
                      "resReq" : "rusage[mem=200:gtmp=5]"
                   },

--- a/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/n-shaped/ptero_workflow_for_process.json
@@ -176,8 +176,8 @@
                                     "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.out",
-                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.err --stdout /tmp/ptero-lsf-logfile-b9246da9-c08d-43da-b470-adf0b7a37527.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-c02b3036-3791-4ee6-8b48-4cce61c9dab4.err --stdout /tmp/ptero-lsf-logfile-c02b3036-3791-4ee6-8b48-4cce61c9dab4.out' > /tmp/ptero-lsf-logfile-c02b3036-3791-4ee6-8b48-4cce61c9dab4-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-c02b3036-3791-4ee6-8b48-4cce61c9dab4-postexec.log",
+                                    "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -250,8 +250,8 @@
                                     "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.out",
-                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.err --stdout /tmp/ptero-lsf-logfile-efb38deb-8d8c-4e07-94f6-afd17530b76d.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-d1898669-6b58-4cea-a2e1-a192ee46cc4f.err --stdout /tmp/ptero-lsf-logfile-d1898669-6b58-4cea-a2e1-a192ee46cc4f.out' > /tmp/ptero-lsf-logfile-d1898669-6b58-4cea-a2e1-a192ee46cc4f-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-d1898669-6b58-4cea-a2e1-a192ee46cc4f-postexec.log",
+                                    "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -324,8 +324,8 @@
                                     "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.out",
-                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.err --stdout /tmp/ptero-lsf-logfile-983a1277-9aae-4993-8d8e-6d323b22c4b9.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4ab3cf23-0279-4f69-be8b-69adaf7a4820.err --stdout /tmp/ptero-lsf-logfile-4ab3cf23-0279-4f69-be8b-69adaf7a4820.out' > /tmp/ptero-lsf-logfile-4ab3cf23-0279-4f69-be8b-69adaf7a4820-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-4ab3cf23-0279-4f69-be8b-69adaf7a4820-postexec.log",
+                                    "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },
@@ -398,8 +398,8 @@
                                     "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 4,
                                     "outFile" : "/tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.out",
-                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.err --stdout /tmp/ptero-lsf-logfile-92ab40c7-370f-4084-a250-b3265b0f9319.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-9b2bf5da-5260-47b4-b949-69e028051852.err --stdout /tmp/ptero-lsf-logfile-9b2bf5da-5260-47b4-b949-69e028051852.out' > /tmp/ptero-lsf-logfile-9b2bf5da-5260-47b4-b949-69e028051852-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-9b2bf5da-5260-47b4-b949-69e028051852-postexec.log",
+                                    "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "short",
                                     "resReq" : "rusage[mem=200:gtmp=5]"
                                  },

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -114,8 +114,8 @@
                                                    "jobGroup" : "/genome/dmorton",
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
-                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.err --stdout /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-5df2b662-7929-473d-94b0-6fafaa7f1b9f.err --stdout /tmp/ptero-lsf-logfile-5df2b662-7929-473d-94b0-6fafaa7f1b9f.out' > /tmp/ptero-lsf-logfile-5df2b662-7929-473d-94b0-6fafaa7f1b9f-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-5df2b662-7929-473d-94b0-6fafaa7f1b9f-postexec.log",
+                                                   "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                    "queue" : "long",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -155,8 +155,8 @@
                                                                   "jobGroup" : "/genome/dmorton",
                                                                   "numProcessors" : 1,
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
-                                                                  "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.err --stdout /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                                  "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-22cb8333-4170-4a89-a206-26944562040e.err --stdout /tmp/ptero-lsf-logfile-22cb8333-4170-4a89-a206-26944562040e.out' > /tmp/ptero-lsf-logfile-22cb8333-4170-4a89-a206-26944562040e-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-22cb8333-4170-4a89-a206-26944562040e-postexec.log",
+                                                                  "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                                   "queue" : "long",
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
@@ -113,8 +113,8 @@
                                                    "errFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err",
                                                    "jobGroup" : "/genome/dmorton",
                                                    "outFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
-                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err --stdout /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-053f5e3a-7a3c-4fca-81c1-2d07f4fa0c66.err --stdout /tmp/ptero-lsf-logfile-053f5e3a-7a3c-4fca-81c1-2d07f4fa0c66.out' > /tmp/ptero-lsf-logfile-053f5e3a-7a3c-4fca-81c1-2d07f4fa0c66-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-053f5e3a-7a3c-4fca-81c1-2d07f4fa0c66-postexec.log",
+                                                   "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                    "queue" : "long"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
@@ -154,8 +154,8 @@
                                                                   "errFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err",
                                                                   "jobGroup" : "/genome/dmorton",
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
-                                                                  "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err --stdout /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                                  "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-c9490262-d50a-47e1-a273-093dd9b3b795.err --stdout /tmp/ptero-lsf-logfile-c9490262-d50a-47e1-a273-093dd9b3b795.out' > /tmp/ptero-lsf-logfile-c9490262-d50a-47e1-a273-093dd9b3b795-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-c9490262-d50a-47e1-a273-093dd9b3b795-postexec.log",
+                                                                  "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                                   "queue" : "long"
                                                                },
                                                                "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
@@ -113,8 +113,8 @@
                                                    "errFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err",
                                                    "jobGroup" : "/genome/dmorton",
                                                    "outFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
-                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err --stdout /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-1586a730-7fcd-400b-9b88-e725791049f9.err --stdout /tmp/ptero-lsf-logfile-1586a730-7fcd-400b-9b88-e725791049f9.out' > /tmp/ptero-lsf-logfile-1586a730-7fcd-400b-9b88-e725791049f9-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-1586a730-7fcd-400b-9b88-e725791049f9-postexec.log",
+                                                   "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                    "queue" : "long"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
@@ -154,8 +154,8 @@
                                                                   "errFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err",
                                                                   "jobGroup" : "/genome/dmorton",
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
-                                                                  "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err --stdout /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                                  "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4e821cb5-2dc9-4179-a3ad-746d891ea5d1.err --stdout /tmp/ptero-lsf-logfile-4e821cb5-2dc9-4179-a3ad-746d891ea5d1.out' > /tmp/ptero-lsf-logfile-4e821cb5-2dc9-4179-a3ad-746d891ea5d1-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-4e821cb5-2dc9-4179-a3ad-746d891ea5d1-postexec.log",
+                                                                  "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                                   "queue" : "long"
                                                                },
                                                                "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -68,8 +68,8 @@
                      "jobGroup" : "/genome/dmorton",
                      "numProcessors" : 1,
                      "outFile" : "/tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
-                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.err --stdout /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
-                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                     "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-a0a83653-7b2e-4097-8305-254fdae3eec9.err --stdout /tmp/ptero-lsf-logfile-a0a83653-7b2e-4097-8305-254fdae3eec9.out' > /tmp/ptero-lsf-logfile-a0a83653-7b2e-4097-8305-254fdae3eec9-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-a0a83653-7b2e-4097-8305-254fdae3eec9-postexec.log",
+                     "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                      "queue" : "long",
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -109,8 +109,8 @@
                                     "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
-                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.err --stdout /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-11641b61-f207-4bd7-94d0-eeb05f2fb808.err --stdout /tmp/ptero-lsf-logfile-11641b61-f207-4bd7-94d0-eeb05f2fb808.out' > /tmp/ptero-lsf-logfile-11641b61-f207-4bd7-94d0-eeb05f2fb808-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-11641b61-f207-4bd7-94d0-eeb05f2fb808-postexec.log",
+                                    "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "long",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -91,8 +91,8 @@
                                     "jobGroup" : "/genome/dmorton",
                                     "numProcessors" : 1,
                                     "outFile" : "/tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
-                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.err --stdout /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
-                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-e230e01c-3d5c-487b-a4eb-4e189e34ea69.err --stdout /tmp/ptero-lsf-logfile-e230e01c-3d5c-487b-a4eb-4e189e34ea69.out' > /tmp/ptero-lsf-logfile-e230e01c-3d5c-487b-a4eb-4e189e34ea69-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-e230e01c-3d5c-487b-a4eb-4e189e34ea69-postexec.log",
+                                    "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                     "queue" : "long",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -132,8 +132,8 @@
                                                    "jobGroup" : "/genome/dmorton",
                                                    "numProcessors" : 1,
                                                    "outFile" : "/tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
-                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.err --stdout /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "postExecCmd" : "bash -c '/usr/bin/ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-ab927105-f273-4393-a8c6-6cc63dda71e6.err --stdout /tmp/ptero-lsf-logfile-ab927105-f273-4393-a8c6-6cc63dda71e6.out' > /tmp/ptero-lsf-logfile-ab927105-f273-4393-a8c6-6cc63dda71e6-postexec.log 2>&1 && rm -f /tmp/ptero-lsf-logfile-ab927105-f273-4393-a8c6-6cc63dda71e6-postexec.log",
+                                                   "preExecCmd" : "/usr/bin/ptero-lsf-pre-exec; exit 0;",
                                                    "queue" : "long",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -173,7 +173,7 @@ sub _get_ptero_lsf_parameters {
 
     # Redirect stdout/err of post-exec command to file for debugging.
     # Clean up that file if post-exec exits normally.
-    my $postexec_cmd = "ptero-lsf-post-exec --stderr $stderr --stdout $stdout";
+    my $postexec_cmd = "/usr/bin/ptero-lsf-post-exec --stderr $stderr --stdout $stdout";
     if ($docker) {
         $postexec_cmd = join(' ', $docker_run, $postexec_cmd);
     } else {
@@ -187,7 +187,7 @@ sub _get_ptero_lsf_parameters {
     # Unlike post-exec, stdout/err of pre-exec command gets written to
     # errFile or outFile by lsf.  We want to exit 0 no matter what so
     # that the job doesn't get caught in a PEND->RUN->PEND loop.
-    my $preexec_cmd = 'ptero-lsf-pre-exec; exit 0;';
+    my $preexec_cmd = '/usr/bin/ptero-lsf-pre-exec; exit 0;';
     if ($docker) {
         $preexec_cmd = join(' ', $docker_run, $preexec_cmd);
     }

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -168,18 +168,31 @@ sub _get_ptero_lsf_parameters {
     $lsf_params->{options}->{errFile} = $stderr;
     $lsf_params->{options}->{outFile} = $stdout;
 
+    my ($docker) = $ENV{LSB_SUB_ADDITIONAL} =~ /^docker\(([^)]+)\)$/;
+    my $docker_run = File::Spec->join($ENV{LSF_BINDIR}, 'docker_run.py');
+
     # Redirect stdout/err of post-exec command to file for debugging.
     # Clean up that file if post-exec exits normally.
+    my $postexec_cmd = "ptero-lsf-post-exec --stderr $stderr --stdout $stdout";
+    if ($docker) {
+        $postexec_cmd = join(' ', $docker_run, $postexec_cmd);
+    } else {
+        $postexec_cmd = "bash -c '$postexec_cmd'";
+    }
+
     $lsf_params->{options}->{postExecCmd} = sprintf(
-        "bash -c '%s' > %s 2>&1 && rm -f %s",
-        "ptero-lsf-post-exec --stderr $stderr --stdout $stdout",
-        $postexec, $postexec
+        "%s > %s 2>&1 && rm -f %s", $postexec_cmd, $postexec, $postexec
     );
 
     # Unlike post-exec, stdout/err of pre-exec command gets written to
     # errFile or outFile by lsf.  We want to exit 0 no matter what so
     # that the job doesn't get caught in a PEND->RUN->PEND loop.
-    $lsf_params->{options}->{preExecCmd} = "ptero-lsf-pre-exec; exit 0;";
+    my $preexec_cmd = 'ptero-lsf-pre-exec; exit 0;';
+    if ($docker) {
+        $preexec_cmd = join(' ', $docker_run, $preexec_cmd);
+    }
+
+    $lsf_params->{options}->{preExecCmd} = $preexec_cmd;
 
     return $lsf_params;
 }


### PR DESCRIPTION
LSF doesn't automatically launch the pre- and post-exec commands within the chosen docker container, so we've got to call the docker_run.py script ourselves.

In the future I'd like to make some ptero-lsf docker images to accomplish the pre- and post-exec tasks rather than specifying these commands manually within the main container, but this gets these back to their main task of maintaining workflow status.