### PR TITLE
UCSC annotation file changes for ReferenceSequence

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -200,7 +200,7 @@ sub get_or_create_ucsc_tiering_directory {
 
     my %tiering_dirs = (
         '10194788' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/hg18_build36_ucsc_files',
-        '106942997' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/hg18_build36_ucsc_files',
+        '106942997' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build37/hg19_files',
         '107494762' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-mouse-build37/mm9',
         '3ca0ea4786dd4ebebaf3935f3d3ccab8' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-mouse-build38/mm10',
         '4ec1c5bd1f6941b8a99f2e230217cb91' => '/gscmnt/gc13001/info/model_data/jwalker_scratch/GRCh38',

--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -214,21 +214,6 @@ sub get_or_create_ucsc_tiering_directory {
     }
 }
 
-#TODO: figure out how to get this and make it a real result
-sub get_or_create_ucsc_conservation_directory {
-    my $self = shift;
-    if ($self->id eq "101947881") {
-        return "/gscmnt/ams1161/info/model_data/2771411739/build113115679/annotation_data/ucsc_conservation/";
-    }
-    elsif ($self->id eq "106942997") {
-        return "/gscmnt/ams1102/info/model_data/2771411739/build106409619/annotation_data/ucsc_conservation/"
-    }
-    else {
-        $self->status_message("UCSC conservation scores are not currently available in the system for this species: ".$self->species_name);
-        return;
-    }
-}
-
 sub is_derived_from {
     my ($self, $build, $seen) = @_;
     $seen = {} if !defined $seen;

--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -199,7 +199,7 @@ sub get_or_create_ucsc_tiering_directory {
     my $self = shift;
 
     my %tiering_dirs = (
-        '10194788' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/hg18_build36_ucsc_files',
+        '101947881' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/hg18_build36_ucsc_files',
         '106942997' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build37/hg19_files',
         '107494762' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-mouse-build37/mm9',
         '3ca0ea4786dd4ebebaf3935f3d3ccab8' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-mouse-build38/mm10',
@@ -217,7 +217,7 @@ sub get_or_create_ucsc_tiering_directory {
 #TODO: figure out how to get this and make it a real result
 sub get_or_create_ucsc_conservation_directory {
     my $self = shift;
-    if ($self->id eq "10194788") {
+    if ($self->id eq "101947881") {
         return "/gscmnt/ams1161/info/model_data/2771411739/build113115679/annotation_data/ucsc_conservation/";
     }
     elsif ($self->id eq "106942997") {

--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -198,16 +198,10 @@ sub get {
 sub get_or_create_ucsc_tiering_directory {
     my $self = shift;
 
-    my %tiering_dirs = (
-        '101947881' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/hg18_build36_ucsc_files',
-        '106942997' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-human-build37/hg19_files',
-        '107494762' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-mouse-build37/mm9',
-        '3ca0ea4786dd4ebebaf3935f3d3ccab8' => '/gscmnt/sata921/info/medseq/make_tier_bed_files/NCBI-mouse-build38/mm10',
-        '4ec1c5bd1f6941b8a99f2e230217cb91' => '/gscmnt/gc13001/info/model_data/jwalker_scratch/GRCh38',
-    );
+    my $dir = File::Spec->join($self->data_directory, 'ucsc_tiering_files');
 
-    if ($tiering_dirs{$self->id}) {
-        return $tiering_dirs{$self->id};
+    if (-d $dir) {
+        return $dir;
     } else {
         $self->status_message('UCSC Tiering Directory not currently available for this species: '. $self->species_name);
         return;

--- a/lib/perl/Genome/Model/ImportedAnnotation.pm
+++ b/lib/perl/Genome/Model/ImportedAnnotation.pm
@@ -192,12 +192,6 @@ sub _execute_build {
             }
         }
 
-        my $ucsc_directory = $annotation_directory."/ucsc_conservation";
-        my $original_ucsc_dir = $build->reference_sequence->get_or_create_ucsc_conservation_directory;
-        if ($original_ucsc_dir) {
-            Genome::Sys->create_symlink($original_ucsc_dir, $ucsc_directory);
-        }
-
         #generate the rna seq files
         $self->generate_rna_seq_files($build);
 


### PR DESCRIPTION
This changes two things:
* The UCSC conservation directory must be manually linked to each annotation build that wants it.
* The UCSC tiering files for a reference should be linked into the reference build instead of using a hard-coded path.