### PR TITLE
Remove References to Volumes Being Retired

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
@@ -69,7 +69,6 @@ sub _run_aligner {
 
     #my $reference_index_directory = $reference_index->data_directory(); # better way to do this?
     #print "Ref index dir: $reference_index_directory\n";
-    # example dir /gscmnt/sata921/info/medseq/cmiller/methylSeq/bratIndex
 
     # This is your scratch directory.  Whatever you put here will be wiped when the alignment
     # job exits.

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Rtg.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Rtg.pm
@@ -126,10 +126,6 @@ sub _run_aligner {
         $self->debug_message("Trying: $unmated_cmd");
         Genome::Sys->shellcmd(  cmd => $unmated_cmd, input_files => [$finished_unmated_sam], output_files => [$sam_file], skip_if_output_is_present=>0);
     }
-    
-    #  `cp $sam_file /gscmnt/sata921/info/medseq/rtg_evaluation/`;
-    # `cp $output_dir /gscmnt/sata921/info/medseq/rtg_evaluation/`;
-   
 
     # confirm that at the end we have a nonzero sam file, this is what'll get turned into a bam and
     # copied out.

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/AddReadcounts.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/AddReadcounts.pm
@@ -26,7 +26,7 @@ class Genome::Model::Tools::Analysis::Coverage::AddReadcounts{
         genome_build => {
             is => 'String',
             is_optional => 0,
-            doc => 'takes either a string describing the genome build (one of 36, 37, mm9, mus37, mus37wOSK) or a path to the genome fasta file',
+            doc => 'takes either a string describing the genome build (one of 36, 37, mm9, mus37) or a path to the genome fasta file',
         },
         min_quality_score => {
             is => 'Integer',
@@ -143,8 +143,6 @@ sub execute {
     elsif ($genome_build eq "mus37") {
         my $reference_build_fasta_object = Genome::Model::Build::ReferenceSequence->get(name => "NCBI-mouse-build37");
         $fasta = $reference_build_fasta_object->cached_full_consensus_path('fa');
-    } elsif ($genome_build eq "mus37wOSK") {
-        $fasta = "/gscmnt/sata135/info/medseq/dlarson/iPS_analysis/lentiviral_reference/mousebuild37_plus_lentivirus.fa";
     } elsif ($genome_build eq "mm9") {
         my $reference_build_fasta_object = Genome::Model::Build::ReferenceSequence->get(name => "UCSC-mouse-buildmm9");
         $fasta = $reference_build_fasta_object->cached_full_consensus_path('fa');

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/BamReadcount.pm
@@ -37,7 +37,7 @@ class Genome::Model::Tools::Analysis::Coverage::BamReadcount{
     genome_build => {
         is => 'String',
         is_optional => 0,
-        doc => 'takes either a string describing the genome build (one of 36, 37, mm9, mus37, mus37wOSK) or a path to the genome fasta file',
+        doc => 'takes either a string describing the genome build (one of 36, 37, mm9, mus37) or a path to the genome fasta file',
     },
 
     min_mapping_quality => {
@@ -151,8 +151,6 @@ sub execute {
     elsif ($genome_build eq "mus37") {
         my $reference_build_fasta_object = Genome::Model::Build::ReferenceSequence->get(name => "NCBI-mouse-build37");
         $fasta = $reference_build_fasta_object->cached_full_consensus_path('fa');
-    } elsif ($genome_build eq "mus37wOSK") {
-        $fasta = "/gscmnt/sata135/info/medseq/dlarson/iPS_analysis/lentiviral_reference/mousebuild37_plus_lentivirus.fa";
     } elsif ($genome_build eq "mm9") {
         my $reference_build_fasta_object = Genome::Model::Build::ReferenceSequence->get(name => "UCSC-mouse-buildmm9");
         $fasta = $reference_build_fasta_object->cached_full_consensus_path('fa');

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/CoveragePlot.t
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/CoveragePlot.t
@@ -9,65 +9,65 @@ use Test::More tests => 18;
 
 eval
 {
-    
+
     # creates a class instance
     my $class = 'Genome::Model::Tools::Analysis::Coverage::CoveragePlot';
     use_ok($class);
-    
-    
+
+
     # checks test data files
     my $data_dir = Genome::Utility::Test->data_dir($class);
     ok(-d $data_dir, "data_dir exists: $data_dir") or die;
-    
-    
+
+
     # checks inputs
     my $roi_file_path = "$data_dir/test-roi425.bed";
     ok(-s $roi_file_path, 'input exists: roi_file_path') or die;
-    
+
     my $bam_file1 = "$data_dir/test-bam-CKR.bam";
     ok(-s $bam_file1, 'input exists: bam_files') or die;
-    
+
     my $bam_file2 = "$data_dir/test-bam-IKR.bam";
     ok(-s $bam_file2, 'input exists: bam_files') or die;
-    
+
     my $bam_file3 = "$data_dir/test-bam-VKR.bam";
     ok(-s $bam_file3, 'input exists: bam_files') or die;
-    
-    
+
+
     #create temp directory for merging
     my $tempdir = Genome::Sys->create_temp_directory();
     #$tempdir = '/gscmnt/gc3037/info/medseq/gchang/work2/01_EXOME-SEQ/13-26-CoveragePlot';       # for debug
     ok(-d $tempdir, 'temporary directory created') or die;
-    
+
     # creates and executes a command
     my $cmd = $class->create(
         roi_file_path => $roi_file_path,
         output_directory => $tempdir,
-        
+
         bam_files => [$bam_file1, $bam_file2, $bam_file3],
         labels => ["sample1", "sample2", "sample3"],
         min_depth_filters => [1, 20, 40, 60, 80, 100],
         wingspan  => 0,
         band_width => 10,
     );
-    
+
     ok($cmd, 'created command') or die;
     ok($cmd->execute, 'executed command') or die;
-    
-    
+
+
     # check outputs
     ok(-s "$tempdir/table.tsv", 'table.tsv has size');
     compare_ok("$tempdir/table.tsv", "$data_dir/table.tsv", 'table matches');
-    
+
     ok(-s "$tempdir/boxplot.tab", 'boxplot.tab has size');
     compare_ok("$tempdir/boxplot.tab", "$data_dir/boxplot.tab", 'boxplot matches');
-    
+
     ok(-s "$tempdir/coverage.tab", 'coverage.tab has size');
     compare_ok("$tempdir/coverage.tab", "$data_dir/coverage.tab", 'coverage matches');
-    
+
     ok(-s "$tempdir/density.tab", 'density.tab has size');
     compare_ok("$tempdir/density.tab", "$data_dir/density.tab", 'density matches');
-    
+
     # skips this plot PDF file
     ok(-s "$tempdir/coverage-plot.pdf", 'coverage-plot.pdf has size');
     #compare_ok("$tempdir/coverage-plot.pdf", "$data_dir/coverage-plot.pdf", 'coverage-plot matches');

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/CoveragePlot.t
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/CoveragePlot.t
@@ -36,7 +36,6 @@ eval
 
     #create temp directory for merging
     my $tempdir = Genome::Sys->create_temp_directory();
-    #$tempdir = '/gscmnt/gc3037/info/medseq/gchang/work2/01_EXOME-SEQ/13-26-CoveragePlot';       # for debug
     ok(-d $tempdir, 'temporary directory created') or die;
 
     # creates and executes a command

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/MergeReadcounts.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/MergeReadcounts.pm
@@ -40,7 +40,7 @@ class Genome::Model::Tools::Analysis::Coverage::MergeReadcounts{
 	genome_build => {
 	    is => 'String',
 	    is_optional => 0,
-	    doc => 'takes either a string describing the genome build (one of 36, 37, mm9, mus37, mus37wOSK) or a path to the genome fasta file',
+	    doc => 'takes either a string describing the genome build (one of 36, 37, mm9, mus37) or a path to the genome fasta file',
 	},
 	
 	min_quality_score => {
@@ -180,8 +180,6 @@ sub execute {
     elsif ($genome_build eq "mus37") {
         my $reference_build_fasta_object = Genome::Model::Build::ReferenceSequence->get(name => "NCBI-mouse-build37");
         $fasta = $reference_build_fasta_object->cached_full_consensus_path('fa');
-    } elsif ($genome_build eq "mus37wOSK") {
-        $fasta = "/gscmnt/sata135/info/medseq/dlarson/iPS_analysis/lentiviral_reference/mousebuild37_plus_lentivirus.fa";
     } elsif ($genome_build eq "mm9") {
         my $reference_build_fasta_object = Genome::Model::Build::ReferenceSequence->get(name => "UCSC-mouse-buildmm9");
         $fasta = $reference_build_fasta_object->cached_full_consensus_path('fa');

--- a/lib/perl/Genome/Model/Tools/Analysis/Coverage/MergeReadcounts.t
+++ b/lib/perl/Genome/Model/Tools/Analysis/Coverage/MergeReadcounts.t
@@ -17,7 +17,6 @@ eval
 
     # checks test data files
     my $data_dir = Genome::Utility::Test->data_dir($class);
-    # $data_dir = './3.test_suite_data';     # temporarily switched for debug
     ok(-d $data_dir, "data_dir exists: $data_dir") or die;
 
 
@@ -38,7 +37,6 @@ eval
 
     #create temp directory for merging
     my $tempdir = Genome::Sys->create_temp_directory();
-    #$tempdir = '/gscmnt/gc3037/info/medseq/gchang/work2/09_OTHERS/14-24-MergeReadcount-upgrade1';       # for debug
     ok(-s $tempdir, 'temporary directory created') or die;
 
 

--- a/lib/perl/Genome/Model/Tools/Analysis/Mendelian/RareHetRuleOutVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Mendelian/RareHetRuleOutVcf.pm
@@ -27,7 +27,7 @@ class Genome::Model::Tools::Analysis::Mendelian::RareHetRuleOutVcf {
 		min_affected_variant	=> { is => 'Text', doc => "Minimum number of affecteds with variant to include", is_optional => 1, is_input => 1, default => 1},
 		max_unaffected_variant	=> { is => 'Text', doc => "Maximum number of unaffecteds with variant to include", is_optional => 1, is_input => 1, default => 0},
 		plot_results	=> { is => 'Text', doc => "If set to 1, generate per-chromosome plots of results", is_optional => 1, is_input => 1, default => 0},
-		centromere_file	=> { is => 'Text', doc => "A UCSC 0-based BED file of centromere locations per chromosome", is_optional => 0, is_input => 1, default => '/gscmnt/sata809/info/medseq/dkoboldt/SNPseek2/ucsc/hg19/gapTable.centromere.nochr.txt'},
+		centromere_file	=> { is => 'Text', doc => "A UCSC 0-based BED file of centromere locations per chromosome", is_optional => 0, is_input => 1},
 	],
 };
 

--- a/lib/perl/Genome/Model/Tools/Analysis/Mendelian/SharedIbdVcf.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/Mendelian/SharedIbdVcf.pm
@@ -35,8 +35,8 @@ class Genome::Model::Tools::Analysis::Mendelian::SharedIbdVcf {
 		min_call_rate	=> { is => 'Text', doc => "Minimum callrate for affecteds to include a variant", is_optional => 1, is_input => 1, default => 0.50},
 		plot_resolution	=> { is => 'Text', doc => "Bin size for plotting shared IBD segments", is_optional => 1, is_input => 1, default => 100000},
 		path_to_beagle	=> { is => 'Text', doc => "Path to the BEAGLE executable required for fastIBD, i.e. /gsc/pkg/bio/beagle/beagle-3.3.12/beagle.jar", is_optional => 0, is_input => 1},
-		centromere_file	=> { is => 'Text', doc => "A UCSC 0-based BED file of centromere locations per chromosome", is_optional => 0, is_input => 1, default => '/gscmnt/sata809/info/medseq/dkoboldt/SNPseek2/ucsc/hg19/gapTable.centromere.nochr.txt'},
-		hapmap_file_dir	=> { is => 'Text', doc => "Directory containing genetic distances from HapMap, e.g. /gscmnt/sata809/info/medseq/dkoboldt/SNPseek2/ucsc/geneticMap/", is_optional => 0},
+		centromere_file	=> { is => 'Text', doc => "A UCSC 0-based BED file of centromere locations per chromosome", is_optional => 0, is_input => 1},
+		hapmap_file_dir	=> { is => 'Text', doc => "Directory containing genetic distances from HapMap", is_optional => 0},
 		hapmap_file_name => { is => 'Text', doc => "Search string to use for chromosome file with CHROM to replace chromosome name, e.g. genetic_map_GRCh37_chrCHROM.txt", is_optional => 0},
 	],
 };

--- a/lib/perl/Genome/Model/Tools/Analysis/MutationRate.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/MutationRate.pm
@@ -32,9 +32,9 @@ class Genome::Model::Tools::Analysis::MutationRate {
 		tier1_file	=> { is => 'Text', doc => "List of high-confidence tier 1 mutations" , is_optional => 0},
 		tier2_file	=> { is => 'Text', doc => "List of high-confidence tier 2 mutations" , is_optional => 1},
 		tier3_file	=> { is => 'Text', doc => "List of high-confidence tier 3 mutations" , is_optional => 1},
-		tier1_space	=> { is => 'Text', doc => "BED file of tier 1 space" , is_optional => 0, default => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build36/tier1.bed'},
-		tier2_space	=> { is => 'Text', doc => "BED file of tier 2 space" , is_optional => 0, default => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build36/tier2.bed'},
-		tier3_space	=> { is => 'Text', doc => "BED file of tier 3 space" , is_optional => 0, default => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build36/tier3.bed'},
+		tier1_space	=> { is => 'Text', doc => "BED file of tier 1 space" , is_optional => 0},
+		tier2_space	=> { is => 'Text', doc => "BED file of tier 2 space" , is_optional => 0},
+		tier3_space	=> { is => 'Text', doc => "BED file of tier 3 space" , is_optional => 0},
 		coverage_factor	=> { is => 'Text', doc => "Fraction of space covered for mutation detection" , is_optional => 0, default => 1},
     outfile => {is => 'FilesystemPath', doc => "Write output to this file instead of stdout", is_optional => 1},
 	],
@@ -80,18 +80,13 @@ sub execute {                               # replace with real execution logic.
         
         my $total_bases = my $total_mutations = 0;
 
-        ## Use known values whenever possible ##
-        my $tier1_bases = 43884962 if($self->tier1_space eq '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build36/tier1.bed');
-        my $tier2_bases = 248205479 if($self->tier2_space eq '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build36/tier2.bed');
-        my $tier3_bases = 1198993777 if($self->tier3_space eq '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build36/tier3.bed');
-
         my $mutation_string = my $rate_string = "";
 
         ## If other files were provided, calculate bases within them ##        
         
-        $tier1_bases = parse_regions_file($self->tier1_space) if(!$tier1_bases);
-        $tier2_bases = parse_regions_file($self->tier2_space) if(!$tier2_bases);
-        $tier3_bases = parse_regions_file($self->tier3_space) if(!$tier3_bases);
+        my $tier1_bases = parse_regions_file($self->tier1_space);
+        my $tier2_bases = parse_regions_file($self->tier2_space);
+        my $tier3_bases = parse_regions_file($self->tier3_space);
         my $non_tier1_bases = $tier2_bases + $tier3_bases;
 
         ## Load the tier 1 mutations and calculate its rate ##

--- a/lib/perl/Genome/Model/Tools/Analysis/MutationRate.pm
+++ b/lib/perl/Genome/Model/Tools/Analysis/MutationRate.pm
@@ -3,14 +3,14 @@ package Genome::Model::Tools::Analysis::MutationRate;     # rename this when you
 
 #####################################################################################################################################
 # MutationRate - Calculate the mutation rate (per megabase) given a list of mutations (e.g. tier1 SNVs) and a set of regions (e.g. coding space)
-#					
+#
 #	AUTHOR:		Dan Koboldt (dkoboldt@genome.wustl.edu)
 #
 #	CREATED:	04/22/2011 by D.K.
 #	MODIFIED:	04/22/2011 by D.K.
 #
-#	NOTES:	
-#			
+#	NOTES:
+#
 #####################################################################################################################################
 
 use strict;
@@ -25,9 +25,9 @@ use Genome;                                 # using the namespace authorizes Cla
 my %stats = ();
 
 class Genome::Model::Tools::Analysis::MutationRate {
-	is => 'Command',                       
-	
-	has => [                                # specify the command's single-value properties (parameters) <--- 
+	is => 'Command',
+
+	has => [                                # specify the command's single-value properties (parameters) <---
 		sample_name	=> { is => 'Text', doc => "Descriptive name for sample" , is_optional => 1, default => ['Sample']},
 		tier1_file	=> { is => 'Text', doc => "List of high-confidence tier 1 mutations" , is_optional => 0},
 		tier2_file	=> { is => 'Text', doc => "List of high-confidence tier 2 mutations" , is_optional => 1},
@@ -43,7 +43,7 @@ class Genome::Model::Tools::Analysis::MutationRate {
 sub sub_command_sort_position { 12 }
 
 sub help_brief {                            # keep this to just a few words <---
-    "Calculates the average mutation rate per megabase"                 
+    "Calculates the average mutation rate per megabase"
 }
 
 sub help_synopsis {
@@ -57,7 +57,7 @@ EOS
 }
 
 sub help_detail {                           # this is what the user will see with the longer version of help. <---
-    return <<EOS 
+    return <<EOS
 
 OUTPUT format is TSV (SampleName then Mutation counts then Mutation rates per megabase).
 Depends on which tiers are specified but in general of the form:
@@ -77,29 +77,29 @@ sub execute {                               # replace with real execution logic.
 
         my $coverage_factor = $self->coverage_factor;
 	## Get required parameters ##
-        
+
         my $total_bases = my $total_mutations = 0;
 
         my $mutation_string = my $rate_string = "";
 
-        ## If other files were provided, calculate bases within them ##        
-        
+        ## If other files were provided, calculate bases within them ##
+
         my $tier1_bases = parse_regions_file($self->tier1_space);
         my $tier2_bases = parse_regions_file($self->tier2_space);
         my $tier3_bases = parse_regions_file($self->tier3_space);
         my $non_tier1_bases = $tier2_bases + $tier3_bases;
 
         ## Load the tier 1 mutations and calculate its rate ##
-            
-        my $tier1_mutations = parse_mutations_file($self->tier1_file);      
+
+        my $tier1_mutations = parse_mutations_file($self->tier1_file);
         my $tier1_rate = ($tier1_mutations / $coverage_factor) / ($tier1_bases / 1000000);
-        
+
 #        print "TIER\tMUTS\tTOTAL_BASES\tMUTS_PER_MB\n";
 #       print join("\t", "1", $tier1_mutations, commify($tier1_bases), $tier1_rate)  . "\n";
         $mutation_string .= "\t$tier1_mutations";
         $rate_string .= "\t$tier1_rate";
-        
-        $total_mutations = $tier1_mutations;        
+
+        $total_mutations = $tier1_mutations;
         $total_bases = $tier1_bases;
 
         my $tier2_mutations = my $tier3_mutations = 0;
@@ -165,19 +165,19 @@ sub execute {                               # replace with real execution logic.
 sub parse_mutations_file
 {
 	(my $mutation_file) = @_;
-	
+
         if(!(-e $mutation_file))
         {
             die "Mutation file not found: $mutation_file\n";
         }
-        
+
         my $num_mutations = 0;
-        
+
 	## Parse the file ##
 
 	my $input = new FileHandle ($mutation_file);
 	my $lineCounter = 0;
-	
+
 	while (<$input>)
 	{
 		chomp;
@@ -185,18 +185,18 @@ sub parse_mutations_file
 		$lineCounter++;
 
                 my ($chrom, $chr_start, $chr_stop, $ref, $var) = split(/\t/, $line);
-                
+
                 if($chrom && lc($chrom) ne "chr" && lc($chrom) ne "chrom")
                 {
-                    $num_mutations++;   
+                    $num_mutations++;
                 }
 
 	}
-	
+
 	close($input);
 
 	return($num_mutations);
-	
+
 }
 
 
@@ -209,19 +209,19 @@ sub parse_mutations_file
 sub parse_regions_file
 {
 	(my $regions_file) = @_;
-	
+
         if(!(-e $regions_file))
         {
             die "Regions file not found: $regions_file\n";
         }
-        
+
         my $num_bases = 0;
-        
+
 	## Parse the file ##
 
 	my $input = new FileHandle ($regions_file);
 	my $lineCounter = 0;
-	
+
 	while (<$input>)
 	{
 		chomp;
@@ -229,7 +229,7 @@ sub parse_regions_file
 		$lineCounter++;
 
                 my ($chrom, $chr_start, $chr_stop) = split(/\t/, $line);
-                
+
                 if($chrom && lc($chrom) ne "chr" && lc($chrom) ne "chrom")
                 {
                     for(my $position = $chr_start; $position <= $chr_stop; $position++)
@@ -239,11 +239,11 @@ sub parse_regions_file
                 }
 
 	}
-	
+
 	close($input);
 
 	return($num_bases);
-	
+
 }
 
 

--- a/lib/perl/Genome/Model/Tools/Annotate/RegulatoryFeatures.pm
+++ b/lib/perl/Genome/Model/Tools/Annotate/RegulatoryFeatures.pm
@@ -29,7 +29,7 @@ class Genome::Model::Tools::Annotate::RegulatoryFeatures {
 	
 	has => [                                # specify the command's single-value properties (parameters) <--- 
 		variant_file	=> { is => 'Text', doc => "A list of variants in annotation format", is_optional => 0, is_input => 1},
-		regfeats_file	=> { is => 'Text', doc => "Path to ENCODE regulatory features file. Feel free to use /gscmnt/sata809/info/medseq/dkoboldt/SNPseek2/encode/release-66/AnnotatedFeatures.gff.nochr.tsv", is_optional => 0, is_input => 1},
+		regfeats_file	=> { is => 'Text', doc => "Path to ENCODE regulatory features file.", is_optional => 0, is_input => 1},
 		output_file	=> { is => 'Text', doc => "Output file for annotation-results", is_optional => 1, is_input => 1},
 	],
 };

--- a/lib/perl/Genome/Model/Tools/Bed/Convert/Snv/MutectToBed.t
+++ b/lib/perl/Genome/Model/Tools/Bed/Convert/Snv/MutectToBed.t
@@ -13,7 +13,6 @@ use above 'Genome';
 
 use_ok('Genome::Model::Tools::Bed::Convert::Snv::MutectToBed');
 
-#my $test_dir = "/gscmnt/sata831/info/medseq/dlarson/mutect_testing/Genome-Model-Tools-Bed-Convert-Snv-MutectToBed";
 my $test_dir = Genome::Config::get('test_inputs') . "/Genome-Model-Tools-Bed-Convert-Snv-MutectToBed";
 
 my $expected_base = "expected.v2";

--- a/lib/perl/Genome/Model/Tools/Mutect.pm
+++ b/lib/perl/Genome/Model/Tools/Mutect.pm
@@ -179,9 +179,6 @@ sub execute {
         skip_if_output_is_present => 0,
         allow_zero_size_output_files => 1,
     );
-=cut
-java -Xmx5g -jar /gscuser/dlarson/mutect/muTect-1.1.4.jar --analysis_type MuTect --reference_sequence /gscmnt/ams1102/info/model_data/2869585698/build106942997/all_sequences.fa --input_file:normal /gscmnt/gc13001/info/model_data/2889433023/build136498879/alignments/136268587.bam --input_file:tumor /gscmnt/gc9006/info/model_data/2891225638/build136025755/alignments/135842703.bam --vcf aml31relapse_mutect_test100.vcf --coverage_file coverage100.txt --out aml31relapse_call_stats100.txt --cosmic /gscmnt/sata135/info/medseq/dlarson/aml31_mutect_manual/b37_cosmic_v54_120711.vcf --dbsnp /gscmnt/sata135/info/medseq/dlarson/aml31_mutect_manual/gatk_bundle_v2.3_b37/dbsnp_137.b37.vcf --intervals Y:34482907-59373566 --intervals MT:1-16569 
-=cut
 }
 
 1;

--- a/lib/perl/Genome/Model/Tools/Somatic/FilterMouseBases.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/FilterMouseBases.pm
@@ -23,7 +23,6 @@ class Genome::Model::Tools::Somatic::FilterMouseBases {
            is_input => 1,
            is_output => 1,
            doc => 'UCSC liftover chain file for human to mouse',
-           example_values => ['/gscmnt/sata112/info/medseq/reference_sequences/Homo_sapiens/liftOver_files/hg19_GRCh37_Build-37/hg19ToMm9.over.chain.gz'],
        },
        'human_reference' => {
            type => 'String',

--- a/lib/perl/Genome/Model/Tools/Somatic/FilterPindel.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/FilterPindel.pm
@@ -124,8 +124,6 @@ sub execute {
 
     return 1;
 }
-1;
-
 
 sub dbsnp_lookup {
     my $self=shift;
@@ -150,4 +148,5 @@ sub dbsnp_lookup {
     }
     return $dbsnp_id;
 }
-;
+
+1;

--- a/lib/perl/Genome/Model/Tools/Somatic/FilterPindel.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/FilterPindel.pm
@@ -50,7 +50,7 @@ sub help_brief {
 sub help_synopsis {
     my $self = shift;
     return <<"EOS"
-gmt somatic filter-pindel --output-dir=/gscmnt/sata921/info/medseq/testing_launch_pindel/MEL_calls/filtering_results --variant-bed-file=/gscmnt/sata921/info/medseq/testing_launch_pindel/MEL_calls/indels.hq.bed
+gmt somatic filter-pindel --output-dir=/path/to/info/medseq/testing_launch_pindel/MEL_calls/filtering_results --variant-bed-file=/path/to/info/medseq/testing_launch_pindel/MEL_calls/indels.hq.bed
 EOS
 }
 

--- a/lib/perl/Genome/Model/Tools/Somatic/FilterPindel.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/FilterPindel.pm
@@ -54,8 +54,8 @@ gmt somatic filter-pindel --output-dir=/path/to/info/medseq/testing_launch_pinde
 EOS
 }
 
-sub help_detail {                           
-    return <<EOS 
+sub help_detail {
+    return <<EOS
 The temporary pipeline to run pindel removed dbsnp filtering, tiering, and annotation so this replaces that until DetectVariants2 is ready.  Supply a bed input and an output directory and it will filter out dbsnp sites, tier the remaining, and annotate them
 EOS
 }
@@ -88,7 +88,7 @@ sub execute {
     Genome::Sys->validate_file_for_reading($self->variant_bed_file);
     my $output = $self->output_dir;
     Genome::Sys->create_directory($output);  #this seems to be a no op if it exists
- 
+
     my $vfh = Genome::Sys->open_file_for_reading($self->variant_bed_file);
     my $output_file_name = $self->output_dir ."/" .  File::Basename::basename($self->variant_bed_file);
     my $novel_file_name = $output_file_name . ".novel";
@@ -141,12 +141,12 @@ sub dbsnp_lookup {
             }
         }
     }
-    else {        
+    else {
         if(exists($deletions{$chr}{$start}{$stop}{'allele'})) {
             if ($ref eq $deletions{$chr}{$start}{$stop}{'allele'}) {
                 $dbsnp_id=$deletions{$chr}{$start}{$stop}{'id'};
             }
-        } 
+        }
     }
     return $dbsnp_id;
 }

--- a/lib/perl/Genome/Model/Tools/Somatic/LaunchPindel.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/LaunchPindel.pm
@@ -62,8 +62,8 @@ sub help_synopsis {
 EOS
 }
 
-sub help_detail {                           
-    return <<EOS 
+sub help_detail {
+    return <<EOS
 This runs pindel version .4 with the Fisher's Exact test germline filter at the conclusion.  It is implemented inside the DetectVariants API so this wrapper makes it easier to use.  This new version of pindel allows more reads into consideration which should generate more events and also filter out more germline events.  The new filter does a FET between the distribution of reads mapping with an insertion/deletion vs normally mapped reads at the site in tumor and normal.  If the p-value is .15 or below that they are different, we keep the site under consideration.  The idea here is that GATK will resolve similar indel distribution sites more accurately than pindel has been able to do.  In addition, pindel recovers some reads that are unmapped previously and we attempt to pass any of these  sites through the filter.  That 'override' condition is: Tumor reads at site < 10 and pindel_reads > indel mapping reads in tumor
 EOS
 }
@@ -72,18 +72,18 @@ sub execute {
     my $self = shift;
     my $normal_bam = $self->normal_bam;
     my $tumor_bam = $self->tumor_bam;
-    if($self->normal_build && $self->tumor_build) { 
+    if($self->normal_build && $self->tumor_build) {
         my $normal_build = Genome::Model::Build::ReferenceAlignment->get($self->normal_build);
         my $tumor_build = Genome::Model::Build::ReferenceAlignment->get($self->tumor_build);
          $normal_bam = $normal_build->whole_rmdup_bam_file;
          $tumor_bam = $tumor_build->whole_rmdup_bam_file;
     }
-    Genome::Sys->validate_file_for_reading($normal_bam); 
+    Genome::Sys->validate_file_for_reading($normal_bam);
     Genome::Sys->validate_file_for_reading($tumor_bam);
 
     my $output = $self->output_dir;
     Genome::Sys->create_directory($output);  #this seems to be a no op if it exists
-    
+
         my $email_address = Genome::Utility::Email::construct_address($ENV{'LOGNAME'});
         $self->debug_message("sending a completion mail to: $email_address");
         my $include;

--- a/lib/perl/Genome/Model/Tools/Somatic/LaunchPindel.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/LaunchPindel.pm
@@ -58,7 +58,7 @@ sub help_brief {
 sub help_synopsis {
     my $self = shift;
     return <<"EOS"
- gmt somatic launch-pindel --normal-bam=/gscmnt/sata921/info/medseq/indel_validation_bams/true_positive_normal_validation.bam  --tumor-bam=/gscmnt/sata921/info/medseq/indel_validation_bams/true_positive_normal_validation.bam --output-dir=/gscmnt/sata921/info/medseq/testing_launch_pindel
+ gmt somatic launch-pindel --normal-bam=/path/to/info/medseq/indel_validation_bams/true_positive_normal_validation.bam  --tumor-bam=/path/to/info/medseq/indel_validation_bams/true_positive_normal_validation.bam --output-dir=/path/to/info/medseq/testing_launch_pindel
 EOS
 }
 

--- a/lib/perl/Genome/Model/Tools/Somatic/LibrarySupportFilter.pm
+++ b/lib/perl/Genome/Model/Tools/Somatic/LibrarySupportFilter.pm
@@ -89,8 +89,6 @@ sub execute {
     my $single_lib_output = IO::File->new( $self->single_lib_output_file, '>' )
         || die "Could not open for writing " . $self->single_lib_output_file();
 
-# stuff below from /gscmnt/sata146/info/medseq/charris/GBM/somatic_indel_finder.pl
-
     while ( my $line = $indel_file->getline() ) {
 
         chomp $line;
@@ -183,7 +181,6 @@ sub find_read_support {
     my ( $self, $chr, $pos, $indel_cigar ) = @_;
     my %library_hash; 
 
-    # "/gscmnt/sata821/info/model_data/2774314134/build96520626/alignments/H_GP-0124t_merged_rmdup.bam";
     my $sample_alignment_file = $self->sample_alignment_file();
 
     my @reads = `samtools view $sample_alignment_file $chr:$pos-$pos`;

--- a/lib/perl/Genome/Model/Tools/Sv/Pairoscope.pm
+++ b/lib/perl/Genome/Model/Tools/Sv/Pairoscope.pm
@@ -55,7 +55,6 @@ class Genome::Model::Tools::Sv::Pairoscope {
         },
         exon_bam => {
             type => "String",
-            example_values => ["/gscmnt/sata135/info/medseq/dlarson/hg18.NCBI-human.combined-annotation.54_36p_v2.sorted.bam"],
             doc => "bam file of exons to use for displaying gene models", 
             is_optional => 1,
         },

--- a/lib/perl/Genome/Model/Tools/Validation/ClonalityPlot.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/ClonalityPlot.pm
@@ -139,7 +139,6 @@ sub help_brief {
 }
 
 sub help_synopsis {
-    #gmt validation clonality-plot --cnvhmm-file /gscmnt/sata872/info/medseq/luc_wgs/CNV/cnaseg/LUC1.cnaseg --output-image LUC1.clonality.pdf --analysis-type capture --r-script-output-file LUC1.R --varscan-file /gscmnt/sata872/info/medseq/luc_wgs/LUC1/validation/varscan/t123_targeted.pvalue_filtered.somatic --sample-id "LUC1" --positions-highlight test.X.sites
     return <<EOS
         Inputs of Varscan and copy-number segmentation data, Output of R plots.
 EXAMPLE:	gmt validation clonality-plot --analysis-type 'capture' --varscan-file snvs.txt --cnvhmm-file cnaseg.txt --output-image clonality.pdf --sample-id 'Sample'

--- a/lib/perl/Genome/Model/Tools/Validation/GetGeneTargets.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/GetGeneTargets.pm
@@ -59,9 +59,6 @@ sub execute
                 if ($self->exon_file){
                         $exon_file=$self->exon_file;
                 }
-                else{
-                        $exon_file="/gscmnt/gc2108/info/medseq/ckandoth/bed_maker/NCBI-human.combined-annotation_58_37c_v2/all_CDS_and_ncRNA_24Chroms_Contigs_1BasedStart_2bpFlanks_MergedExons";
-                }
                 my %exon_hash;
                 my $exon_fh=new FileHandle($exon_file);
                 while(<$exon_fh>){

--- a/lib/perl/Genome/Model/Tools/Validation/GetGeneTargets.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/GetGeneTargets.pm
@@ -21,7 +21,7 @@ class Genome::Model::Tools::Validation::GetGeneTargets {
     exon_file => {
     type => 'String',
     is_optional => 0,
-    doc => "exon bed file with chromosome, start, stop, and gene name, separated by tab.  build37: /gscmnt/gc2108/info/medseq/ckandoth/bed_maker/NCBI-human.combined-annotation_58_37c_v2/all_CDS_and_ncRNA_24Chroms_Contigs_1BasedStart_2bpFlanks_MergedExons",
+    doc => "exon bed file with chromosome, start, stop, and gene name, separated by tab.",
     },
     ]
 };

--- a/lib/perl/Genome/Model/Tools/Validation/GetGeneTargets.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/GetGeneTargets.pm
@@ -17,23 +17,23 @@ class Genome::Model::Tools::Validation::GetGeneTargets {
     type => 'String',
     is_optional => 1,
     doc => "output file containing targets information, default is targets.tsv in your working directory",
-    },   
+    },
     exon_file => {
     type => 'String',
     is_optional => 0,
     doc => "exon bed file with chromosome, start, stop, and gene name, separated by tab.  build37: /gscmnt/gc2108/info/medseq/ckandoth/bed_maker/NCBI-human.combined-annotation_58_37c_v2/all_CDS_and_ncRNA_24Chroms_Contigs_1BasedStart_2bpFlanks_MergedExons",
     },
-    ] 
+    ]
 };
 
 sub execute
 {
         my $self=shift;
         $DB::single = 1;
-        
+
         my $gene_file;
         my %genelist_hash;
-        
+
         if ($self->input_file){
                 $gene_file=$self->input_file;
                 my $gene_fh=new FileHandle($gene_file);
@@ -42,7 +42,7 @@ sub execute
                 my ($gene,@others)=split/\t/;
                 $genelist_hash{$gene}=1;
                 }
-                
+
                 my $summary_file;
                 my $output_file;
                 if ($self->output_file){
@@ -54,7 +54,7 @@ sub execute
                         $summary_file="summary";
                 }
                 open OUT, ">$output_file";
-                
+
                 my $exon_file;
                 if ($self->exon_file){
                         $exon_file=$self->exon_file;
@@ -66,8 +66,8 @@ sub execute
                         my $line=$_;
                         my ($chr,$start,$stop,$gene)=split/\t/;
                         my $pos=$chr."_".$start."_".$stop;
-#                        if (defined $exon_hash{$gene}){  
-                        if (defined $genelist_hash{$gene}){  
+#                        if (defined $exon_hash{$gene}){
+                        if (defined $genelist_hash{$gene}){
                                 print OUT "$line\n";
                                 push @{$exon_hash{$gene}}, $pos;
                         }
@@ -77,7 +77,7 @@ sub execute
                         }
                }
                close OUT;
-               
+
                open SUM, ">$summary_file";
                my %selected_genes;
 
@@ -89,7 +89,7 @@ sub execute
 
                 foreach my $gene (keys %genelist_hash){
                         if (defined $exon_hash{$gene}){
-                                
+
                                 my $total_bases=0;
                                 my @exons=@{$exon_hash{$gene}};
                                 my $num_exon=@exons;
@@ -104,7 +104,7 @@ sub execute
                                 print SUM "$gene\t$num_exon\t$total_bases\n";
                                 delete $genelist_hash{$gene};
                         }
-                        
+
                 }
 
                 print SUM "\n\n==============================\n";
@@ -122,8 +122,8 @@ sub execute
                 print "Please enter an input file containing gene list, one gene per line\n";
                 return 1;
         }
-        
-        
+
+
         return 1;
 }
 1;
@@ -134,9 +134,9 @@ sub help_brief {
 
 sub help_detail {
     <<'HELP';
-this script will print out the chr,start and end of exons for a given gene list, it will also generate a summary report containing the following: 
+this script will print out the chr,start and end of exons for a given gene list, it will also generate a summary report containing the following:
 1) how many exons and bases per gene were selected
 2) warn you about genes that had no exons in the file.
-The summary file will be named your_output.summary along with your output_file, if output_file is not defined, then the summary file will be in your working directory, and named "summary". 
+The summary file will be named your_output.summary along with your output_file, if output_file is not defined, then the summary file will be in your working directory, and named "summary".
 HELP
 }

--- a/lib/perl/Genome/Model/Tools/Validation/LongIndelsParseRemapped.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/LongIndelsParseRemapped.pm
@@ -98,7 +98,6 @@ sub execute {
     print `$cmd`;
 
     #create an annotate-able list of somatic calls, getting ref and var bases from the contigs
-    #gmt annotate adaptor indel-contig --contig-count-file /gscmnt/sata204/info/medseq/prc1/validation/Indel_analysis/lcm3/long_indels/combined_counts_somatic.csv --contig-fasta-file /gscmnt/sata204/info/medseq/prc1/validation/Indel_analysis/lcm3/long_indels/contigs.fa --output-file /gscmnt/sata204/info/medseq/prc1/validation/Indel_analysis/lcm3/long_indels/combined_counts_somatic.csv.indel.contig
     my $adapted_somatic_calls = $somatic_calls_file . ".adapted";
     $self->debug_message("Running gmt annotate adaptor indel-contig");
     my $adaptor_cmd = Genome::Model::Tools::Annotate::Adaptor::IndelContig->create(

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Snv/Mutect.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Snv/Mutect.t
@@ -13,7 +13,6 @@ use above 'Genome';
 
 use_ok('Genome::Model::Tools::Vcf::Convert::Snv::Mutect');
 
-#my $test_dir = "/gscmnt/sata831/info/medseq/dlarson/mutect_testing/Genome-Model-Tools-Vcf-Convert-Snv-Mutect";
 my $test_dir = Genome::Config::get('test_inputs') . "/Genome-Model-Tools-Vcf-Convert-Snv-Mutect";
 
 my $expected_base = "expected.v1";

--- a/lib/perl/Genome/Model/Tools/Vcf/ConvertToBeagle.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/ConvertToBeagle.pm
@@ -34,7 +34,7 @@ class Genome::Model::Tools::Vcf::ConvertToBeagle {
 		chromosome	=> { is => 'Text', doc => "Output results for a single chromosome" , is_optional => 1},
 		complete_only	=> { is => 'Text', doc => "Only output if all samples have genotypes" , is_optional => 1},
 		min_read_depth	=> { is => 'Text', doc => "Minimum VCF read depth to accept backfilled wildtype genotypes" , is_optional => 0, default => 20},
-		hapmap_file	=> { is => 'Text', doc => "Genetic map distances from HapMap, e.g. /gscmnt/sata809/info/medseq/dkoboldt/SNPseek2/ucsc/geneticMap/genetic_map_GRCh37_chr1.txt" , is_optional => 1},
+		hapmap_file	=> { is => 'Text', doc => "Genetic map distances from HapMap" , is_optional => 1},
 	],
 };
 


### PR DESCRIPTION
Having a bunch of hard-coded paths around in the code is sub-optimal!  Most of these were in comments or examples, but a few remove defaults.

Subsequent PRs will address other affected modules for which I think more expansive changes are required.