### PR TITLE
CQID: Give all the "new" things a try first.

### DIFF
--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -178,7 +178,7 @@ sub _ordered_sample_id_iterator {
     my $it = Genome::Config::AnalysisProject::InstrumentDataBridge->create_iterator(
         status => ['new', 'failed'],
         'analysis_project.status' => 'In Progress',
-        -order => ['fail_count'],
+        -order => ['-status', 'fail_count'],
         -hint => ['analysis_project', 'instrument_data', 'instrument_data.sample'],
     );
 


### PR DESCRIPTION
If someone manually resets the status to `new` (for example, via `genome analysis-project reprocess`) they probably expect us to try their instrument data at least once in short order!  This is also a good clue that they may have corrected whatever issues were causing the previous failures.

If it still fails, its `fail_count` will be incremented as usual and it'll fall back to its previous spot in line.