### PR TITLE
Remove uses of Workflow::Model in GenePrediction.

### DIFF
--- a/lib/perl/Genome/Model/GenePrediction/Command/Pap/BtabHmmtab.pm
+++ b/lib/perl/Genome/Model/GenePrediction/Command/Pap/BtabHmmtab.pm
@@ -82,7 +82,7 @@ sub help_brief
 sub help_synopsis
 {
     return <<"EOS"
-    my \$w = Workflow::Model->create_from_xml("some xml...");
+    my \$w = Genome::WorkflowBuilder::DAG->from_xml("some xml...");
     my \$result = \$w->execute( 'locus tag'       => "locustag",
                               'fastadir'        => \$self->fastadirpath,
                               'berdirpath'      => \$self->berdirpath,

--- a/lib/perl/Genome/Model/GenePrediction/Eukaryotic.pm
+++ b/lib/perl/Genome/Model/GenePrediction/Eukaryotic.pm
@@ -192,10 +192,10 @@ sub _resolve_workflow_for_build {
     my $xml = __FILE__ . '.xml';
     confess "Did not find workflow xml file at $xml!" unless -e $xml;
 
-    my $workflow = Workflow::Operation->create_from_xml($xml);
+    my $workflow = Genome::WorkflowBuilder::DAG->from_xml_filename($xml);
     confess "Could not create workflow object from $xml!" unless $workflow;
 
-    $workflow->log_dir($build->log_directory);
+    $workflow->recursively_set_log_dir($build->log_directory);
     $workflow->name($build->workflow_name);
 
     return $workflow;


### PR DESCRIPTION
These didn't `use Workflow` or its derivatives but still referred to `Workflow::Model`.