### PR TITLE
CCSVCF Result: "command" property should be optional.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Vcf/CreateCrossSampleVcf/CreateCrossSampleVcfBase/Result.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/CreateCrossSampleVcf/CreateCrossSampleVcfBase/Result.pm
@@ -23,7 +23,7 @@ class Genome::Model::Tools::Vcf::CreateCrossSampleVcf::CreateCrossSampleVcfBase:
         allow_multiple_processing_profiles => { is => 'Boolean' },
         joinx_version => { is => 'Text' },
     ],
-    has_transient => [
+    has_transient_optional => [
         command => {
             is => 'Genome::Model::Tools::Vcf::CreateCrossSampleVcf::CreateCrossSampleVcfBase',
             doc => 'The command for constructing this result',


### PR DESCRIPTION
We won't have the Command around if we load this from the database, which prevents us from `commit()`ing in contexts where one of these results has been loaded.

(I ran across this while trying to archive some of these results.  They might similarly be resistant to purging presently.)