### PR TITLE
SomVar uses WorkflowBuilder

### DIFF
--- a/lib/perl/Genome/Model/SomaticVariation.pm
+++ b/lib/perl/Genome/Model/SomaticVariation.pm
@@ -428,14 +428,14 @@ sub _resolve_workflow_for_build {
     my $self = shift;
     my $build = shift;
 
-    my $operation = Workflow::Operation->create_from_xml(__FILE__ . '.xml');
+    my $workflow = Genome::WorkflowBuilder::DAG->from_xml_filename(__FILE__ . '.xml');
 
     my $log_directory = $build->log_directory;
-    $operation->log_dir($log_directory);
+    $workflow->recursively_set_log_dir($log_directory);
 
-    $operation->name($build->workflow_name);
+    $workflow->name($build->workflow_name);
 
-    return $operation;
+    return $workflow;
 }
 
 sub map_workflow_inputs {

--- a/lib/perl/Genome/Model/SomaticVariation.pm
+++ b/lib/perl/Genome/Model/SomaticVariation.pm
@@ -433,7 +433,6 @@ sub _resolve_workflow_for_build {
     my $log_directory = $build->log_directory;
     $operation->log_dir($log_directory);
 
-    #I think this ideally should be handled 
     $operation->name($build->workflow_name);
 
     return $operation;


### PR DESCRIPTION
The base class has long since accepted either a `Genome::WorkflowBuilder::DAG` or a `Workflow::Model`. This PR switches SomaticVariation from the latter to the former.