### PR TITLE
Require a newer SSL implementation to perform the web queries.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.pm
@@ -477,7 +477,9 @@ sub _parse_tcga_response {
 sub get_sample_meta {
     my $self = shift;
 
-    if ($self->_tcga_vcf) {
+    use Net::SSLeay;
+
+    if ($self->_tcga_vcf and $Net::SSLeay::VERSION >= 1.74) {
         my @tcga_barcodes;
         my ($n_sample, $t_sample) = ($self->control_aligned_reads_sample, $self->aligned_reads_sample);
         push @tcga_barcodes, $n_sample if $n_sample and $n_sample =~ /^TCGA\-/;

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Base.t
@@ -4,7 +4,14 @@ use strict;
 use warnings;
 
 use above 'Genome';
-use Test::More tests => 2;
+
+use Net::SSLeay;
+use Test::More;
+if ($Net::SSLeay::VERSION < 1.74) {
+    plan skip_all => 'SSL is too old';
+} else {
+    plan tests => 2;
+}
 
 my $class = 'Genome::Model::Tools::Vcf::Convert::Base';
 use_ok($class);

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Snv/Strelka.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Snv/Strelka.t
@@ -48,8 +48,24 @@ $rv = $command->execute;
 ok($rv, 'Command completed successfully');
 ok(-s $output_file2, "TCGA output file created");
 
-compare_file($expected_file2, $output_file2);
+_run_if_ssl_new_enough( sub {
+    compare_file($expected_file2, $output_file2);
+} );
+
 done_testing();
+
+
+sub _run_if_ssl_new_enough {
+    my $sub = shift;
+
+    use Net::SSLeay;
+    SKIP: {
+        if ($Net::SSLeay::VERSION < 1.74) {
+            skip 'SSL is too old', 1;
+        }
+        $sub->();
+    }
+}
 
 # The files will have a timestamp that will differ. Ignore this but check the rest.
 sub compare_file {

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Snv/VarscanSomatic.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Snv/VarscanSomatic.t
@@ -62,7 +62,9 @@ $rv = $command->execute;
 ok($rv, 'Command completed successfully');
 ok(-s $output_file2, "TCGA output file created");
 
-compare_file($expected_file2, $output_file2);
+_run_if_ssl_new_enough( sub {
+    compare_file($expected_file2, $output_file2);
+} );
 
 my $expected_file3 = $expected_dir . '/TCGA_output2.vcf';
 my $output_file3 = Genome::Sys->create_temp_file_path;
@@ -76,10 +78,25 @@ ok($command, 'Command created');
 $rv = $command->execute;
 ok($rv, 'Command completed successfully');
 ok(-s $output_file3, "TCGA output file created");
-compare_file($expected_file3, $output_file3);
+
+_run_if_ssl_new_enough( sub {
+    compare_file($expected_file3, $output_file3);
+} );
 
 done_testing();
 
+
+sub _run_if_ssl_new_enough {
+    my $sub = shift;
+
+    use Net::SSLeay;
+    SKIP: {
+        if ($Net::SSLeay::VERSION < 1.74) {
+            skip 'SSL is too old', 1;
+        }
+        $sub->();
+    }
+}
 
 # The files will have a timestamp that will differ. Ignore this but check the rest.
 sub compare_file {

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Snv/VarscanSomaticValidation.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Snv/VarscanSomaticValidation.t
@@ -56,7 +56,9 @@ $rv = $command->execute;
 ok($rv, 'Command completed successfully');
 ok(-s $output_file2, "TCGA output file created");
 
-compare_file($expected_file2, $output_file2);
+_run_if_ssl_new_enough( sub {
+    compare_file($expected_file2, $output_file2);
+} );
 
 my $expected_file3 = $expected_dir . '/TCGA_output2.vcf';
 my $output_file3 = Genome::Sys->create_temp_file_path;
@@ -70,10 +72,23 @@ ok($command, 'Command created');
 $rv = $command->execute;
 ok($rv, 'Command completed successfully');
 ok(-s $output_file3, "TCGA output file created");
-compare_file($expected_file3, $output_file3);
+_run_if_ssl_new_enough( sub {
+    compare_file($expected_file3, $output_file3);
+} );
 
 done_testing();
 
+sub _run_if_ssl_new_enough {
+    my $sub = shift;
+
+    use Net::SSLeay;
+    SKIP: {
+        if ($Net::SSLeay::VERSION < 1.74) {
+            skip 'SSL is too old', 1;
+        }
+        $sub->();
+    }
+}
 
 # The files will have a timestamp that will differ. Ignore this but check the rest.
 sub compare_file {


### PR DESCRIPTION
The GDC portal now requires newer SSL to perform the handshake, so disable the TCGA support for "older" systems.  (Running with an outdated OpenSSL is scary, and one probably shouldn't do it, anyway!)