### PR TITLE
Make trio wrapper work on somatic cases

### DIFF
--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/IgvSession.pm
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/IgvSession.pm
@@ -96,10 +96,12 @@ sub bed_file_label {
 
     my %labels = (
         docm      => 'Recurrent AML Variants',
-        followup  => sprintf('Followup(%s) Variants', $process->followup_sample->name),
         discovery => sprintf('Discovery(%s) Variants', $process->tumor_sample->name),
         germline  => sprintf('Germline(%s) Variants', $process->normal_sample->name)
     );
+
+    $labels{followup} = sprintf('Followup(%s) Variants', $process->followup_sample->name)
+        if $process->followup_sample;
 
     return $labels{$category};
 }

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.pm
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.pm
@@ -79,13 +79,12 @@ sub get_model_pairs {
                 label => 'discovery',
             );
         }
+        elsif (@models != 2) { 
+            $self->warning_message("Skipping models for ROI %s because there are not either one or two models: %s",
+                $roi, join(", ", map {$_->__display_name__} @models));
+            next;
+        }
         else {
-            unless (@models == 2) {
-                $self->warning_message("Skipping models for ROI %s because there are not exactly two models: %s",
-                    $roi, join(", ", map {$_->__display_name__} @models));
-                next;
-            }
-
             my @discovery_models = grep { $self->is_model_discovery($_) } @models;
             my @validation_models = grep { $self->is_model_followup($_) } @models;
 

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.pm
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.pm
@@ -13,7 +13,7 @@ class Genome::VariantReporting::Command::Wrappers::ModelPairFactory {
             is_many => 1,
         },
         discovery_sample => { is => 'Genome::Sample', },
-        followup_sample => { is => 'Genome::Sample', },
+        followup_sample => { is => 'Genome::Sample', is_optional => 1},
         normal_sample => { is => 'Genome::Sample',},
         other_input_vcf_pairs => { is => 'Hashref', default_value => {}},
     },
