### PR TITLE
FeatureList Import: Skip blank lines instead of crashing.

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/Import.pm
+++ b/lib/perl/Genome/FeatureList/Command/Import.pm
@@ -165,6 +165,8 @@ sub validate_and_sanitize_bed {
         next if $line =~ /^browser/;
         $line =~ s/\015$//; #remove CRs if BED came from Windows
 
+        next if $line =~ /^\s*$/; #skip blank lines
+
         if($line =~ /^track/) {
             $self->is_multitracked(1);
             my %track_attrs = Genome::FeatureList->parse_track_definition($line);


### PR DESCRIPTION
I'm not sure why there'd be blank lines here to begin with, but at least there's a straightforward thing to do with them. 😄 