### PR TITLE
Use Config to Select a Default LSF Queue if None Specified

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Bam.downsample.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Bam.downsample.t
@@ -30,6 +30,10 @@ ok($wf, 'build_workflow');
 my $expected_xml_file = __FILE__;
 $expected_xml_file =~ s/t$/xml/;
 my $expected_xml = Genome::Sys->read_file($expected_xml_file);
-is($wf->get_xml, $expected_xml, 'xml matches');
+
+my $actual_xml = $wf->get_xml;
+$actual_xml =~ s/lsfQueue="[^"]+"\s+//g;
+
+is($actual_xml, $expected_xml, 'xml matches');
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Bam.downsample.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Bam.downsample.t
@@ -30,6 +30,6 @@ ok($wf, 'build_workflow');
 my $expected_xml_file = __FILE__;
 $expected_xml_file =~ s/t$/xml/;
 my $expected_xml = Genome::Sys->read_file($expected_xml_file);
-is($wf->get_xml, $expected_xml, 'xml mathes');
+is($wf->get_xml, $expected_xml, 'xml matches');
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Bam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Bam.t
@@ -25,6 +25,10 @@ ok($wf, 'build_workflow');
 my $expected_xml_file = __FILE__;
 $expected_xml_file =~ s/t$/xml/;
 my $expected_xml = Genome::Sys->read_file($expected_xml_file);
-is($wf->get_xml, $expected_xml, 'xml matches');
+
+my $actual_xml = $wf->get_xml;
+$actual_xml =~ s/lsfQueue="[^"]+"\s+//g;
+
+is($actual_xml, $expected_xml, 'xml matches');
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Bam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Bam.t
@@ -25,6 +25,6 @@ ok($wf, 'build_workflow');
 my $expected_xml_file = __FILE__;
 $expected_xml_file =~ s/t$/xml/;
 my $expected_xml = Genome::Sys->read_file($expected_xml_file);
-is($wf->get_xml, $expected_xml, 'xml mathes');
+is($wf->get_xml, $expected_xml, 'xml matches');
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Fastq.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Fastq.t
@@ -25,6 +25,10 @@ ok($wf, 'build_workflow');
 my $expected_xml_file = __FILE__;
 $expected_xml_file =~ s/t$/xml/;
 my $expected_xml = Genome::Sys->read_file($expected_xml_file);
-is($wf->get_xml, $expected_xml, 'xml matches');
+
+my $actual_xml = $wf->get_xml;
+$actual_xml =~ s/lsfQueue="[^"]+"\s+//g;
+
+is($actual_xml, $expected_xml, 'xml matches');
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Fastq.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Fastq.t
@@ -25,6 +25,6 @@ ok($wf, 'build_workflow');
 my $expected_xml_file = __FILE__;
 $expected_xml_file =~ s/t$/xml/;
 my $expected_xml = Genome::Sys->read_file($expected_xml_file);
-is($wf->get_xml, $expected_xml, 'xml mathes');
+is($wf->get_xml, $expected_xml, 'xml matches');
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Sra.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Sra.t
@@ -25,6 +25,10 @@ ok($wf, 'build_workflow');
 my $expected_xml_file = __FILE__;
 $expected_xml_file =~ s/t$/xml/;
 my $expected_xml = Genome::Sys->read_file($expected_xml_file);
-is($wf->get_xml, $expected_xml, 'xml matches');
+
+my $actual_xml = $wf->get_xml;
+$actual_xml =~ s/lsfQueue="[^"]+"\s+//g;
+
+is($actual_xml, $expected_xml, 'xml matches');
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Sra.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/Builder/Sra.t
@@ -25,6 +25,6 @@ ok($wf, 'build_workflow');
 my $expected_xml_file = __FILE__;
 $expected_xml_file =~ s/t$/xml/;
 my $expected_xml = Genome::Sys->read_file($expected_xml_file);
-is($wf->get_xml, $expected_xml, 'xml mathes');
+is($wf->get_xml, $expected_xml, 'xml matches');
 
 done_testing();

