### PR TITLE
Make trio wrapper merge work if one of input reports is empty

### DIFF
--- a/lib/perl/Genome/VariantReporting/Framework/Component/Report/MergedReport.pm
+++ b/lib/perl/Genome/VariantReporting/Framework/Component/Report/MergedReport.pm
@@ -57,6 +57,20 @@ sub _run {
         Genome::Sys->touch($self->_temp_output_file);
         return 1;
     }
+    #refer to CI-178, this will handle the case that one of base and
+    #supplemental report is empty, specifically bed merge
+    elsif (!$self->base_report->has_size or !$self->supplemental_report->has_size) {
+        my $non_zero_size_file;
+        for my $report_name ('base_report', 'supplemental_report') {
+            my $report = $self->$report_name;
+            if ($report->has_size) {
+               $non_zero_size_file = $report->report_path;
+               last;
+            }
+        }
+        Genome::Sys->copy_file($non_zero_size_file, $self->_temp_output_file);
+        return 1;
+    }
 
     $self->validate;
 

--- a/lib/perl/Genome/VariantReporting/Framework/MergeReports.t
+++ b/lib/perl/Genome/VariantReporting/Framework/MergeReports.t
@@ -183,9 +183,28 @@ subtest "Source tags must be defined" => sub {
         "Error if source tag is not defined for one report");
 };
 
-subtest "test one empty file" => sub {
+subtest "test one empty supplemental_report file" => sub {
     my $result_a = get_report_result('report_a.noheader');
     my $result_b = get_report_result('report_empty');
+    my $expected = get_data('report_a.noheader');
+
+    my $cmd = $pkg->create(
+        base_report => $result_a,
+        supplemental_report => $result_b,
+        sort_columns => ['1', '2'],
+        contains_header => 0,
+        process_id => $process->id,
+        label => 'results',
+    );
+    isa_ok($cmd, $pkg);
+
+    ok($cmd->execute, 'Executed the test command');
+    compare_ok($cmd->output_result->report_path, $expected, 'Output file looks as expected');
+};
+
+subtest "test one empty base_report file" => sub {
+    my $result_a = get_report_result('report_empty');
+    my $result_b = get_report_result('report_a.noheader');
     my $expected = get_data('report_a.noheader');
 
     my $cmd = $pkg->create(


### PR DESCRIPTION
Currently trio process will crash at merge report step if one of input bed file is empty (refer to https://jira.gsc.wustl.edu/browse/CI-167). This PR fixes this.