### PR TITLE
Use %J (LSF's standard) instead of %%JOB_ID%%.

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -199,7 +199,7 @@ sub _get_lsf_log_paths {
     my $self = shift;
     my $log_dir = shift;
 
-    my $base = File::Spec->join($log_dir, "ptero-lsf-logfile-%%JOB_ID%%");
+    my $base = File::Spec->join($log_dir, "ptero-lsf-logfile-%J");
     return ($base . '.err', $base . '.out');
 }
 


### PR DESCRIPTION
LSF will translate this for us to be the LSF Job ID.