### PR TITLE
Delete the tag bridges in advance of deleting the subject mapping.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/SubjectMapping.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/SubjectMapping.pm
@@ -51,20 +51,11 @@ class Genome::Config::AnalysisProject::SubjectMapping {
 
 sub delete {
     my $self = shift;
-    eval {
-        for ($self->subject_bridges) {
-            $_->delete();
-        }
-        for ($self->inputs) {
-            $_->delete();
-        }
-        for ($self->tag_bridges) {
-            $_->delete();
-        }
-    };
-    if(my $error = $@) {
-        die($error);
+
+    for my $hangoff (qw(subject_bridges inputs tag_bridges)) {
+        $_->delete foreach $self->$hangoff;
     }
+
     return $self->SUPER::delete();
 }
 

--- a/lib/perl/Genome/Config/AnalysisProject/SubjectMapping.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/SubjectMapping.pm
@@ -58,6 +58,9 @@ sub delete {
         for ($self->inputs) {
             $_->delete();
         }
+        for ($self->tag_bridges) {
+            $_->delete();
+        }
     };
     if(my $error = $@) {
         die($error);


### PR DESCRIPTION
Otherwise the delete will fail due to the FK constraint.