### PR TITLE
ClinSeq: Remove false comment.

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -563,7 +563,6 @@ sub map_workflow_inputs {
 
 sub _resolve_workflow_for_build {
     # This is called by Genome::Model::Build::start()
-    # Returns a Workflow::Operation
     my $self        = shift;
     my $build       = shift;
     my $lsf_queue   = shift;  # TODO: the workflow shouldn't need this yet


### PR DESCRIPTION
This was converted to WorkflowBuilder in #1326, but this comment was missed.  (This now returns a `Genome::WorkflowBuilder::DAG`, but I don't think a comment to that effect is necessary.)