--- a/lib/perl/Genome/Ptero/ToJSON.t
+++ b/lib/perl/Genome/Ptero/ToJSON.t
@@ -15,6 +15,11 @@ use File::Basename qw(dirname basename);
 use File::Spec qw();
 use File::Copy qw(copy);
 
+use Sub::Override;
+use Genome::ConfigValidator::LSFQueue;
+
+#since we kill the environment in this test, the LSFQueue check cannot pass
+my $override = Sub::Override->new('Genome::ConfigValidator::LSFQueue::check', sub { 1 });
 
 for my $test_directory (glob test_data_directory('*')) {
     my $test_name = basename($test_directory);
@@ -47,6 +52,7 @@ for my $test_directory (glob test_data_directory('*')) {
             qr/^.*"outFile" :.*$/,
             qr/^.*"errFile" :.*$/,
             qr/^.*"jobGroup" :.*$/,
+            qr/^.*"queue" :.*$/,
         ],
     );
 }

--- a/lib/perl/Genome/Ptero/ToJSONForProcess.t
+++ b/lib/perl/Genome/Ptero/ToJSONForProcess.t
@@ -15,6 +15,13 @@ use File::Basename qw(dirname basename);
 use File::Spec qw();
 use File::Copy qw(copy);
 
+use Sub::Override;
+use Genome::ConfigValidator::LSFQueue;
+
+#since we kill the environment in this test, the LSFQueue check cannot pass
+my $override = Sub::Override->new('Genome::ConfigValidator::LSFQueue::check', sub { 1 });
+
+
 {
     package TestProcess;
 
@@ -62,6 +69,7 @@ for my $test_directory (glob test_data_directory('*')) {
             qr/^.*"outFile" :.*$/,
             qr/^.*"errFile" :.*$/,
             qr/^.*"jobGroup" :.*$/,
+            qr/^.*"queue" :.*$/,
         ],
     );
 }

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow.json
@@ -85,6 +85,7 @@
                      "outFile" : "/tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.err --stdout /tmp/ptero-lsf-logfile-4a3e43b5-7779-4d40-be86-dad0181826f1.out",
                      "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                     "queue" : "long",
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
                   "pollingInterval" : 300,
@@ -203,6 +204,7 @@
                                                    "outFile" : "/tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.err --stdout /tmp/ptero-lsf-logfile-ddfbc917-694a-480c-a077-33781b39e38f.out",
                                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "queue" : "long",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/jagged-parallel-models/ptero_workflow_for_process.json
@@ -129,6 +129,7 @@
                                     "outFile" : "/tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.err --stdout /tmp/ptero-lsf-logfile-28740132-2b5a-4893-a364-e628bb931cd3.out",
                                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "queue" : "long",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,
@@ -249,6 +250,7 @@
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.err --stdout /tmp/ptero-lsf-logfile-3d67cf8b-f715-4578-9845-67a5912ad0c2.out",
                                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                                  "queue" : "long",
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
                                                                "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow.json
@@ -116,6 +116,7 @@
                                                    "outFile" : "/tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.err --stdout /tmp/ptero-lsf-logfile-1bc57aae-446f-45bb-b986-5992084488d9.out",
                                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "queue" : "long",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/nested-parallel-models/ptero_workflow_for_process.json
@@ -157,6 +157,7 @@
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.err --stdout /tmp/ptero-lsf-logfile-4a4c7f53-c98e-4a64-ac81-d314447a2215.out",
                                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                                  "queue" : "long",
                                                                   "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                                },
                                                                "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow.json
@@ -114,7 +114,8 @@
                                                    "jobGroup" : "/genome/dmorton",
                                                    "outFile" : "/tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.err --stdout /tmp/ptero-lsf-logfile-0327f318-8b34-4e00-a478-ee04d0018517.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"
