### PR TITLE
Specify a default LSF queue in CopyNumber PlotSegments

### DIFF
--- a/lib/perl/Genome/Model/Tools/CopyNumber/PlotSegments.pm
+++ b/lib/perl/Genome/Model/Tools/CopyNumber/PlotSegments.pm
@@ -275,7 +275,13 @@ class Genome::Model::Tools::CopyNumber::PlotSegments {
 	},
        
 	
-    ]
+    ],
+    has_param => [
+        lsf_queue => {
+            is => 'Text',
+            value => Genome::Config::get('lsf_queue_build_worker_alt'),
+        },
+    ],
 };
 
 sub help_brief {


### PR DESCRIPTION
This was caught by the "long" model tests.