### PR TITLE
Don't die just because we can't revert the logging.

### DIFF
--- a/lib/perl/Genome/Ptero/Wrapper.pm
+++ b/lib/perl/Genome/Ptero/Wrapper.pm
@@ -72,7 +72,11 @@ sub execute {
         die $error;
     };
 
-    $self->_teardown_logging;
+    try {
+        $self->_teardown_logging
+    } catch {
+        $self->warning_message('Failed to tear down logging: %s', $_);
+    };
 
     printf SAVED_STDERR "Setting outputs: %s\n", pp(_get_command_outputs($command, $self->command_class));
     $self->execution->set_outputs(


### PR DESCRIPTION
Letting a few messages leak into the task's log files is far better than throwing out all of our work when there's an issue reopening the original log file!

(#1509 is a long-term solution to the present problem causing the errors reopening the log file, but we probably shouldn't fail in any event.)