+                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "queue" : "long"
                                                 },
                                                 "pollingInterval" : 300,
                                                 "rLimits" : {},

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties-unspecified/ptero_workflow_for_process.json
@@ -155,7 +155,8 @@
                                                                   "jobGroup" : "/genome/dmorton",
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.err --stdout /tmp/ptero-lsf-logfile-b9704d30-f4ca-48f8-bc8c-a8f9af610a73.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                                  "queue" : "long"
                                                                },
                                                                "pollingInterval" : 300,
                                                                "rLimits" : {},

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow.json
@@ -114,7 +114,8 @@
                                                    "jobGroup" : "/genome/dmorton",
                                                    "outFile" : "/tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.err --stdout /tmp/ptero-lsf-logfile-8d75ad24-52a8-4d54-b010-11a71f481937.out",
-                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"
+                                                   "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "queue" : "long"
                                                 },
                                                 "pollingInterval" : 300,
                                                 "rLimits" : {},

--- a/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/optional-input-properties/ptero_workflow_for_process.json
@@ -155,7 +155,8 @@
                                                                   "jobGroup" : "/genome/dmorton",
                                                                   "outFile" : "/tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
                                                                   "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.err --stdout /tmp/ptero-lsf-logfile-2ead1cfb-ee32-4f9c-8d0d-d031a14625c3.out",
-                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;"
+                                                                  "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                                  "queue" : "long"
                                                                },
                                                                "pollingInterval" : 300,
                                                                "rLimits" : {},

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow.json
@@ -70,6 +70,7 @@
                      "outFile" : "/tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
                      "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.err --stdout /tmp/ptero-lsf-logfile-f4d7d9d9-cc1d-498d-9b06-23376a788db8.out",
                      "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                     "queue" : "long",
                      "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                   },
                   "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-cmd/ptero_workflow_for_process.json
@@ -111,6 +111,7 @@
                                     "outFile" : "/tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.err --stdout /tmp/ptero-lsf-logfile-aa257d34-2f57-45f5-900f-57bb3aa8e4b9.out",
                                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "queue" : "long",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow.json
@@ -93,6 +93,7 @@
                                     "outFile" : "/tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
                                     "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.err --stdout /tmp/ptero-lsf-logfile-87718807-3060-4c53-a0a8-f0ec12ea39c8.out",
                                     "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                    "queue" : "long",
                                     "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                  },
                                  "pollingInterval" : 300,

--- a/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
+++ b/lib/perl/Genome/Ptero/workflow_tests/parallel-model/ptero_workflow_for_process.json
@@ -134,6 +134,7 @@
                                                    "outFile" : "/tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
                                                    "postExecCmd" : "ptero-lsf-post-exec --stderr /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.err --stdout /tmp/ptero-lsf-logfile-36eb3984-6a0a-4fd1-bc73-bf44742636ad.out",
                                                    "preExecCmd" : "ptero-lsf-pre-exec; exit 0;",
+                                                   "queue" : "long",
                                                    "resReq" : "select[gtmp>1 && mem>3000] span[hosts=1] rusage[gtmp=1 && mem=3000]"
                                                 },
                                                 "pollingInterval" : 300,

--- a/lib/perl/Genome/VariantReporting/Framework/TestHelpers.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/TestHelpers.pm
@@ -183,7 +183,14 @@ sub test_xml {
     if ($ENV{GENERATE_TEST_DATA}) {
         File::Copy::copy($xml_path, $expected_xml_path);
     }
-    compare_ok($expected_xml_path, $xml_path, "Xml looks as expected");
+    compare_ok(
+        $expected_xml_path, $xml_path,
+        name => "Xml looks as expected",
+        replace => [
+            [qr(lsfQueue="[^"]+"\s+), q()],
+            [qr(lsfResource="[^"]+"\s+), q()],
+        ],
+    );
     return;
 }
 

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -247,6 +247,11 @@ sub operation_type_attributes {
             $attributes{$expected_attributes{$name}} = $value;
         }
     }
+
+    unless (defined $attributes{'lsfQueue'}) {
+        $attributes{'lsfQueue'} = Genome::Config::get('lsf_queue_build_worker');
+    }
+
     return %attributes;
 }
 


### PR DESCRIPTION
This was split off from #1487 after it led to a large number of test failures.  This version includes updates to applicable tests to ignore whatever queue might be specified.  (Since it's decided by config, we shouldn't rely on it having any particular value!)