### PR TITLE
Better Model/RnaSeq.t Diffs

### DIFF
--- a/lib/perl/Genome/Model/RnaSeq.t
+++ b/lib/perl/Genome/Model/RnaSeq.t
@@ -59,8 +59,7 @@ ok(-s $expected_xml_file, "Expected xml file exists at $expected_xml_file");
 ok(-s $xml_file, "Current xml file exists at $xml_file");
 compare_ok($expected_xml_file, $xml_file, name => "Xml file is as expected for the workflow",
     replace => [
-        [qr(lsfQueue="apipe"), q(lsfQueue="GENOME_LSF_QUEUE_BUILD_WORKER_ALT")],
-        [qr(lsfQueue="apipe-pd"), q(lsfQueue="GENOME_LSF_QUEUE_BUILD_WORKER_ALT")],
+        [qr(lsfQueue="[^"]+"), q(lsfQueue="GENOME_LSF_QUEUE_BUILD_WORKER_ALT")],
     ],
 );
 

--- a/lib/perl/Genome/Model/RnaSeq.t
+++ b/lib/perl/Genome/Model/RnaSeq.t
@@ -60,6 +60,7 @@ ok(-s $xml_file, "Current xml file exists at $xml_file");
 compare_ok($expected_xml_file, $xml_file, name => "Xml file is as expected for the workflow",
     replace => [
         [qr(lsfQueue="[^"]+"), q(lsfQueue="GENOME_LSF_QUEUE_BUILD_WORKER_ALT")],
+        [qr(lsfResource="[^"]+"), q(lsfResource="LSF_RESOURCE")],
     ],
 );
 


### PR DESCRIPTION
The existing diff logic was dependent on configuration having certain values, which defeats the purpose of configuration!  (We recently changed away from the assumed values, exposing this flaw.)