### PR TITLE
Defer to new Ptero feature to decide the log paths.

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -6,7 +6,6 @@ use warnings;
 use Genome;
 use Cwd qw();
 use Genome::Sys::LSF::ResourceParser qw(parse_lsf_params);
-use Data::UUID;
 use Carp qw();
 use Data::Dump qw(pp);
 use Try::Tiny;
@@ -174,7 +173,7 @@ sub _get_ptero_lsf_parameters {
     my ($docker) = $ENV{LSB_SUB_ADDITIONAL} =~ /^docker\(([^)]+)\)$/;
     my $docker_run = File::Spec->join($ENV{LSF_BINDIR}, 'docker_run.py');
 
-    my $postexec_cmd = "/usr/bin/ptero-lsf-post-exec --stderr $stderr --stdout $stdout";
+    my $postexec_cmd = "/usr/bin/ptero-lsf-post-exec";
     if ($docker) {
         $postexec_cmd = join(' ', $docker_run, $postexec_cmd);
     } else {
@@ -196,16 +195,11 @@ sub _get_ptero_lsf_parameters {
     return $lsf_params;
 }
 
-#FIXME This is not unique within parallel_by operations.
 sub _get_lsf_log_paths {
     my $self = shift;
     my $log_dir = shift;
 
-    my $ug = Data::UUID->new();
-    my $uuid = $ug->create();
-    my $uuid_str = $ug->to_string($uuid);
-
-    my $base = File::Spec->join($log_dir, sprintf("ptero-lsf-logfile-%s", $uuid_str));
+    my $base = File::Spec->join($log_dir, "ptero-lsf-logfile-%%JOB_ID%%");
     return ($base . '.err', $base . '.out');
 }
 

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -167,15 +167,13 @@ sub _get_ptero_lsf_parameters {
     );
     $set_lsf_option->('jobGroup', $default_job_group);
 
-    my ($stderr, $stdout, $postexec) = $self->_get_lsf_log_paths($log_dir);
+    my ($stderr, $stdout) = $self->_get_lsf_log_paths($log_dir);
     $lsf_params->{options}->{errFile} = $stderr;
     $lsf_params->{options}->{outFile} = $stdout;
 
     my ($docker) = $ENV{LSB_SUB_ADDITIONAL} =~ /^docker\(([^)]+)\)$/;
     my $docker_run = File::Spec->join($ENV{LSF_BINDIR}, 'docker_run.py');
 
-    # Redirect stdout/err of post-exec command to file for debugging.
-    # Clean up that file if post-exec exits normally.
     my $postexec_cmd = "/usr/bin/ptero-lsf-post-exec --stderr $stderr --stdout $stdout";
     if ($docker) {
         $postexec_cmd = join(' ', $docker_run, $postexec_cmd);
@@ -183,9 +181,7 @@ sub _get_ptero_lsf_parameters {
         $postexec_cmd = "bash -c '$postexec_cmd'";
     }
 
-    $lsf_params->{options}->{postExecCmd} = sprintf(
-        "%s > %s 2>&1 && rm -f %s", $postexec_cmd, $postexec, $postexec
-    );
+    $lsf_params->{options}->{postExecCmd} = $postexec_cmd;
 
     # Unlike post-exec, stdout/err of pre-exec command gets written to
     # errFile or outFile by lsf.  We want to exit 0 no matter what so
@@ -210,7 +206,7 @@ sub _get_lsf_log_paths {
     my $uuid_str = $ug->to_string($uuid);
 
     my $base = File::Spec->join($log_dir, sprintf("ptero-lsf-logfile-%s", $uuid_str));
-    return ($base . '.err', $base . '.out', $base . "-postexec.log");
+    return ($base . '.err', $base . '.out');
 }
 
 


### PR DESCRIPTION
This uses the new features in genome/ptero-lsf#124 and genome/ptero-perl-sdk#117 to ensure a unique filename is chosen for each job, even during a parallel-by.  As a bonus that filename's UUID will now be the Job ID making it easier to match to the job to which it belongs.

(This should not be merged until the aformentioned PRs are deployed.)