### PR TITLE
InstDAta Import: Fix RevComp Bug

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
@@ -27,7 +27,7 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v01');
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v02');
 my $source_bam = $test_dir.'/input.bam';
 ok(-s $source_bam, 'source bam exists') or die;
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_downsample.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_downsample.t
@@ -27,7 +27,7 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v01');
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v02');
 my $source_bam = $test_dir.'/input.bam';
 ok(-s $source_bam, 'source bam exists') or die;
 

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_multi_groups.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_multi_groups.t
@@ -26,7 +26,7 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
-my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v01');
+my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v02');
 my $source_bam = $test_dir.'/input.multi-rg.bam';
 ok(-s $source_bam, 'source bam exists') or die;
 
@@ -82,7 +82,6 @@ for my $rg_id ( sort keys %expected_read_groups ) {
     is($bam_path, $instrument_data->data_directory.'/all_sequences.bam', 'bam path correctly named');
     is(eval{$instrument_data->attributes(attribute_label => 'bam_path')->attribute_value}, $bam_path, 'set attributes bam path');
     my $bam_basename = join('.', 'basic-bam-multi-rg', $rg_id, $type, 'bam');
-    print join("\n", $bam_path, $test_dir.'/'.$bam_basename, '');
     is(File::Compare::compare($bam_path, $test_dir.'/'.$bam_basename), 0, 'bam matches');
     is(File::Compare::compare($bam_path.'.flagstat', $test_dir.'/'.$bam_basename.'.flagstat'), 0, 'flagstat matches');
 
@@ -92,5 +91,4 @@ for my $rg_id ( sort keys %expected_read_groups ) {
 
 }
 
-#diag(join("\n", map { $_->bam_path } values %instrument_data)); <STDIN>;
 done_testing();

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.pm
@@ -159,10 +159,10 @@ sub _write_reads {
     my $rg_id = _read_group_id_for_reads($separated_reads);
     my $type = _sanitize_reads($separated_reads);
     my $fh = $self->_get_fh_for_read_group_and_type($rg_id, $type);
-    for my $read_tokens ( @$separated_reads ) {
-        # Add RG tag
-        push @$read_tokens, 'RG:Z:'.$self->old_and_new_read_group_ids->{$rg_id}->{$type};
-        $fh->print( join( "\t", @$read_tokens)."\n");
+    my $new_rg_id = $self->old_and_new_read_group_ids->{$rg_id}->{$type};
+    for ( @$separated_reads ) {
+        push @{$_}, 'RG:Z:'.$new_rg_id; # add new RG tag
+        $fh->print( join( "\t", @{$_})."\n");
     }
 
     return scalar @$separated_reads;

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.pm
@@ -156,12 +156,10 @@ sub _write_reads {
     my $separated_reads =_separate_reads(@_);
     return 0 if not @$separated_reads;
 
-    my $type = _determine_type_and_set_flags($separated_reads);
     my $rg_id = _read_group_id_for_reads($separated_reads);
+    my $type = _sanitize_reads($separated_reads);
     my $fh = $self->_get_fh_for_read_group_and_type($rg_id, $type);
     for my $read_tokens ( @$separated_reads ) {
-        # Sanitize!
-        _sanitize_read($read_tokens);
         # Add RG tag
         push @$read_tokens, 'RG:Z:'.$self->old_and_new_read_group_ids->{$rg_id}->{$type};
         $fh->print( join( "\t", @$read_tokens)."\n");
@@ -200,9 +198,11 @@ sub _separate_reads {
     return [ grep { defined } $read1s[0], $read2s[0] ];
 }
 
-sub _determine_type_and_set_flags {
+sub _sanitize_reads {
     # Gotta send in reads!
-    die 'No reads given to _determine_type_and_set_flags!' if not @{$_[0]};
+    die 'No reads given to _sanitize_reads!' if not @{$_[0]};
+    # Sanitize...
+    for ( @{$_[0]} ) { _sanitize_read($_); }
     # Determine the type paired/singleton and set the flags accordingly
     my $type;
     # paired will get:

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.t
@@ -117,7 +117,7 @@ subtest '_read_group_id_for_reads' => sub{
 subtest 'execute' => sub{
     plan tests => 18;
 
-    my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v4') or die;
+    my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Command::Import', 'v02') or die;
     Genome::InstrumentData::Command::Import::WorkFlow::Helpers->overload_uuid_generator_for_class($class);
     my $library = Genome::Library->__define__(
         name => 'TEST-SAMPLE-extlibs',
@@ -144,7 +144,7 @@ subtest 'execute' => sub{
         my $output_bam_path = File::Spec::->join($tmp_dir, 'input.rg-multi.'.$basename.'.bam');
         ok((List::MoreUtils::any { $_ eq $output_bam_path } @output_bam_paths), 'expected bam in output bams');
         ok(-s $output_bam_path, 'expected bam path exists');
-        my $expected_bam_path = File::Spec->join($test_dir, 'split-by-rg.'.$basename.'.bam');
+        my $expected_bam_path = File::Spec->join($test_dir, 'sanitize-and-split.'.$basename.'.bam');
         is(File::Compare::compare($output_bam_path, $expected_bam_path), 0, "expected $basename bam path matches");
     }
     ok(!glob($multi_rg_bam_path.'*'), 'removed bam path and auxiliary files after spliting');

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.t
@@ -16,7 +16,7 @@ require File::Spec;
 require File::Temp;
 require List::MoreUtils;
 use Test::Exception;
-use Test::More tests => 5;
+use Test::More tests => 6;
 
 my $class = 'Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam';
 use_ok($class) or die;
@@ -73,6 +73,20 @@ subtest "_determine_type_and_set_flags" => sub{
         sub{ Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags([]); },
         qr/No reads given to _determine_type_and_set_flags\!/,
         'determine reads fails w/o reads',
+    );
+
+};
+
+subtest '_read_group_id_for_reads' => sub{
+    plan tests => 2;
+
+    is(Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_read_group_id_for_reads([[]]), 'unknown', 'read groupd id is unknown for no read groups');
+    is(
+        Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_read_group_id_for_reads(
+            [ ['RG:Z:ONE'], ['RG:Z:TWO'], ['RG:Z:ONE'] ],
+        ),
+        'ONE',
+        'read group id is ONE when multiple are found',
     );
 
 };

--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/SanitizeAndSplitBam.t
@@ -30,26 +30,26 @@ subtest 'separate reads' => sub{
     my $read2 = ['read2', 128 ];
     my $supplementary = ['supplementary', 2048 ];
 
-    my @r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($read);
-    is_deeply(\@r, [$read, undef], 'separate single read w/o flag info');
+    my $r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($read);
+    is_deeply($r, [$read], 'separate single read w/o flag info');
 
-    @r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($read1, $read1);
-    is_deeply(\@r, [$read1, undef], 'separate reads when given 2 read1s');
+    $r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($read1, $read1);
+    is_deeply($r, [$read1], 'separate reads when given 2 read1s');
 
-    @r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($read1, $secondary);
-    is_deeply(\@r, [$read1, undef], 'separate reads when given read1 and secondary');
+    $r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($read1, $secondary);
+    is_deeply($r, [$read1], 'separate reads when given read1 and secondary');
 
-    @r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($secondary);
-    is_deeply(\@r, [$secondary, undef], 'separate secondary read');
+    $r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($secondary);
+    is_deeply($r, [$secondary], 'separate secondary read');
 
-    @r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($supplementary);
-    is_deeply(\@r, [undef, undef], 'separate supplementary read');
+    $r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($supplementary);
+    is_deeply($r, [], 'separate supplementary read');
 
-    @r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($secondary, $supplementary, $read1, $read2);
-    is_deeply(\@r, [$secondary, $read2], 'separate secondary, supplementary, read1, and read2');
+    $r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($secondary, $supplementary, $read1, $read2);
+    is_deeply($r, [$secondary, $read2], 'separate secondary, supplementary, read1, and read2');
 
-    @r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($read2);
-    is_deeply(\@r, [undef, $read2], 'separate read2');
+    $r = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_separate_reads($read2);
+    is_deeply($r, [$read2], 'separate read2');
 
 };
 
@@ -57,20 +57,20 @@ subtest "_determine_type_and_set_flags" => sub{
     plan tests => 7;
 
     my ($read1, $read2) = ( [], [] );
-    my $type = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags($read1, $read2);
+    my $type = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags([$read1, $read2]);
     is($type, 'paired', 'type is paired for 2 reads');
     is_deeply([$read1, $read2], [[undef, 77], [undef, 141]], 'correct flags for 2 reads');
 
-    $type = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags($read1, undef);
+    $type = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags([$read1]);
     is($type, 'singleton', 'given read1, type is singleton');
     is_deeply($read1, [undef, 68], 'correct flags for just read1');
 
-    $type = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags(undef, $read2);
+    $type = Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags([$read2]);
     is($type, 'singleton', 'given read2, type is singleton');
     is_deeply($read2, [undef, 68], 'correct flags for just read2');
 
     throws_ok(
-        sub{ Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags(undef, undef); },
+        sub{ Genome::InstrumentData::Command::Import::WorkFlow::SanitizeAndSplitBam::_determine_type_and_set_flags([]); },
         qr/No reads given to _determine_type_and_set_flags\!/,
         'determine reads fails w/o reads',
     );


### PR DESCRIPTION
The importer was attempting to revcomp sequences, but only after the bit flag had been altered. This led to sequences not being correctly written.

In response to https://rt.gsc.wustl.edu/Ticket/Display.html?id=111023