### PR TITLE
Speedseq SV remove sort and symlink VCF.

### DIFF
--- a/etc/genome/spec/lsf_resource_dv2_speedseq_sv.yaml
+++ b/etc/genome/spec/lsf_resource_dv2_speedseq_sv.yaml
@@ -1,3 +1,3 @@
 ---
-default_value: "-R 'select[tmp>=10000 && mem>=12000] rusage[tmp=10000, mem=12000]' -M 12000000"
+default_value: "-R 'select[tmp>=10000 && mem>=16000] rusage[tmp=10000, mem=16000]' -M 16000000"
 env: XGENOME_LSF_RESOURCE_DV2_SPEEDSEQ_SV

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
@@ -7,7 +7,6 @@ use Genome;
 
 use File::Basename qw(fileparse);
 use File::Spec;
-use Cwd;
 
 class Genome::Model::Tools::DetectVariants2::SpeedseqSv {
     is => 'Genome::Model::Tools::DetectVariants2::Detector',
@@ -68,12 +67,9 @@ sub _detect_variants {
     # Make a symlink to the actual VCF as the DV2 Dispatcher expects an output of svs.hq rather than BED or VCF output
     my ($vcf_file) = glob($self->_sv_staging_output .'*.vcf.gz');
     if ($vcf_file) {
-        my $cwd = getcwd();
-        chdir($self->_temp_staging_directory);
         my $rel_path = File::Spec->abs2rel( $vcf_file, $self->_temp_staging_directory ) ;
-        symlink($rel_path,$self->_sv_base_name .'.vcf.gz');
-        symlink($rel_path,$self->_sv_base_name .'.vcf.gz.tbi');
-        chdir($cwd);
+        symlink($rel_path,$self->_sv_staging_output .'.vcf.gz');
+        symlink($rel_path,$self->_sv_staging_output .'.vcf.gz.tbi');
     }
 }
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
@@ -136,5 +136,10 @@ sub has_version {
     }
 }
 
+sub _sort_detector_output {
+    # This command does not produce a BED output file
+    return 1;
+}
+
 
 1;

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
@@ -68,8 +68,8 @@ sub _detect_variants {
     my ($vcf_file) = glob($self->_sv_staging_output .'*.vcf.gz');
     if ($vcf_file) {
         my $rel_path = File::Spec->abs2rel( $vcf_file, $self->_temp_staging_directory ) ;
-        symlink($rel_path,$self->_sv_staging_output .'.vcf.gz');
-        symlink($rel_path,$self->_sv_staging_output .'.vcf.gz.tbi');
+        Genome::Sys->create_symlink($rel_path,$self->_sv_staging_output .'.vcf.gz');
+        Genome::Sys->create_symlink($rel_path,$self->_sv_staging_output .'.vcf.gz.tbi');
     }
 }
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
@@ -7,6 +7,7 @@ use Genome;
 
 use File::Basename qw(fileparse);
 use File::Spec;
+use Cwd;
 
 class Genome::Model::Tools::DetectVariants2::SpeedseqSv {
     is => 'Genome::Model::Tools::DetectVariants2::Detector',
@@ -67,7 +68,12 @@ sub _detect_variants {
     # Make a symlink to the actual VCF as the DV2 Dispatcher expects an output of svs.hq rather than BED or VCF output
     my ($vcf_file) = glob($self->_sv_staging_output .'*.vcf.gz');
     if ($vcf_file) {
-        symlink($vcf_file,$self->_sv_staging_output);
+        my $cwd = getcwd();
+        chdir($self->_temp_staging_directory);
+        my $rel_path = File::Spec->abs2rel( $vcf_file, $self->_temp_staging_directory ) ;
+        symlink($rel_path,$self->_sv_base_name .'.vcf.gz');
+        symlink($rel_path,$self->_sv_base_name .'.vcf.gz.tbi');
+        chdir($cwd);
     }
 }
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.pm
@@ -69,7 +69,7 @@ sub _detect_variants {
     if ($vcf_file) {
         my $rel_path = File::Spec->abs2rel( $vcf_file, $self->_temp_staging_directory ) ;
         Genome::Sys->create_symlink($rel_path,$self->_sv_staging_output .'.vcf.gz');
-        Genome::Sys->create_symlink($rel_path,$self->_sv_staging_output .'.vcf.gz.tbi');
+        Genome::Sys->create_symlink($rel_path .'.tbi',$self->_sv_staging_output .'.vcf.gz.tbi');
     }
 }
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/SpeedseqSv.t
@@ -54,6 +54,9 @@ my $differ = Genome::File::Vcf::Differ->new("$output/svs.hq.sv.vcf.gz", "$test_d
 my $diff = $differ->diff;
 is($diff, undef, "Found No differences between $output/svs.hq.sv.vcf.gz and (expected) $test_dir/svs.hq.sv.vcf.gz") ||	diag $diff->to_string;
 
+ok(-l $command2->sv_output .'.vcf.gz', 'output VCF file symlink exists as expected');
+ok(-l $command2->sv_output .'.vcf.gz.tbi', 'output VCF index symlink exists as expected');
+
 compare_ok("$output/svs.hq.sv.NA12878.20slice.30X.aligned.bam.readdepth.bed","$test_dir/svs.hq.sv.NA12878.20slice.30X.aligned.bam.readdepth.bed");
 compare_ok("$output/svs.hq.sv.NA12878.20slice.30X.aligned.bam.readdepth.txt","$test_dir/svs.hq.sv.NA12878.20slice.30X.aligned.bam.readdepth.txt");
 


### PR DESCRIPTION
1. Skip the sort since the output is VCF.
2. Generate a symlink for the VCF (and index) so the DV2 Dispatcher will find the output file.
3. Increase RAM to 16GB