### PR TITLE
Allow Running Builds with Missing Instrument Data BAMs

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwa.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwa.pm
@@ -92,7 +92,8 @@ sub tmp_megabytes_estimated {
 
         my $bam_bytes = -s $bam_path;
         unless ($bam_bytes) {
-            die $class->error_message("Instrument Data " . $instrument_data->id  . " has BAM ($bam_path) but has no size!");
+            $class->warning_message("Instrument Data " . $instrument_data->id  . " has BAM ($bam_path) but has no size!");
+            $bam_bytes = 1; #This will eventually fail since we can't find the BAM, so a very small size is sufficient.
         }
 
         if ($instrument_data->can('get_segments')) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.pm
@@ -87,7 +87,8 @@ sub tmp_megabytes_estimated {
 
         my $bam_bytes = -s $bam_path;
         unless ($bam_bytes) {
-            die $class->error_message("Instrument Data " . $instrument_data->id  . " has BAM ($bam_path) but has no size!");
+            $class->warning_message("Instrument Data " . $instrument_data->id  . " has BAM ($bam_path) but has no size!");
+            $bam_bytes = 1; #This will eventually fail since we can't find the BAM, so a very small size is sufficient.
         }
 
         if ($instrument_data->can('get_segments')) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/BwamemStream.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/BwamemStream.pm
@@ -84,7 +84,8 @@ sub tmp_megabytes_estimated {
 
         my $bam_bytes = -s $bam_path;
         unless ($bam_bytes) {
-            die $class->error_message("Instrument Data " . $instrument_data->id  . " has BAM ($bam_path) but has no size!");
+            $class->warning_message("Instrument Data " . $instrument_data->id  . " has BAM ($bam_path) but has no size!");
+            $bam_bytes = 1; #This will eventually fail since we can't find the BAM, so a very small size is sufficient.
         }
 
         if ($instrument_data->can('get_segments')) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwasw.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwasw.pm
@@ -84,7 +84,8 @@ sub tmp_megabytes_estimated {
 
         my $bam_bytes = -s $bam_path;
         unless ($bam_bytes) {
-            die $class->error_message("Instrument Data " . $instrument_data->id  . " has BAM ($bam_path) but has no size!");
+            $class->warning_message("Instrument Data " . $instrument_data->id  . " has BAM ($bam_path) but has no size!");
+            $bam_bytes = 1; #This will eventually fail since we can't find the BAM, so a very small size is sufficient.
         }
 
         if ($instrument_data->can('get_segments')) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
@@ -126,7 +126,8 @@ sub estimated_gtmp_for_instrument_data {
 
     my $st = stat($bam_path);
     unless ($st) {
-        die $class->error_message('Unable to find bam file at %s', $bam_path);
+        $class->warning_message('Unable to find bam file at %s', $bam_path);
+        return 1; #This job will fail when scheduled if the BAM is missing, so won't need much gtmp!
     }
 
     return 3 * $st->size();

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1158,18 +1158,7 @@ sub validate_instrument_data{
         }
         if (my $bam_path = $instrument_data->bam_path) {
             if (! -f $bam_path) {
-                push @tags, UR::Object::Tag->create(
-                    type => 'error',
-                    properties => ['instrument_data'],
-                    desc => 'instrument data (' . $instrument_data->id . ') has bam_path but the file does not exist',
-                );
-
-            } elsif (! -s $bam_path) {
-                push @tags, UR::Object::Tag->create(
-                    type => 'error',
-                    properties => ['instrument_data'],
-                    desc => 'instrument data (' . $instrument_data->id . ') has bam_path but no size',
-                );
+                $self->warning_message('instrument data (%s) has bam_path but the file could not be found', $instrument_data->id);
             }
         }
     }


### PR DESCRIPTION
Since they're being very aggressively archived, we're frequently running into the situation where we want to run builds for instrument data that has already vanished.  This allows us to potentially re-use the existing alignments (if they're available) to avoid referring back to the original instrument data.

It may lead to some more inscrutable errors from tools if in fact we do need the instrument data BAMs, but hopefully a real tiered disk architecture will soon end the need for our concern about explicit archiving!

Closes #1521.