### PR TITLE
Use config to decide the LSF queue (Ptero NullCommand)

### DIFF
--- a/lib/perl/Genome/Ptero/TestCommand/NullCommand.pm
+++ b/lib/perl/Genome/Ptero/TestCommand/NullCommand.pm
@@ -35,7 +35,10 @@ class Genome::Ptero::TestCommand::NullCommand {
     ],
     has => [
         lsf_resource => {
-            default_value => "-M 200000 -n 4 -R 'rusage[mem=200:gtmp=5]' -q short",
+            default_value => "-M 200000 -n 4 -R 'rusage[mem=200:gtmp=5]'",
+        },
+        lsf_queue => {
+            default_value => Genome::Config::get('lsf_queue_short'),
         },
     ]
 };


### PR DESCRIPTION
Somehow this hardcoded queue in the Ptero tests snuck by us!