### PR TITLE
InstData Import: allow the specification of working directory

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic.pm
@@ -26,7 +26,7 @@ class Genome::InstrumentData::Command::Import::Basic {
             doc => 'Source files to import. If importing fastqs, put the file containing the forward [read 1] reads first.',
         },
     ],
-    has_optional_input => [
+    has_optional_input => {
         description  => {
             is => 'Text',
             doc => 'Description of the data.',
@@ -36,7 +36,11 @@ class Genome::InstrumentData::Command::Import::Basic {
             is_many => 1,
             doc => 'Name and value pairs to add to the instrument data. Separate name and value with an equals (=) and name/value pairs with a comma (,).',
         },
-    ],
+        base_working_directory => {
+            is => 'Text',
+            doc => 'Base working directory to use when running the import. A temporary directory will be made inside this directory, and removed when the import fails or completes.',
+        },
+    },
     has_optional_transient => [
         _new_instrument_data => {},
     ],
@@ -91,6 +95,7 @@ sub _resolve_work_flow_inputs {
         analysis_project => $self->analysis_project,
     );
     return $factory->from_params({
+            base_working_directory => $self->base_working_directory,
             entity_params => {
                 library => { id => $self->library->id, },
                 instdata => $self->_resolve_instrument_data_properties,

--- a/lib/perl/Genome/InstrumentData/Command/Import/Inputs.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Inputs.pm
@@ -24,6 +24,7 @@ class Genome::InstrumentData::Command::Import::Inputs {
     },
     has_optional => {
         analysis_project_id => { is => 'Text', },
+        base_working_directory => { is => 'Text' },
     },
     has_transient => {
         format => { via => 'source_files', to => 'format', },

--- a/lib/perl/Genome/InstrumentData/Command/Import/Inputs/Factory.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Inputs/Factory.pm
@@ -197,6 +197,10 @@ sub from_params {
         $params->{line_number} = $line_number++;
     }
     
+    if ( $params->{base_working_directory} ) {
+        Genome::Sys->validate_directory_for_write_access( $params->{base_working_directory} );
+    }
+
     # Check cache - get directly with UR::Object
     my $inputs = UR::Object::get(
         'Genome::InstrumentData::Command::Import::Inputs', 

--- a/lib/perl/Genome/InstrumentData/Command/Import/Inputs/Factory.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Inputs/Factory.t
@@ -70,7 +70,7 @@ subtest 'from_line' => sub{
 };
 
 subtest 'from_params' => sub{
-    plan tests => 10;
+    plan tests => 11;
 
     my $sample_name = 'TEST-01-001';
     my $library = Genome::Library->__define__(name => $sample_name.'-libs', sample => Genome::Sample->__define__(name => $sample_name));
@@ -85,6 +85,7 @@ subtest 'from_params' => sub{
     };
 
     my $inputs = $factory->from_params({
+            base_working_directory => '/tmp',
             source_paths => \@source_files,
             entity_params => {
                 individual => { name => 'TEST-01', nomenclature => 'TEST', upn => '01', },
@@ -96,6 +97,7 @@ subtest 'from_params' => sub{
     ok($inputs, 'create inputs');
     is($inputs->format, 'fastq', 'source files format is fastq');
     is($inputs->library, $library, 'library');
+    is($inputs->base_working_directory, '/tmp', 'base_working_directory');
 
     # instrument data
     ok(!$inputs->instrument_data_for_original_data_path, 'no instrument_data_for_original_data_path ... yet');
@@ -144,7 +146,7 @@ subtest 'from_inputs_id' => sub {
 };
 
 subtest 'fails' => sub{
-    plan tests => 8;
+    plan tests => 9;
 
     throws_ok(
         sub{ $class->create(process => $process, file => File::Spec->join($data_dir, 'samples.blah')); },
@@ -194,6 +196,13 @@ subtest 'fails' => sub{
         qr/Invalid individual name: TGI-AAAA\. It must include the first part of the sample name: TGI-AA12345-Z98765\./,
         'failed when sample name does not include individual name',
     );
+
+    throws_ok(
+        sub{ $class->create->from_params({ base_working_directory => '/dev/null', entity_params => {},}); },
+        qr/Can't validate/,
+        'failed when given non writable base_working_directory',
+    );
+
 };
 
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/ImportInstData.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/ImportInstData.pm
@@ -64,7 +64,11 @@ sub execute {
 sub _resolve_working_directory {
     my $self = shift;
 
-    my $tmp_dir = File::Temp::tempdir(CLEANUP => 1);
+    my %temp_dir_params = (CLEANUP => 1);
+    if ( $self->work_flow_inputs->base_working_directory ) {
+        $temp_dir_params{DIR} = $self->work_flow_inputs->base_working_directory;
+    }
+    my $tmp_dir = File::Temp::tempdir(%temp_dir_params);
     if ( not $tmp_dir ) {
         $self->error_message('Failed to create tmp dir!');
         return;


### PR DESCRIPTION
This will overcome the problem of not having enough local (tmp) disk space to process files for import.