@@ -68,58 +68,76 @@ sub get_model_pairs {
     my %models_for_roi = %{$self->get_models_for_roi};
     while (my ($roi, $model_list) = each %models_for_roi) {
         my @models = grep {!$self->is_single_bam($_)} @{$model_list};
+        my ($discovery_build, $validation_build);
 
-        unless (@models == 2) {
-            $self->warning_message("Skipping models for ROI %s because there are not exactly two models: %s",
-                $roi, join(", ", map {$_->__display_name__} @models));
-            next;
+        if (@models == 1) {#case for no followup
+            $discovery_build = $models[0]->last_succeeded_build;
+            push @model_pairs, Genome::VariantReporting::Command::Wrappers::ModelPair->create(
+                common_translations => $self->get_common_translations(),
+                plan_file_basename => "cle_somatic_TYPE_report.yaml",
+                discovery => $discovery_build,
+                label => 'discovery',
+            );
         }
+        else {
+            unless (@models == 2) {
+                $self->warning_message("Skipping models for ROI %s because there are not exactly two models: %s",
+                    $roi, join(", ", map {$_->__display_name__} @models));
+                next;
+            }
 
-        my @discovery_models = grep { $self->is_model_discovery($_) } @models;
-        my @validation_models = grep { $self->is_model_followup($_) } @models;
+            my @discovery_models = grep { $self->is_model_discovery($_) } @models;
+            my @validation_models = grep { $self->is_model_followup($_) } @models;
 
-        if ( @discovery_models != 1 or @validation_models != 1 ) {
-            $self->warning_message("Incorrect discovery/followup pairing for models for ROI (%s). One of each is required!\nDiscovery:%s\nFollowup:%s\n", $roi, join(", ", map {$_->__display_name__} @discovery_models),
-            join(", ", map {$_->__display_name__} @validation_models));
-            next;
-        }
+            if ( @discovery_models != 1 or @validation_models != 1 ) {
+                $self->warning_message("Incorrect discovery/followup pairing for models for ROI (%s). One of each is required!\nDiscovery:%s\nFollowup:%s\n", $roi, join(", ", map {$_->__display_name__} @discovery_models),
+                    join(", ", map {$_->__display_name__} @validation_models));
+                next;
+            }
 
-        my $discovery_build = $discovery_models[0]->last_succeeded_build;
-        if ( not $discovery_build ) {
-            $self->warning_message('No last succeeded build for discovery model (%s). Skipping ROI %s.', $discovery_models[0]->__display_name__, $roi);
-            next;
-        }
+            $discovery_build = $discovery_models[0]->last_succeeded_build;
+            if ( not $discovery_build ) {
+                $self->warning_message('No last succeeded build for discovery model (%s). Skipping ROI %s.', $discovery_models[0]->__display_name__, $roi);
+                next;
+            }
 
-        my $validation_build = $validation_models[0]->last_succeeded_build;
-        if ( not $validation_build ) {
-            $self->warning_message('No last succeeded build for followup model (%s). Skipping ROI %s.', $validation_models[0]->__display_name__, $roi);
-            next;
-        }
+            $validation_build = $validation_models[0]->last_succeeded_build;
+            if ( not $validation_build ) {
+                $self->warning_message('No last succeeded build for followup model (%s). Skipping ROI %s.', $validation_models[0]->__display_name__, $roi);
+                next;
+            }
 
-        push @model_pairs, Genome::VariantReporting::Command::Wrappers::ModelPair->create(
-            common_translations => $self->get_common_translations(),
-            discovery => $discovery_build,
-            followup => $validation_build,
-            label => "discovery",
-        );
-
-        push @model_pairs, Genome::VariantReporting::Command::Wrappers::ModelPair->create(
-            common_translations => $self->get_common_translations(),
-            discovery => $validation_build,
-            followup => $discovery_build,
-            label => "followup",
-        );
-
-        for my $other_input_vcf_pair (keys %{$self->other_input_vcf_pairs}) {
-            push @model_pairs, Genome::VariantReporting::Command::Wrappers::ModelPairWithInput->create(
+            push @model_pairs, Genome::VariantReporting::Command::Wrappers::ModelPair->create(
                 common_translations => $self->get_common_translations(),
                 discovery => $discovery_build,
                 followup => $validation_build,
+                label => "discovery",
+            );
+
+            push @model_pairs, Genome::VariantReporting::Command::Wrappers::ModelPair->create(
+                common_translations => $self->get_common_translations(),
+                discovery => $validation_build,
+                followup => $discovery_build,
+                label => "followup",
+            );
+        }
+
+        for my $other_input_vcf_pair (keys %{$self->other_input_vcf_pairs}) {
+            my %params = (
+                common_translations => $self->get_common_translations(),
+                discovery => $discovery_build,
                 plan_file_basename => "cle_docm_report_TYPE.yaml",
                 label => $other_input_vcf_pair,
                 other_snvs_vcf_input => $self->other_input_vcf_pairs->{$other_input_vcf_pair}->[0],
                 other_indels_vcf_input => $self->other_input_vcf_pairs->{$other_input_vcf_pair}->[1],
             );
+            if ($validation_build) {
+                $params{followup} = $validation_build
+            }
+            else { # case for no followup
+                $params{plan_file_basename} = "cle_somatic_docm_report_TYPE.yaml";
+            }
+            push @model_pairs, Genome::VariantReporting::Command::Wrappers::ModelPairWithInput->create(%params);
         }
     }
 
@@ -129,20 +147,23 @@ sub get_model_pairs {
 sub get_common_translations {
     my $self = shift;
 
+    my $sample_translations  = {
+        $self->discovery_sample->name => sprintf('Discovery(%s)', $self->discovery_sample->name),
+        $self->normal_sample->name    => sprintf('Normal(%s)', $self->normal_sample->name),
+    };
+
+    my $library_translations = {
+        $self->get_library_name_labels('discovery', $self->discovery_sample, [$self->models]),
+        $self->get_library_name_labels('normal', $self->normal_sample, [$self->models]),
+    };
+
+    if ($self->followup_sample) {
+        $sample_translations->{$self->followup_sample->name} = sprintf('Followup(%s)', $self->followup_sample->name);
+        %$library_translations = (%$library_translations, $self->get_library_name_labels('followup', $self->followup_sample, [$self->models]));
+    }
     return {
-        sample_name_labels => {
-            $self->discovery_sample->name =>
-                sprintf('Discovery(%s)', $self->discovery_sample->name),
-            $self->followup_sample->name =>
-                sprintf('Followup(%s)', $self->followup_sample->name),
-            $self->normal_sample->name =>
-                sprintf('Normal(%s)', $self->normal_sample->name),
-        },
-        library_name_labels => {
-            $self->get_library_name_labels('discovery', $self->discovery_sample, [$self->models]),
-            $self->get_library_name_labels('followup', $self->followup_sample, [$self->models]),
-            $self->get_library_name_labels('normal', $self->normal_sample, [$self->models]),
-        },
+        sample_name_labels  => $sample_translations,
+        library_name_labels => $library_translations,
     };
 }
 

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.pm
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.pm
@@ -125,13 +125,13 @@ sub get_model_pairs {
             my %params = (
                 common_translations => $self->get_common_translations(),
                 discovery => $discovery_build,
-                plan_file_basename => "cle_docm_report_TYPE.yaml",
                 label => $other_input_vcf_pair,
                 other_snvs_vcf_input => $self->other_input_vcf_pairs->{$other_input_vcf_pair}->[0],
                 other_indels_vcf_input => $self->other_input_vcf_pairs->{$other_input_vcf_pair}->[1],
             );
             if ($validation_build) {
-                $params{followup} = $validation_build
+                $params{followup} = $validation_build;
+                $params{plan_file_basename} = "cle_docm_report_TYPE.yaml";
             }
             else { # case for no followup
                 $params{plan_file_basename} = "cle_somatic_docm_report_TYPE.yaml";

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.t
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.t
@@ -39,7 +39,7 @@ subtest "Three models for an roi" => sub {
 
     my @pairs = @{$factory->get_model_pairs};
     ok(@pairs == 0, "Factory with three model returned no pairs");
-    ok($factory->warning_message =~ /Skipping models for ROI $roi_name because there are not exactly two models/,
+    ok($factory->warning_message =~ /Skipping models for ROI $roi_name because there are not either one or two models/,
         "Warning message set correctly");
 
 };

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.t
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.t
@@ -29,19 +29,6 @@ my $build3 = get_build($roi_name, $tumor_sample2, $normal_sample1);
 my $build4 = get_build($roi2, $tumor_sample1, $normal_sample1);
 my $build5 = get_build($roi2, $tumor_sample2, $normal_sample1);
 
-subtest "Only one model for an roi" => sub {
-
-    my $factory = $pkg->create(models => [$build1->model],
-        discovery_sample => $tumor_sample1,
-        followup_sample => $tumor_sample2,
-        normal_sample => $normal_sample1,
-    );
-
-    my @pairs = @{$factory->get_model_pairs};
-    ok(@pairs == 0, "Factory with only one model returned no pairs");
-    ok($factory->warning_message =~ /Skipping models for ROI $roi_name because there are not exactly two models/,
-        "Warning message set correctly");
-};
 
 subtest "Three models for an roi" => sub {
     my $factory = $pkg->create(models => [$build1->model, $build2->model, $build3->model],
@@ -51,7 +38,7 @@ subtest "Three models for an roi" => sub {
     );
 
     my @pairs = @{$factory->get_model_pairs};
-    ok(@pairs == 0, "Factory with only one model returned no pairs");
+    ok(@pairs == 0, "Factory with three model returned no pairs");
     ok($factory->warning_message =~ /Skipping models for ROI $roi_name because there are not exactly two models/,
         "Warning message set correctly");
 
@@ -66,7 +53,7 @@ subtest "Models for an roi don't have the right samples" => sub {
     );
 
     my @pairs = @{$factory->get_model_pairs};
-    ok(@pairs == 0, "Factory with only one model returned no pairs");
+    ok(@pairs == 0, "Factory with wrong samples returned no pairs");
     ok($factory->warning_message =~ /Incorrect discovery\/followup pairing for models for ROI \($roi_name\)/,
         "Warning message set correctly");
 };
@@ -79,14 +66,25 @@ subtest "One model doesn't have last succeeded build" => sub {
     );
 
     my @pairs = @{$factory->get_model_pairs};
-    ok(@pairs == 0, "Factory with only one model returned no pairs");
+    ok(@pairs == 0, "Factory with model that does not have succeeded build returned no pairs");
     ok($factory->warning_message =~ /No last succeeded build for discovery model/,
 
         "Warning message set correctly");
 };
 
-subtest "Two valid model pairs" => sub {
+subtest "one discovery model for an roi" => sub {
     succeed_build($build1);
+
+    my $factory = $pkg->create(models => [$build1->model],
+        discovery_sample => $tumor_sample1,
+        normal_sample    => $normal_sample1,
+    );
+
+    my @pairs = @{$factory->get_model_pairs};
+    ok(@pairs == 1, "Factory with only one discovery model returned ok");
+};
+
+subtest "Two valid model pairs" => sub {
     succeed_build($build2);
     succeed_build($build4);
     succeed_build($build5);

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.t
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPairFactory.t
@@ -38,7 +38,7 @@ subtest "Three models for an roi" => sub {
     );
 
     my @pairs = @{$factory->get_model_pairs};
-    ok(@pairs == 0, "Factory with three model returned no pairs");
+    ok(@pairs == 0, "Factory with three models returned no pairs");
     ok($factory->warning_message =~ /Skipping models for ROI $roi_name because there are not either one or two models/,
         "Warning message set correctly");
 

--- a/lib/perl/Genome/VariantReporting/Process/Trio.pm
+++ b/lib/perl/Genome/VariantReporting/Process/Trio.pm
@@ -22,6 +22,7 @@ class Genome::VariantReporting::Process::Trio {
         },
         followup_sample => {
             is => 'Genome::Sample',
+            is_optional => 1,
         },
         normal_sample => {
             is => 'Genome::Sample',

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_somatic_docm_report_indels.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_somatic_docm_report_indels.yaml
@@ -1,0 +1,56 @@
+experts:
+    'bam-readcount':
+        aligned_bam_result_id: [aligned_bam_result_id]
+        version: 0.7
+        minimum_mapping_quality: 0
+        minimum_base_quality: 0
+        max_count: 10000000
+        per_library: 1
+        insertion_centric: 1
+    vep:
+        ensembl_version: 75
+        reference_version: GRCh37
+        custom_annotation_tags:
+            - ON_TARGET
+            - SEG_DUP
+            - AML_RMG
+        feature_list_ids: feature_list_ids
+        reference_fasta: reference_fasta
+        species: 'homo-sapiens'
+        plugins:
+            - Condel@PLUGIN_DIR@b@2
+        plugins_version: 1
+        joinx_version: 1.11
+        short_name: 0
+        allow_same_file: 1
+reports:
+    'docm':
+        filters: {}
+        interpreters:
+            position: {}
+            vaf:
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+            'per-library-vaf':
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+                library_name_labels: library_name_labels
+                library_names: [library_names]
+            vep: {}
+        params:
+            sample_name_labels: sample_name_labels
+            sample_names:
+                - discovery_tumor
+                - normal
+            library_name_labels: library_name_labels
+            library_names: [library_names]
+    'bed':
+        filters: {}
+        interpreters:
+            'bed-entry': {}
+        params:
+            generate_legend_file: 0

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_somatic_docm_report_snvs.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_somatic_docm_report_snvs.yaml
@@ -1,0 +1,56 @@
+experts:
+    'bam-readcount':
+        aligned_bam_result_id: [aligned_bam_result_id]
+        version: 0.7
+        minimum_mapping_quality: 0
+        minimum_base_quality: 0
+        max_count: 10000000
+        per_library: 1
+        insertion_centric: 0
+    vep:
+        ensembl_version: 75
+        reference_version: GRCh37
+        custom_annotation_tags:
+            - ON_TARGET
+            - SEG_DUP
+            - AML_RMG
+        feature_list_ids: feature_list_ids
+        reference_fasta: reference_fasta
+        species: 'homo-sapiens'
+        plugins:
+            - Condel@PLUGIN_DIR@b@2
+        plugins_version: 1
+        joinx_version: 1.11
+        short_name: 0
+        allow_same_file: 1
+reports:
+    'docm':
+        filters: {}
+        interpreters:
+            position: {}
+            vaf:
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+            'per-library-vaf':
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+                library_name_labels: library_name_labels
+                library_names: [library_names]
+            vep: {}
+        params:
+            sample_name_labels: sample_name_labels
+            sample_names:
+                - discovery_tumor
+                - normal
+            library_name_labels: library_name_labels
+            library_names: [library_names]
+    'bed':
+        filters: {}
+        interpreters:
+            'bed-entry': {}
+        params:
+            generate_legend_file: 0

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_somatic_indels_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_somatic_indels_report.yaml
@@ -1,0 +1,166 @@
+experts:
+    'bam-readcount':
+        aligned_bam_result_id: [aligned_bam_result_id]
+        version: 0.7
+        minimum_mapping_quality: 0
+        minimum_base_quality: 0
+        max_count: 10000000
+        per_library: 1
+        insertion_centric: 1
+    vep:
+        ensembl_version: 75
+        reference_version: GRCh37
+        custom_annotation_tags:
+            - ON_TARGET
+            - SEG_DUP
+            - AML_RMG
+        feature_list_ids: feature_list_ids
+        reference_fasta: reference_fasta
+        species: 'homo-sapiens'
+        plugins:
+            - Condel@PLUGIN_DIR@b@2
+        plugins_version: 1
+        joinx_version: 1.9
+        short_name: 0
+        allow_same_file: 0
+    dbsnp:
+        joinx_version: 1.10
+        info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'
+        vcf: dbsnp_vcf
+    homopolymer:
+        joinx_version: 1.9
+        max_length: 2
+        info_string: 'HOMP_FILTER'
+        homopolymer_list_id: homopolymer_list_id
+reports:
+    'full':
+        filters:
+            'allele-in-genotype':
+                sample_name: discovery_tumor
+            'ft-keep':
+                keep_filter_values:
+                    - PASS
+                    - .
+                sample_name: discovery_tumor
+            'contains-tag':
+                info_tag: ON_TARGET
+            homopolymer:
+                info_tag: HOMP_FILTER
+            'min-coverage.tumor':
+                min_coverage: 20
+                sample_name: discovery_tumor
+            'min-coverage.normal':
+                min_coverage: 20
+                sample_name: normal
+        interpreters:
+            position: {}
+            'variant-type': {}
+            vep: {}
+            'info-tags': {}
+            rsid: {}
+            caf: {}
+            'min-coverage':
+                min_coverage: 10
+                sample_name: discovery_tumor
+            'min-coverage-observed':
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+            'max-vaf-observed':
+                tumor_sample_names:
+                    - discovery_tumor
+                normal_sample_names:
+                    - normal
+            'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
+                    - Pindel
+                    - GatkSomaticIndel
+                sample_name: discovery_tumor
+            vaf:
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+            'per-library-vaf':
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+                library_name_labels: library_name_labels
+                library_names: [library_names]
+        params:
+            sample_name_labels: sample_name_labels
+            sample_names:
+                - discovery_tumor
+                - normal
+            library_name_labels: library_name_labels
+            library_names: [library_names]
+    'simple':
+        filters:
+            'allele-in-genotype':
+                sample_name: discovery_tumor
+            'ft-keep':
+                keep_filter_values:
+                    - PASS
+                    - .
+                sample_name: discovery_tumor
+            'contains-tag':
+                info_tag: ON_TARGET
+            homopolymer:
+                info_tag: HOMP_FILTER
+            'min-coverage.tumor':
+                min_coverage: 20
+                sample_name: discovery_tumor
+            'min-coverage.normal':
+                min_coverage: 20
+                sample_name: normal
+        interpreters:
+            position: {}
+            vep: {}
+            'variant-type': {}
+    'vcf':
+        filters: {}
+        interpreters:
+            'vcf-entry': {}
+            'ft-keep':
+                keep_filter_values:
+                    - PASS
+                    - .
+                sample_name: discovery_tumor
+            'contains-tag':
+                info_tag: ON_TARGET
+            homopolymer:
+                info_tag: HOMP_FILTER  
+            'min-coverage.tumor':
+                min_coverage: 20
+                sample_name: discovery_tumor
+            'min-coverage.normal':
+                min_coverage: 20
+                sample_name: normal
+    'bed':
+        filters:
+            'allele-in-genotype':
+                sample_name: discovery_tumor
+            'ft-keep':
+                keep_filter_values:
+                    - PASS
+                    - .
+                sample_name: discovery_tumor
+            'contains-tag':
+                info_tag: ON_TARGET
+            homopolymer:
+                info_tag: HOMP_FILTER
+            'min-coverage.tumor':
+                min_coverage: 20
+                sample_name: discovery_tumor
+            'min-coverage.normal':
+                min_coverage: 20
+                sample_name: normal
+        interpreters:
+            'bed-entry': {}
+        params:
+            generate_legend_file: 0

--- a/lib/perl/Genome/VariantReporting/plan_files/cle_somatic_snvs_report.yaml
+++ b/lib/perl/Genome/VariantReporting/plan_files/cle_somatic_snvs_report.yaml
@@ -1,0 +1,151 @@
+experts:
+    'bam-readcount':
+        aligned_bam_result_id: [aligned_bam_result_id]
+        version: 0.7
+        minimum_mapping_quality: 0
+        minimum_base_quality: 0
+        max_count: 10000000
+        per_library: 1
+        insertion_centric: 0
+    vep:
+        ensembl_version: 75
+        reference_version: GRCh37
+        custom_annotation_tags:
+            - ON_TARGET
+            - SEG_DUP
+            - AML_RMG
+        feature_list_ids: feature_list_ids
+        reference_fasta: reference_fasta
+        species: 'homo-sapiens'
+        plugins:
+            - Condel@PLUGIN_DIR@b@2
+        plugins_version: 1
+        joinx_version: 1.9
+        short_name: 0
+        allow_same_file: 0
+    dbsnp:
+        joinx_version: 1.10
+        info_string: 'CAF:dbSNPBuildID=dbSNPBuildID,per-alt:MUT'
+        vcf: dbsnp_vcf
+reports:
+    'full':
+        filters:
+            'allele-in-genotype':
+                sample_name: discovery_tumor
+            'ft-keep':
+                keep_filter_values:
+                    - PASS
+                    - .
+                sample_name: discovery_tumor
+            'contains-tag':
+                info_tag: ON_TARGET
+            'min-coverage.tumor':
+                min_coverage: 20
+                sample_name: discovery_tumor
+            'min-coverage.normal':
+                min_coverage: 20
+                sample_name: normal
+        interpreters:
+            position: {}
+            'variant-type': {}
+            vep: {}
+            'info-tags': {}
+            rsid: {}
+            caf: {}
+            'min-coverage':
+                min_coverage: 10
+                sample_name: discovery_tumor
+            'min-coverage-observed':
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+            'max-vaf-observed':
+                tumor_sample_names:
+                    - discovery_tumor
+                normal_sample_names:
+                    - normal
+            'variant-callers':
+                valid_callers:
+                    - VarscanSomatic
+                    - Sniper
+                    - Strelka
+                sample_name: discovery_tumor
+            vaf:
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+            'per-library-vaf':
+                sample_name_labels: sample_name_labels
+                sample_names:
+                    - discovery_tumor
+                    - normal
+                library_name_labels: library_name_labels
+                library_names: [library_names]
+        params:
+            sample_name_labels: sample_name_labels
+            sample_names:
+                - discovery_tumor
+                - normal
+            library_name_labels: library_name_labels
+            library_names: [library_names]
+    'simple':
+        filters:
+            'allele-in-genotype':
+                sample_name: discovery_tumor
+            'ft-keep':
+                keep_filter_values:
+                    - PASS
+                    - .
+                sample_name: discovery_tumor
+            'contains-tag':
+                info_tag: ON_TARGET
+            'min-coverage.tumor':
+                min_coverage: 20
+                sample_name: discovery_tumor
+            'min-coverage.normal':
+                min_coverage: 20
+                sample_name: normal
+        interpreters:
+            position: {}
+            vep: {}
+            'variant-type': {}
+    'vcf':
+        filters: {}
+        interpreters:
+            'vcf-entry': {}
+            'ft-keep':
+                keep_filter_values:
+                    - PASS
+                    - .
+                sample_name: discovery_tumor
+            'contains-tag':
+                info_tag: ON_TARGET
+            'min-coverage.tumor':
+                min_coverage: 20
+                sample_name: discovery_tumor
+            'min-coverage.normal':
+                min_coverage: 20
+                sample_name: normal
+    'bed':
+        filters:
+            'allele-in-genotype':
+                sample_name: discovery_tumor
+            'ft-keep':
+                keep_filter_values:
+                    - PASS
+                    - .
+                sample_name: discovery_tumor
+            'contains-tag':
+                info_tag: ON_TARGET
+            'min-coverage.tumor':
+                min_coverage: 20
+                sample_name: discovery_tumor
+            'min-coverage.normal':
+                min_coverage: 20
+                sample_name: normal
+        interpreters:
+            'bed-entry': {}
+        params:
+            generate_legend_file: 0


### PR DESCRIPTION
Currently trio wrapper works on three samples: normal, tumor and followup. But there are cases in cle that only have normal and tumor available. This PR is to tweak the trio command and its supporting modules to make trio work on cases without followup.