### PR TITLE
If we don't get a username back from `getpwuid`, try again!

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1379,6 +1379,9 @@ sub username {
         my $username = getpwuid($user_id);
         return $username if $username;
 
+        #This is a hack!
+        #Sometimes our machines fail to get a result from getpwuid() on the first try.
+        #If we wait a second, it tends to work on subsequent attempts!
         $class->warning_message('Failed attempt %s to resolve username for user ID %s', $try, $user_id);
         sleep 1;
     }

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1372,9 +1372,11 @@ sub user_id {
 sub username {
     my $class = shift;
 
+    return $ENV{'REMOTE_USER'} if $ENV{'REMOTE_USER'};
+
     my $user_id = $class->user_id;
     for my $try (1..5) {
-        my $username = $ENV{'REMOTE_USER'} || getpwuid($user_id);
+        my $username = getpwuid($user_id);
         return $username if $username;
 
         $class->warning_message('Failed attempt %s to resolve username for user ID %s', $try, $user_id);

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1371,8 +1371,18 @@ sub user_id {
 
 sub username {
     my $class = shift;
-    my $username = $ENV{'REMOTE_USER'} || getpwuid($class->user_id);
-    return $username;
+
+    my $user_id = $class->user_id;
+    for my $try (1..5) {
+        my $username = $ENV{'REMOTE_USER'} || getpwuid($user_id);
+        return $username if $username;
+
+        $class->warning_message('Failed attempt %s to resolve username for user ID %s', $try, $user_id);
+        sleep 1;
+    }
+
+    $class->warning_message('Giving up and returning user_id instead of name for %s' , $user_id);
+    return $user_id;
 }
 
 my $sudo_username = undef;

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1381,8 +1381,7 @@ sub username {
         sleep 1;
     }
 
-    $class->warning_message('Giving up and returning user_id instead of name for %s' , $user_id);
-    return $user_id;
+    $class->fatal_message('Could not determine name for user ID %s' , $user_id);
 }
 
 my $sudo_username = undef;


### PR DESCRIPTION
It seems our systems are sometimes unreliable at returning a value here, causing some build failures.  In my testing, it will fail to return a value on the first attempt, but the second attempt will succeed.  Trying this five times is thus probably overkill(!), but hopefully is sufficient to make `Genome::Sys->username` reliable.

~~If things really go poorly, the user_id is often "good enough" as a unique per-user value... just one less friendly to the viewer.  However, it's insufficient to locate a `Genome::Sys::User` object, so anything depending on real user objects would still fail.~~