### PR TITLE
RefSeq Converter: Use names of references instead of object hashes in error message.

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceSequence/ConvertedBedResult.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/ConvertedBedResult.pm
@@ -49,7 +49,7 @@ sub _generate_result {
 
     unless (-s $converted_bed_file) {
         die $self->error_message("Failed to convert from bed (%s) with reference (%s) to bed (%s) with reference (%s)",
-            $self->source_bed, $self->source_reference, $converted_file_path, $self->target_reference);
+            $self->source_bed, $self->source_reference->__display_name__, $converted_file_path, $self->target_reference->__display_name__);
     }
     return 1;
 }


### PR DESCRIPTION
I recently encountered a build with this error message in it, but 
```
Failed to convert from bed (...) with reference (Genome::Model::Build::ImportedReferenceSequence=HASH(0x70802e0)) to bed (...) with reference (Genome::Model::Build::ImportedReferenceSequence=HASH(0x70260c0)
```
is not the most informative!