### PR TITLE
Use GDC Portal instead of TCGA Portal

### DIFF
--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.pm
@@ -478,7 +478,7 @@ sub get_sample_meta {
         my $uuids = $self->query_tcga_barcode(\@tcga_barcodes);
 
         my @lines;
-        for my $id (@tcga_barcodes) {
+        for my $id (sort { $uuids->{$b} cmp $uuids->{$a} } @tcga_barcodes) {
             my $uuid = $uuids->{$id};
             unless ($uuid) {
                 $self->fatal_message(query_tcga_barcode_error_template, $id, 'No match found in results');

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.t
@@ -10,7 +10,7 @@ my $class = 'Genome::Model::Tools::Vcf::Convert::Base';
 use_ok($class);
 
 subtest 'query_tcga_barcode' => sub {
-    plan tests => 5;
+    plan tests => 3;
 
     my $test_class = join('::', $class, 'Test');
     UR::Object::Type->define(
@@ -22,24 +22,14 @@ subtest 'query_tcga_barcode' => sub {
     $self->dump_error_messages(0);
 
     {
-        my $barcode = 'TCGA-A2-A25B-01A-11R-A169-07';
+        my $barcode = ['TCGA-A2-A25B-01A-11R-A169-07'];
         my $content = $self->query_tcga_barcode($barcode, sleep => 1);
         ok($content, qq(received content for barcode: $barcode));
     }
 
     {
-        my $barcode = 'NOT-A-BARCODE';
+        my $barcode = ['NOT-A-BARCODE'];
         my $content = eval { $self->query_tcga_barcode($barcode, sleep => 1) };
-        my $error = $@;
-        ok(!$content, qq(did not receive content for barcode: $barcode));
-        my $error_re = sprintf($class->query_tcga_barcode_error_template, '.*', '.*');
-        like($error, qr/$error_re/, qq(expected exception thrown for barcode: $barcode));
-    }
-
-    {
-        my $barcode = 'TCGA-A2-A25B-01A-11R-A169-07';
-        my $bad_URL = 'https://tcga-data.nci.nih.gov/XXX/uuidws/mapping/json/barcode/batch';
-        my $content = eval { $self->query_tcga_barcode($barcode, sleep => 1, url => $bad_URL) };
         my $error = $@;
         ok(!$content, qq(did not receive content for barcode: $barcode));
         my $error_re = sprintf($class->query_tcga_barcode_error_template, '.*', '.*');

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.t
@@ -10,7 +10,7 @@ my $class = 'Genome::Model::Tools::Vcf::Convert::Base';
 use_ok($class);
 
 subtest 'query_tcga_barcode' => sub {
-    plan tests => 3;
+    plan tests => 4;
 
     my $test_class = join('::', $class, 'Test');
     UR::Object::Type->define(
@@ -22,14 +22,15 @@ subtest 'query_tcga_barcode' => sub {
     $self->dump_error_messages(0);
 
     {
-        my $barcode = ['TCGA-A2-A25B-01A-11R-A169-07'];
-        my $content = $self->query_tcga_barcode($barcode, sleep => 1);
+        my $barcode = 'TCGA-A2-A25B-01A-11R-A169-07';
+        my $content = $self->query_tcga_barcode([$barcode], sleep => 1);
         ok($content, qq(received content for barcode: $barcode));
+        ok(exists $content->{$barcode}, 'found a response for query');
     }
 
     {
-        my $barcode = ['NOT-A-BARCODE'];
-        my $content = eval { $self->query_tcga_barcode($barcode, sleep => 1) };
+        my $barcode = 'NOT-A-BARCODE';
+        my $content = eval { $self->query_tcga_barcode([$barcode], sleep => 1) };
         my $error = $@;
         ok(!$content, qq(did not receive content for barcode: $barcode));
         my $error_re = sprintf($class->query_tcga_barcode_error_template, '.*', '.*');


### PR DESCRIPTION
The [TCGA Data Portal](https://tcga-data.nci.nih.gov) has been down several days and contains a note directing users to the GDC Portal instead.  This updates our TCGA barcode query to retrieve the UUID from the GDC API.