### PR TITLE
Specify queues in Mutect and SomVal's VerifyBam.

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/VerifyBam.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/VerifyBam.pm
@@ -17,6 +17,9 @@ class Genome::Model::SomaticValidation::Command::VerifyBam {
             is_optional => 1,
             doc => 'default LSF resource expectations',
         },
+        lsf_queue => {
+            default_value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
     ],
 };
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Mutect.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Mutect.pm
@@ -21,6 +21,9 @@ class Genome::Model::Tools::DetectVariants2::Mutect {
         lsf_resource => {
             default_value => Genome::Config::get('lsf_resource_dv2_mutect'),
         },
+        lsf_queue => {
+            default_value => Genome::Config::get('lsf_queue_dv2_workflow'),
+        },
     ],
 };
 

--- a/lib/perl/Genome/Model/Tools/Mutect/ParallelWrapper.pm
+++ b/lib/perl/Genome/Model/Tools/Mutect/ParallelWrapper.pm
@@ -34,6 +34,11 @@ class Genome::Model::Tools::Mutect::ParallelWrapper {
             is_optional => 1,
         },
     ],
+    has_param => [
+        lsf_queue => {
+            default_value => Genome::Config::get('lsf_queue_dv2_worker'),
+        },
+    ],
 };
 
 sub help_short {


### PR DESCRIPTION
The default queue is no longer guaranteed to work, which makes it easier to spot cases where the queue specification has been omitted.