### PR TITLE
Increase annotation memory usage from 4g to 8g

### DIFF
--- a/etc/genome/spec/lsf_resource_annotate_variants.yaml
+++ b/etc/genome/spec/lsf_resource_annotate_variants.yaml
@@ -1,3 +1,3 @@
 ---
-default_value: "-M 4000000 -R 'select[mem>=4000 && tmp>=2000] rusage[mem=4000,tmp=2000]'"
+default_value: "-M 8000000 -R 'select[mem>=8000 && tmp>=2000] rusage[mem=8000,tmp=2000]'"
 env: XGENOME_LSF_RESOURCE_ANNOTATE_VARIANTS


### PR DESCRIPTION
Recently there are quite a few of cle somatic validation builds failed at annotation step due to out of memory. This PR doubles the default memory usage for variant annotation.