### PR TITLE
Stop warning about undefined environment variables.

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -171,7 +171,7 @@ sub _get_ptero_lsf_parameters {
     $lsf_params->{options}->{errFile} = $stderr;
     $lsf_params->{options}->{outFile} = $stdout;
 
-    my ($docker) = $ENV{LSB_SUB_ADDITIONAL} =~ /^docker\(([^)]+)\)$/;
+    my ($docker) = $ENV{LSB_SUB_ADDITIONAL} && $ENV{LSB_SUB_ADDITIONAL} =~ /^docker\(([^)]+)\)$/;
     my $docker_run = File::Spec->join($ENV{LSF_BINDIR}, 'docker_run.py');
 
     # Redirect stdout/err of post-exec command to file for debugging.

--- a/lib/perl/Genome/WorkflowBuilder/Detail/Operation.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Detail/Operation.pm
@@ -276,8 +276,6 @@ sub _get_sanitized_env {
     while (my($key, $value) = each %ENV) {
         if (defined($value)) {
             $env->{$key} = $value;
-        } else {
-            $self->warning_message("Found Environment variable with no value: %s", $key);
         }
     }
     return $env;


### PR DESCRIPTION
This doesn't affect the operation of the workflow, and users don't really care about the limitations of the environment compared to Perl hashes.