### PR TITLE
AlignmentResult: Check the reference and annotation builds when seeking our Merged result(s)

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -1965,6 +1965,11 @@ sub filter_non_matching_results {
         my $name = $param->property_name;
         $params{$name} = $self->$name;
     }
+
+    for my $input (qw(reference_build_id annotation_build_id)) {
+        $params{$input} = $self->$input;
+    }
+
     my $bx = Genome::InstrumentData::AlignmentResult::Merged->define_boolexpr(%params);
 
     my @matching_results;


### PR DESCRIPTION
This reduces the number of false-positives when the same data has been aligned to many references, saving us from collecting all their individual alignments when we know they won't match.

(This is a bit of a selfish improvement, since the most drastic impact will be on test data that gets aligned to many, many references 😄 )