### PR TITLE
Specify a default queue in several SomVal steps.

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/IdentifyDnp.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/IdentifyDnp.pm
@@ -34,6 +34,11 @@ class Genome::Model::SomaticValidation::Command::IdentifyDnp {
             doc => "Somatic Validation build that the DNP result will belong to and which procides the reads and proportion parameters.",
         },
     ],
+    has_param => [
+        lsf_queue => {
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
+    ],
     doc => 'identify DNPs',
 };
 

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ProcessValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ProcessValidation.pm
@@ -25,6 +25,11 @@ class Genome::Model::SomaticValidation::Command::ProcessValidation {
             id_by => 'build_id',
         },
     ],
+    has_param => {
+        lsf_queue => {
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
+    },
     doc => 'final processing of HQ SNV detection results',
 };
 

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.pm
@@ -42,6 +42,11 @@ class Genome::Model::SomaticValidation::Command::ValidateSvs::CreateAssembledCon
             is_optional => 1,
         },
     ],
+    has_param => [
+       lsf_queue => {
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+       },
+    ],
     doc => 'creates a reference sequence for validating by alignment',
 };
 

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/GenerateMergedAssemblies.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/GenerateMergedAssemblies.pm
@@ -46,6 +46,12 @@ class Genome::Model::SomaticValidation::Command::ValidateSvs::GenerateMergedAsse
         },
     ],
 
+    has_param => [
+       lsf_queue => {
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+       },
+    ],
+
     doc => 'generates a merged callset and FASTA for validating by alignment',
 };
 

--- a/lib/perl/Genome/Model/Tools/Gatk/IndelRealigner.pm
+++ b/lib/perl/Genome/Model/Tools/Gatk/IndelRealigner.pm
@@ -55,6 +55,11 @@ class Genome::Model::Tools::Gatk::IndelRealigner {
             gatk_param_name => '--targetIntervalsAreNotSorted',
         },
     ],
+    has_param => [
+        lsf_queue => {
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
+    ],
 };
 
 sub help_brief {

--- a/lib/perl/Genome/Model/Tools/Validation/LongIndelsParseRemapped.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/LongIndelsParseRemapped.pm
@@ -36,6 +36,11 @@ class Genome::Model::Tools::Validation::LongIndelsParseRemapped {
             default => 0,
         },
     ],
+    has_param => [
+        lsf_queue => {
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
+    ],
 };
 
 sub execute {

--- a/lib/perl/Genome/Model/Tools/Varscan/ProcessValidationIndels.pm
+++ b/lib/perl/Genome/Model/Tools/Varscan/ProcessValidationIndels.pm
@@ -48,6 +48,11 @@ class Genome::Model::Tools::Varscan::ProcessValidationIndels {
             is_optional => 0,
         },
     ],
+    has_param => [
+        lsf_queue => {
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
+    ],
 };
 
 sub sub_command_sort_position { 12 }

--- a/lib/perl/Genome/Model/Tools/Varscan/PullOneTwoBpIndels.pm
+++ b/lib/perl/Genome/Model/Tools/Varscan/PullOneTwoBpIndels.pm
@@ -105,6 +105,11 @@ class Genome::Model::Tools::Varscan::PullOneTwoBpIndels {
             is_output => 1,
         },
     ],
+    has_param => [
+        lsf_queue => {
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
+    ],
 };
 
 sub help_synopsis {

--- a/lib/perl/Genome/Model/Tools/Varscan/Validation.pm
+++ b/lib/perl/Genome/Model/Tools/Varscan/Validation.pm
@@ -84,6 +84,9 @@ class Genome::Model::Tools::Varscan::Validation {
         lsf_resource => {
             default_value => 'select[tmp>1000] rusage[mem=4000,tmp=1000]'
         },
+        lsf_queue => {
+            default_value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
     ],
 };
 


### PR DESCRIPTION
I am surprised so many SomaticValidation build steps didn't already have a queue set; I'd thought this was required awhile ago.  At any rate, now `WorkflowBuilder` will specify a queue for any steps that don't have one set.