### PR TITLE
Use lower queue for BamQc "server" process.

### DIFF
--- a/lib/perl/Genome/Model/ReferenceAlignment/Command/BamQc.pm
+++ b/lib/perl/Genome/Model/ReferenceAlignment/Command/BamQc.pm
@@ -15,7 +15,7 @@ class Genome::Model::ReferenceAlignment::Command::BamQc {
     ],
     has_param => [
         lsf_queue => {
-            default => Genome::Config::get('lsf_queue_build_worker_alt'),
+            default => Genome::Config::get('lsf_queue_build_worker'),
         },
     ],
 };


### PR DESCRIPTION
This shouldn't use the same queue as its workers, lest they potentially deadlock.