### PR TITLE
Convert RnaSeq Workflow Generation to WorkflowBuilder.

### DIFF
--- a/lib/perl/Genome/Model/RnaSeq.pm
+++ b/lib/perl/Genome/Model/RnaSeq.pm
@@ -188,10 +188,10 @@ sub _parse_strategy {
     unless ( ($tool, $version, $x, $params) = ($strategy =~ /^(.+?)\s+(\S+)\s*(|\[(.*)\])\s*$/) ) {
         die "failed to parse strategy: $strategy!";
     }
-   
+
     #Genome::Utility::Text::string_to_camel_case($detector,"-")
     my $cmd_class = 'Genome::Model::Tools::' . join('::', map { ucfirst(lc($_)) } split('-',$tool));
-    
+
     my %params;
     my %params1 = ($params ? split(/\s+/,$params) : ());
     for my $param (keys %params1) {
@@ -299,7 +299,7 @@ sub _resolve_workflow_for_build {
         }
         if ($ensembl_version >= 67) {
             $run_splice_junction_summary = 1;
-        } 
+        }
         else {
             $self->debug_message('Skipping SpliceJunctionSummary for annotation build: '. $self->annotation_build);
         }
@@ -359,7 +359,7 @@ sub _resolve_workflow_for_build {
         right_operation => $alignment_operation,
         right_property => 'build_id'
     );
-   
+
     # Digital expression
     my $digital_expression_detection_operation = undef;
     if (my $strategy = $processing_profile->digital_expression_detection_strategy) {
@@ -383,14 +383,14 @@ sub _resolve_workflow_for_build {
                 right_property => $key,
             );
         }
-        
+
         $link = $workflow->add_link(
             left_operation => $alignment_operation,
             left_property => 'individual_alignment_results',
             right_operation => $digital_expression_detection_operation,
             right_property => 'alignment_results',
         );
-        
+
         $link = $workflow->add_link(
             left_operation => $digital_expression_detection_operation,
             left_property => 'output_result',
@@ -435,7 +435,7 @@ sub _resolve_workflow_for_build {
 
         $bam_qc_operation->operation_type->lsf_queue($lsf_queue);
         $bam_qc_operation->operation_type->lsf_project($lsf_project);
-        
+
         $workflow->add_link(
             left_operation => $alignment_operation,
             left_property => 'build_id',
@@ -457,7 +457,7 @@ sub _resolve_workflow_for_build {
             );
             $splice_junction_operation->operation_type->lsf_queue($lsf_queue);
             $splice_junction_operation->operation_type->lsf_project($lsf_project);
-            
+
             $workflow->add_link(
                 left_operation => $alignment_operation,
                 left_property => 'build_id',
@@ -472,7 +472,7 @@ sub _resolve_workflow_for_build {
             );
         }
     }
-    
+
     # Picard
     my $picard_operation = $workflow->add_operation(
         name => 'RnaSeq Picard Metrics',
@@ -805,7 +805,7 @@ Illumina RNA-seq library.  Reads were initially aligned to the $species
 reference genome using Eland and stored as a BAM file.  These alignments
 were used for basic quality assessment purposes only and no read filtering
 was performed.  Mapping statistics for the BAM file were generated
-using Samtools flagstat (v. $lims_samtools_version) (REF). 
+using Samtools flagstat (v. $lims_samtools_version) (REF).
 The BAM file was converted to FastQ using Picard (v.$picard_version) (REF)
 and all reads were re-aligned to the $alignment_ref
 using $aligner_name (v $aligner_version) (REF).  $aligner_name was run in default mode with
@@ -814,11 +814,11 @@ were estimated prior to run time using the Eland alignments described
 above (elaborate) and specified at run time.  The '-G' option was used
 to specify a GTF file for $aligner_name to generate an exon-exon junction
 database to assist in the mapping of known junctions.  The transcripts
-for this GTF were obtained from $annotation_source.  The 
+for this GTF were obtained from $annotation_source.  The
 resulting $aligner_name BAM file was indexed by $bam_index_tool
-and sorted by chromosome mapping position using $bam_sort_tool. 
+and sorted by chromosome mapping position using $bam_sort_tool.
 Transcript expression values were estimated by Cufflinks (v$cufflinks_version)
-(REF) using default parameters with the following exceptions.  The Cufflinks 
+(REF) using default parameters with the following exceptions.  The Cufflinks
 parameter '-G' was specified to force cufflinks to estimate expression
 for known transcripts provided by the same GTF file that was supplied
 to $aligner_name described above.  A second GTF containing only the
@@ -828,7 +828,7 @@ overall robustness of transcript abundance estimates.  The variant
 and corresponding gene expression status in the transcriptome were
 determined for SNV positions identified as somatic in the WGS
 tumor/normal data.  FPKM values were summarized to the gene level by
-adding Cufflinks FPKMs from alternative transcripts of each Ensembl gene. 
+adding Cufflinks FPKMs from alternative transcripts of each Ensembl gene.
 The variant allele frequencies were determined by counting reads
 supporting reference and variant base counts using the Perl module
 "Bio::DB::Sam".

--- a/lib/perl/Genome/Model/RnaSeq.pm
+++ b/lib/perl/Genome/Model/RnaSeq.pm
@@ -353,7 +353,7 @@ sub _resolve_workflow_for_build {
     $alignment_operation->operation_type->lsf_queue($lsf_queue);
     $alignment_operation->operation_type->lsf_project($lsf_project);
 
-    my $link = $workflow->add_link(
+    $workflow->add_link(
         left_operation => $input_connector,
         left_property => 'build_id',
         right_operation => $alignment_operation,
@@ -376,7 +376,7 @@ sub _resolve_workflow_for_build {
         $digital_expression_detection_operation->operation_type->lsf_project($lsf_project);
 
         for my $key (keys %$params, qw/requestor sponsor user label output_dir/) {
-            my $link = $workflow->add_link(
+            $workflow->add_link(
                 left_operation => $input_connector,
                 left_property => 'digital_expression_' . $key,
                 right_operation => $digital_expression_detection_operation,
@@ -384,14 +384,14 @@ sub _resolve_workflow_for_build {
             );
         }
 
-        $link = $workflow->add_link(
+        $workflow->add_link(
             left_operation => $alignment_operation,
             left_property => 'individual_alignment_results',
             right_operation => $digital_expression_detection_operation,
             right_property => 'alignment_results',
         );
 
-        $link = $workflow->add_link(
+        $workflow->add_link(
             left_operation => $digital_expression_detection_operation,
             left_property => 'output_result',
             right_operation => $output_connector,

--- a/lib/perl/Genome/Model/RnaSeq.pm
+++ b/lib/perl/Genome/Model/RnaSeq.pm
@@ -629,26 +629,21 @@ sub connect_fusion_detector_to_input_connector {
     my $input_connector = shift;
     my $fusion_detection_operation = shift;
 
-    $workflow->add_link(
-        left_operation => $input_connector,
-        left_property => 'fusion_detector',
-        right_operation => $fusion_detection_operation,
-        right_property => 'detector_name',
+    my %input_properties = (
+        'fusion_detector'           => 'detector_name',
+        'fusion_detector_version'   => 'detector_version',
+        'fusion_detector_params'    => 'detector_params',
     );
 
-    $workflow->add_link(
-        left_operation => $input_connector,
-        left_property => 'fusion_detector_version',
-        right_operation => $fusion_detection_operation,
-        right_property => 'detector_version',
-    );
+    while (my ($input, $destination) = each %input_properties) {
+        $workflow->add_link(
+            left_operation => $input_connector,
+            left_property => $input,
+            right_operation => $fusion_detection_operation,
+            right_property => $destination,
+        );
+    }
 
-    $workflow->add_link(
-        left_operation => $input_connector,
-        left_property => 'fusion_detector_params',
-        right_operation => $fusion_detection_operation,
-        right_property => 'detector_params',
-    );
     return;
 }
 

--- a/lib/perl/Genome/Model/RnaSeq.t
+++ b/lib/perl/Genome/Model/RnaSeq.t
@@ -53,7 +53,7 @@ ok($workflow, "Got a workflow");
 my $test_dir = __FILE__ . '.d';
 my $xml_file = Genome::Sys->create_temp_file_path;
 my $expected_xml_file = "$test_dir/workflow.xml";
-$workflow->save_to_xml(OutputFile => $xml_file);
+Genome::Sys->write_file($xml_file, $workflow->get_xml);
 
 ok(-s $expected_xml_file, "Expected xml file exists at $expected_xml_file");
 ok(-s $xml_file, "Current xml file exists at $xml_file");

--- a/lib/perl/Genome/Model/RnaSeq.t
+++ b/lib/perl/Genome/Model/RnaSeq.t
@@ -50,7 +50,7 @@ my $workflow = $rnaseq_model->_resolve_workflow_for_build($rnaseq_build);
 ok($workflow, "Got a workflow");
 
 # Test expected workflow xml
-my $test_dir = Genome::Utility::Test->data_dir('Genome::Model::RnaSeq', '2015-01-22');
+my $test_dir = __FILE__ . '.d';
 my $xml_file = Genome::Sys->create_temp_file_path;
 my $expected_xml_file = "$test_dir/workflow.xml";
 $workflow->save_to_xml(OutputFile => $xml_file);

--- a/lib/perl/Genome/Model/RnaSeq.t.d/workflow.xml
+++ b/lib/perl/Genome/Model/RnaSeq.t.d/workflow.xml
@@ -1,0 +1,68 @@
+<?xml version='1.0' standalone='yes'?>
+<workflow name="135296493" executor="Workflow::Executor::SerialDeferred" logDir="/gscmnt/gc8001/info/model_data/2891321785/build135296493/logs/">
+  <link fromOperation="input connector" fromProperty="build_id" toOperation="RnaSeq Alignment" toProperty="build_id" />
+  <link fromOperation="input connector" fromProperty="digital_expression_app_version" toOperation="RnaSeq Digital Expression Detection" toProperty="app_version" />
+  <link fromOperation="input connector" fromProperty="digital_expression_blacklist_alignments_flags" toOperation="RnaSeq Digital Expression Detection" toProperty="blacklist_alignments_flags" />
+  <link fromOperation="input connector" fromProperty="digital_expression_mode" toOperation="RnaSeq Digital Expression Detection" toProperty="mode" />
+  <link fromOperation="input connector" fromProperty="digital_expression_minaqual" toOperation="RnaSeq Digital Expression Detection" toProperty="minaqual" />
+  <link fromOperation="input connector" fromProperty="digital_expression_result_version" toOperation="RnaSeq Digital Expression Detection" toProperty="result_version" />
+  <link fromOperation="input connector" fromProperty="digital_expression_requestor" toOperation="RnaSeq Digital Expression Detection" toProperty="requestor" />
+  <link fromOperation="input connector" fromProperty="digital_expression_sponsor" toOperation="RnaSeq Digital Expression Detection" toProperty="sponsor" />
+  <link fromOperation="input connector" fromProperty="digital_expression_user" toOperation="RnaSeq Digital Expression Detection" toProperty="user" />
+  <link fromOperation="input connector" fromProperty="digital_expression_label" toOperation="RnaSeq Digital Expression Detection" toProperty="label" />
+  <link fromOperation="input connector" fromProperty="digital_expression_output_dir" toOperation="RnaSeq Digital Expression Detection" toProperty="output_dir" />
+  <link fromOperation="RnaSeq Alignment" fromProperty="individual_alignment_results" toOperation="RnaSeq Digital Expression Detection" toProperty="alignment_results" />
+  <link fromOperation="RnaSeq Digital Expression Detection" fromProperty="output_result" toOperation="output connector" toProperty="digital_expression_detection_result" />
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Alignment Metrics" toProperty="build_id" />
+  <link fromOperation="RnaSeq Alignment Metrics" fromProperty="result" toOperation="output connector" toProperty="alignment_stats_result" />
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq BamQc" toProperty="build_id" />
+  <link fromOperation="RnaSeq BamQc" fromProperty="result" toOperation="output connector" toProperty="bam_qc_result" />
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Picard Metrics" toProperty="build_id" />
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Coverage" toProperty="build_id" />
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Cufflinks Expression" toProperty="build_id" />
+  <link fromOperation="input connector" fromProperty="annotation_reference_transcripts_mode" toOperation="RnaSeq Cufflinks Expression" toProperty="annotation_reference_transcripts_mode" />
+  <link fromOperation="RnaSeq Picard Metrics" fromProperty="result" toOperation="output connector" toProperty="metrics_result" />
+  <link fromOperation="RnaSeq Coverage" fromProperty="result" toOperation="output connector" toProperty="coverage_result" />
+  <link fromOperation="RnaSeq Cufflinks Expression" fromProperty="result" toOperation="output connector" toProperty="expression_result" />
+  <operation name="RnaSeq Alignment">
+    <operationtype commandClass="Genome::Model::RnaSeq::Command::AlignReads" lsfProject="build135296493" lsfQueue="apipe" typeClass="Workflow::OperationType::Command" />
+  </operation>
+  <operation name="RnaSeq Digital Expression Detection">
+    <operationtype commandClass="Genome::Model::Tools::Htseq::Count" lsfProject="build135296493" lsfQueue="apipe" typeClass="Workflow::OperationType::Command" />
+  </operation>
+  <operation name="RnaSeq Alignment Metrics">
+    <operationtype commandClass="Genome::Model::RnaSeq::Command::Tophat2AlignmentStats" lsfProject="build135296493" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=8000] rusage[mem=8000]' -M 8000000" typeClass="Workflow::OperationType::Command" />
+  </operation>
+  <operation name="RnaSeq BamQc">
+    <operationtype commandClass="Genome::Model::RnaSeq::Command::BamQc" lsfProject="build135296493" lsfQueue="apipe" typeClass="Workflow::OperationType::Command" />
+  </operation>
+  <operation name="RnaSeq Picard Metrics">
+    <operationtype commandClass="Genome::Model::RnaSeq::Command::PicardRnaSeqMetrics" lsfProject="build135296493" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=8000] rusage[mem=8000]' -M 8000000" typeClass="Workflow::OperationType::Command" />
+  </operation>
+  <operation name="RnaSeq Coverage">
+    <operationtype commandClass="Genome::Model::RnaSeq::Command::Coverage" lsfProject="build135296493" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=32000] rusage[mem=32000]' -M 32000000" typeClass="Workflow::OperationType::Command" />
+  </operation>
+  <operation name="RnaSeq Cufflinks Expression" parallelBy="annotation_reference_transcripts_mode">
+    <operationtype commandClass="Genome::Model::RnaSeq::Command::Expression::Cufflinks" lsfProject="build135296493" lsfQueue="apipe" lsfResource="-R 'span[hosts=1]' -n 4" typeClass="Workflow::OperationType::Command" />
+  </operation>
+  <operationtype typeClass="Workflow::OperationType::Model">
+    <inputproperty>digital_expression_label</inputproperty>
+    <inputproperty>digital_expression_minaqual</inputproperty>
+    <inputproperty>build_id</inputproperty>
+    <inputproperty>digital_expression_requestor</inputproperty>
+    <inputproperty>digital_expression_mode</inputproperty>
+    <inputproperty>digital_expression_user</inputproperty>
+    <inputproperty>digital_expression_output_dir</inputproperty>
+    <inputproperty>annotation_reference_transcripts_mode</inputproperty>
+    <inputproperty>digital_expression_result_version</inputproperty>
+    <inputproperty>digital_expression_sponsor</inputproperty>
+    <inputproperty>digital_expression_app_version</inputproperty>
+    <inputproperty>digital_expression_blacklist_alignments_flags</inputproperty>
+    <outputproperty>coverage_result</outputproperty>
+    <outputproperty>expression_result</outputproperty>
+    <outputproperty>metrics_result</outputproperty>
+    <outputproperty>digital_expression_detection_result</outputproperty>
+    <outputproperty>bam_qc_result</outputproperty>
+    <outputproperty>alignment_stats_result</outputproperty>
+  </operationtype>
+</workflow>

--- a/lib/perl/Genome/Model/RnaSeq.t.d/workflow.xml
+++ b/lib/perl/Genome/Model/RnaSeq.t.d/workflow.xml
@@ -1,68 +1,103 @@
-<?xml version='1.0' standalone='yes'?>
-<workflow name="135296493" executor="Workflow::Executor::SerialDeferred" logDir="/gscmnt/gc8001/info/model_data/2891321785/build135296493/logs/">
-  <link fromOperation="input connector" fromProperty="build_id" toOperation="RnaSeq Alignment" toProperty="build_id" />
-  <link fromOperation="input connector" fromProperty="digital_expression_app_version" toOperation="RnaSeq Digital Expression Detection" toProperty="app_version" />
-  <link fromOperation="input connector" fromProperty="digital_expression_blacklist_alignments_flags" toOperation="RnaSeq Digital Expression Detection" toProperty="blacklist_alignments_flags" />
-  <link fromOperation="input connector" fromProperty="digital_expression_mode" toOperation="RnaSeq Digital Expression Detection" toProperty="mode" />
-  <link fromOperation="input connector" fromProperty="digital_expression_minaqual" toOperation="RnaSeq Digital Expression Detection" toProperty="minaqual" />
-  <link fromOperation="input connector" fromProperty="digital_expression_result_version" toOperation="RnaSeq Digital Expression Detection" toProperty="result_version" />
-  <link fromOperation="input connector" fromProperty="digital_expression_requestor" toOperation="RnaSeq Digital Expression Detection" toProperty="requestor" />
-  <link fromOperation="input connector" fromProperty="digital_expression_sponsor" toOperation="RnaSeq Digital Expression Detection" toProperty="sponsor" />
-  <link fromOperation="input connector" fromProperty="digital_expression_user" toOperation="RnaSeq Digital Expression Detection" toProperty="user" />
-  <link fromOperation="input connector" fromProperty="digital_expression_label" toOperation="RnaSeq Digital Expression Detection" toProperty="label" />
-  <link fromOperation="input connector" fromProperty="digital_expression_output_dir" toOperation="RnaSeq Digital Expression Detection" toProperty="output_dir" />
-  <link fromOperation="RnaSeq Alignment" fromProperty="individual_alignment_results" toOperation="RnaSeq Digital Expression Detection" toProperty="alignment_results" />
-  <link fromOperation="RnaSeq Digital Expression Detection" fromProperty="output_result" toOperation="output connector" toProperty="digital_expression_detection_result" />
-  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Alignment Metrics" toProperty="build_id" />
-  <link fromOperation="RnaSeq Alignment Metrics" fromProperty="result" toOperation="output connector" toProperty="alignment_stats_result" />
-  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq BamQc" toProperty="build_id" />
-  <link fromOperation="RnaSeq BamQc" fromProperty="result" toOperation="output connector" toProperty="bam_qc_result" />
-  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Picard Metrics" toProperty="build_id" />
-  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Coverage" toProperty="build_id" />
-  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Cufflinks Expression" toProperty="build_id" />
-  <link fromOperation="input connector" fromProperty="annotation_reference_transcripts_mode" toOperation="RnaSeq Cufflinks Expression" toProperty="annotation_reference_transcripts_mode" />
-  <link fromOperation="RnaSeq Picard Metrics" fromProperty="result" toOperation="output connector" toProperty="metrics_result" />
-  <link fromOperation="RnaSeq Coverage" fromProperty="result" toOperation="output connector" toProperty="coverage_result" />
-  <link fromOperation="RnaSeq Cufflinks Expression" fromProperty="result" toOperation="output connector" toProperty="expression_result" />
-  <operation name="RnaSeq Alignment">
-    <operationtype commandClass="Genome::Model::RnaSeq::Command::AlignReads" lsfProject="build135296493" lsfQueue="apipe" typeClass="Workflow::OperationType::Command" />
-  </operation>
-  <operation name="RnaSeq Digital Expression Detection">
-    <operationtype commandClass="Genome::Model::Tools::Htseq::Count" lsfProject="build135296493" lsfQueue="apipe" typeClass="Workflow::OperationType::Command" />
-  </operation>
-  <operation name="RnaSeq Alignment Metrics">
-    <operationtype commandClass="Genome::Model::RnaSeq::Command::Tophat2AlignmentStats" lsfProject="build135296493" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=8000] rusage[mem=8000]' -M 8000000" typeClass="Workflow::OperationType::Command" />
-  </operation>
-  <operation name="RnaSeq BamQc">
-    <operationtype commandClass="Genome::Model::RnaSeq::Command::BamQc" lsfProject="build135296493" lsfQueue="apipe" typeClass="Workflow::OperationType::Command" />
-  </operation>
-  <operation name="RnaSeq Picard Metrics">
-    <operationtype commandClass="Genome::Model::RnaSeq::Command::PicardRnaSeqMetrics" lsfProject="build135296493" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=8000] rusage[mem=8000]' -M 8000000" typeClass="Workflow::OperationType::Command" />
-  </operation>
-  <operation name="RnaSeq Coverage">
-    <operationtype commandClass="Genome::Model::RnaSeq::Command::Coverage" lsfProject="build135296493" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=32000] rusage[mem=32000]' -M 32000000" typeClass="Workflow::OperationType::Command" />
-  </operation>
-  <operation name="RnaSeq Cufflinks Expression" parallelBy="annotation_reference_transcripts_mode">
-    <operationtype commandClass="Genome::Model::RnaSeq::Command::Expression::Cufflinks" lsfProject="build135296493" lsfQueue="apipe" lsfResource="-R 'span[hosts=1]' -n 4" typeClass="Workflow::OperationType::Command" />
-  </operation>
+<?xml version="1.0"?>
+<operation name="135296493" logDir="/gscmnt/gc8001/info/model_data/2891321785/build135296493/logs/">
   <operationtype typeClass="Workflow::OperationType::Model">
-    <inputproperty>digital_expression_label</inputproperty>
-    <inputproperty>digital_expression_minaqual</inputproperty>
-    <inputproperty>build_id</inputproperty>
-    <inputproperty>digital_expression_requestor</inputproperty>
-    <inputproperty>digital_expression_mode</inputproperty>
-    <inputproperty>digital_expression_user</inputproperty>
-    <inputproperty>digital_expression_output_dir</inputproperty>
     <inputproperty>annotation_reference_transcripts_mode</inputproperty>
-    <inputproperty>digital_expression_result_version</inputproperty>
-    <inputproperty>digital_expression_sponsor</inputproperty>
+    <inputproperty>build_id</inputproperty>
     <inputproperty>digital_expression_app_version</inputproperty>
     <inputproperty>digital_expression_blacklist_alignments_flags</inputproperty>
+    <inputproperty>digital_expression_label</inputproperty>
+    <inputproperty>digital_expression_minaqual</inputproperty>
+    <inputproperty>digital_expression_mode</inputproperty>
+    <inputproperty>digital_expression_output_dir</inputproperty>
+    <inputproperty>digital_expression_requestor</inputproperty>
+    <inputproperty>digital_expression_result_version</inputproperty>
+    <inputproperty>digital_expression_sponsor</inputproperty>
+    <inputproperty>digital_expression_user</inputproperty>
+    <outputproperty>alignment_stats_result</outputproperty>
+    <outputproperty>bam_qc_result</outputproperty>
     <outputproperty>coverage_result</outputproperty>
+    <outputproperty>digital_expression_detection_result</outputproperty>
     <outputproperty>expression_result</outputproperty>
     <outputproperty>metrics_result</outputproperty>
-    <outputproperty>digital_expression_detection_result</outputproperty>
-    <outputproperty>bam_qc_result</outputproperty>
-    <outputproperty>alignment_stats_result</outputproperty>
   </operationtype>
-</workflow>
+  <operation name="RnaSeq Alignment">
+    <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="apipe" commandClass="Genome::Model::RnaSeq::Command::AlignReads" lsfProject="build135296493">
+      <inputproperty>build_id</inputproperty>
+      <outputproperty>build_id</outputproperty>
+      <outputproperty>individual_alignment_results</outputproperty>
+      <outputproperty>merged_alignment_result_id</outputproperty>
+      <outputproperty>merged_bam_path</outputproperty>
+      <outputproperty>result</outputproperty>
+    </operationtype>
+  </operation>
+  <operation name="RnaSeq Alignment Metrics">
+    <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=8000] rusage[mem=8000]' -M 8000000" commandClass="Genome::Model::RnaSeq::Command::Tophat2AlignmentStats" lsfProject="build135296493">
+      <inputproperty>build_id</inputproperty>
+      <outputproperty>build_id</outputproperty>
+      <outputproperty>result</outputproperty>
+      <outputproperty>tophat2_alignment_stats_result_id</outputproperty>
+    </operationtype>
+  </operation>
+  <operation name="RnaSeq BamQc">
+    <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="apipe" commandClass="Genome::Model::RnaSeq::Command::BamQc" lsfProject="build135296493">
+      <inputproperty>build_id</inputproperty>
+      <outputproperty>bam_qc_result_id</outputproperty>
+      <outputproperty>result</outputproperty>
+    </operationtype>
+  </operation>
+  <operation name="RnaSeq Coverage">
+    <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=32000] rusage[mem=32000]' -M 32000000" commandClass="Genome::Model::RnaSeq::Command::Coverage" lsfProject="build135296493">
+      <inputproperty>build_id</inputproperty>
+      <outputproperty>build_id</outputproperty>
+      <outputproperty>result</outputproperty>
+      <outputproperty>transcriptome_coverage_result_id</outputproperty>
+    </operationtype>
+  </operation>
+  <operation name="RnaSeq Cufflinks Expression" parallelBy="annotation_reference_transcripts_mode">
+    <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=64000] rusage[mem=64000] span[hosts=1]' -M 64000000 -n 4" commandClass="Genome::Model::RnaSeq::Command::Expression::Cufflinks" lsfProject="build135296493">
+      <inputproperty>build_id</inputproperty>
+      <outputproperty>build_id</outputproperty>
+      <outputproperty>cufflinks_expression_result_id</outputproperty>
+      <outputproperty>result</outputproperty>
+    </operationtype>
+  </operation>
+  <operation name="RnaSeq Digital Expression Detection">
+    <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="apipe" commandClass="Genome::Model::Tools::Htseq::Count" lsfProject="build135296493">
+      <inputproperty>alignment_results</inputproperty>
+      <outputproperty>output_result</outputproperty>
+      <outputproperty>result</outputproperty>
+    </operationtype>
+  </operation>
+  <operation name="RnaSeq Picard Metrics">
+    <operationtype typeClass="Workflow::OperationType::Command" lsfQueue="apipe" lsfResource="-R 'select[mem&gt;=8000] rusage[mem=8000]' -M 8000000" commandClass="Genome::Model::RnaSeq::Command::PicardRnaSeqMetrics" lsfProject="build135296493">
+      <inputproperty>build_id</inputproperty>
+      <outputproperty>build_id</outputproperty>
+      <outputproperty>picard_rna_seq_metrics_result_id</outputproperty>
+      <outputproperty>result</outputproperty>
+    </operationtype>
+  </operation>
+  <link fromOperation="RnaSeq Alignment Metrics" fromProperty="result" toOperation="output connector" toProperty="alignment_stats_result"/>
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Alignment Metrics" toProperty="build_id"/>
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq BamQc" toProperty="build_id"/>
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Coverage" toProperty="build_id"/>
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Cufflinks Expression" toProperty="build_id"/>
+  <link fromOperation="RnaSeq Alignment" fromProperty="individual_alignment_results" toOperation="RnaSeq Digital Expression Detection" toProperty="alignment_results"/>
+  <link fromOperation="RnaSeq Alignment" fromProperty="build_id" toOperation="RnaSeq Picard Metrics" toProperty="build_id"/>
+  <link fromOperation="RnaSeq BamQc" fromProperty="result" toOperation="output connector" toProperty="bam_qc_result"/>
+  <link fromOperation="RnaSeq Coverage" fromProperty="result" toOperation="output connector" toProperty="coverage_result"/>
+  <link fromOperation="RnaSeq Cufflinks Expression" fromProperty="result" toOperation="output connector" toProperty="expression_result"/>
+  <link fromOperation="RnaSeq Digital Expression Detection" fromProperty="output_result" toOperation="output connector" toProperty="digital_expression_detection_result"/>
+  <link fromOperation="RnaSeq Picard Metrics" fromProperty="result" toOperation="output connector" toProperty="metrics_result"/>
+  <link fromOperation="input connector" fromProperty="build_id" toOperation="RnaSeq Alignment" toProperty="build_id"/>
+  <link fromOperation="input connector" fromProperty="annotation_reference_transcripts_mode" toOperation="RnaSeq Cufflinks Expression" toProperty="annotation_reference_transcripts_mode"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_app_version" toOperation="RnaSeq Digital Expression Detection" toProperty="app_version"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_blacklist_alignments_flags" toOperation="RnaSeq Digital Expression Detection" toProperty="blacklist_alignments_flags"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_label" toOperation="RnaSeq Digital Expression Detection" toProperty="label"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_minaqual" toOperation="RnaSeq Digital Expression Detection" toProperty="minaqual"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_mode" toOperation="RnaSeq Digital Expression Detection" toProperty="mode"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_output_dir" toOperation="RnaSeq Digital Expression Detection" toProperty="output_dir"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_requestor" toOperation="RnaSeq Digital Expression Detection" toProperty="requestor"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_result_version" toOperation="RnaSeq Digital Expression Detection" toProperty="result_version"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_sponsor" toOperation="RnaSeq Digital Expression Detection" toProperty="sponsor"/>
+  <link fromOperation="input connector" fromProperty="digital_expression_user" toOperation="RnaSeq Digital Expression Detection" toProperty="user"/>
+</operation>


### PR DESCRIPTION
`Genome::Model::Build->start` was already converting the resulting workflow to `WorkflowBuilder` when starting the build, but now it uses it the whole time.  Another step on the road to removing `Workflow`!