### PR TITLE
Remove references to sata132/jwalker file paths.

### DIFF
--- a/lib/perl/Genome/Model/Tools/BioSamtools/RepeatContent.pm
+++ b/lib/perl/Genome/Model/Tools/BioSamtools/RepeatContent.pm
@@ -6,7 +6,6 @@ use warnings;
 use Genome;
 use Bio::Tools::RepeatMasker;
 
-my $DEFAULT_REPEATS_FILE = '/gscmnt/sata132/techd/solexa/jwalker/RepeatReducedCapture/RepeatMasker/hg18.fa.out';
 class Genome::Model::Tools::BioSamtools::RepeatContent {
     is => ['Genome::Model::Tools::BioSamtools'],
     has_input => [
@@ -15,8 +14,7 @@ class Genome::Model::Tools::BioSamtools::RepeatContent {
         repeats_file => {
             doc => 'A RepeatMasker table of repeats for the genome.',
             is => 'Text',
-            default_value => $DEFAULT_REPEATS_FILE,
-            is_optional => 1,
+            example_value => '/gscmnt/gc13001/info/model_data/jwalker_scratch/RepeatEval/hg19.fa.out',
         }
     ],
 };

--- a/lib/perl/Genome/Model/Tools/BioSamtools/RepeatContent.pm
+++ b/lib/perl/Genome/Model/Tools/BioSamtools/RepeatContent.pm
@@ -14,7 +14,7 @@ class Genome::Model::Tools::BioSamtools::RepeatContent {
         repeats_file => {
             doc => 'A RepeatMasker table of repeats for the genome.',
             is => 'Text',
-            example_value => '/gscmnt/gc13001/info/model_data/jwalker_scratch/RepeatEval/hg19.fa.out',
+            example_values => ['/gscmnt/gc13001/info/model_data/jwalker_scratch/RepeatEval/hg19.fa.out'],
         }
     ],
 };

--- a/lib/perl/Genome/Model/Tools/Capture/EvaluateExomeBreadth.pm
+++ b/lib/perl/Genome/Model/Tools/Capture/EvaluateExomeBreadth.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 my $DEFAULT_DELIMITER = ':';
-my $DEFAULT_ANNOTATION_FILE = '/gscmnt/sata132/techd/solexa/jwalker/RNAseq/annotation/hg18/NCBI-human.combined-annotation-54_36p_v2/NCBI-human.combined-annotation_54_36p_v2.bed';
 
 class Genome::Model::Tools::Capture::EvaluateExomeBreadth {
     is => ['Command'],
@@ -24,9 +23,7 @@ class Genome::Model::Tools::Capture::EvaluateExomeBreadth {
         },
         annotation_bed_file => {
             is => 'Text',
-            is_optional => 1,
             doc => 'The annotation BED format file.  With features named like $GENE:$TRANSCRIPT:$TYPE:$ORDINAL.',
-            default_value => $DEFAULT_ANNOTATION_FILE,
         },
         coverage_of => {
             is => 'Text',


### PR DESCRIPTION
The repeat masker file was moved.  Instead of a default_value it's switched to an example_value.

For the capture tool, the default_value was simply removed.