### PR TITLE
Require an Analysis Project to run Builds.

### DIFF
--- a/lib/perl/Genome/Model-build_requested.t
+++ b/lib/perl/Genome/Model-build_requested.t
@@ -17,10 +17,15 @@ use Genome::Model::TestHelpers qw(
     create_test_model
 );
 
+use Genome::Test::Factory::AnalysisProject;
+
 define_test_classes();
 my $sample = create_test_sample('test_sample');
 my $pp = create_test_pp('test_pp');
 my $model = create_test_model($sample, $pp, 'test_model');
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object;
+$anp->add_model_bridge(model_id => $model->id);
 
 my $tx = UR::Context::Transaction->begin();
 

--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -629,9 +629,14 @@ sub build_requested {
     my ($self, $value, $reason) = @_;
     # Writing the if like this allows someone to do build_requested(undef)
     if (@_ > 1) {
-        if($value and $self->status eq 'Disabled') {
-            $self->error_message('Cannot request a build for disabled model %s', $self->__display_name__);
-            return;
+        if ($value) {
+            if ($self->status eq 'Disabled') {
+                $self->error_message('Cannot request a build for disabled model %s', $self->__display_name__);
+                return;
+            } elsif (not $self->analysis_project) {
+                $self->error_message('Cannot request a build for model %s without an analysis project', $self->__display_name__);
+                return;
+            }
         }
 
         $self->_lock();

--- a/lib/perl/Genome/Model/Build-multiple-model-inputs.t
+++ b/lib/perl/Genome/Model/Build-multiple-model-inputs.t
@@ -11,6 +11,8 @@ use warnings;
 use above "Genome";
 use Test::More;
 
+use Genome::Test::Factory::AnalysisProject;
+
 Genome::Report::Email->silent();
 
 class Genome::ProcessingProfile::Test {
@@ -48,6 +50,8 @@ my $sample = Genome::Sample->create(
     name => 'test sample',
 );
 
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+
 my $model1 = Genome::Model->create(
     name => 'test model 1',
     subject_id => $sample->id,
@@ -56,6 +60,7 @@ my $model1 = Genome::Model->create(
 );
 
 ok ($model1, 'created test model 1') or die;
+$anp->add_model_bridge(model_id => $model1->id);
 
 my $model2 = Genome::Model->create(
     name => 'test model 2',
@@ -65,6 +70,7 @@ my $model2 = Genome::Model->create(
 );
 
 ok ($model2, 'created test model 2') or die;
+$anp->add_model_bridge(model_id => $model2->id);
 
 my $model3 = Genome::Model::Test->create(
     name => 'test model 3',
@@ -75,6 +81,8 @@ my $model3 = Genome::Model::Test->create(
 );
 
 ok ($model3, 'created test model 3') or die;
+$anp->add_model_bridge(model_id => $model3->id);
+
 my @models = $model3->input_models;
 is (scalar(@models),2, 'test model has 2 input models');
 

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1080,6 +1080,7 @@ sub validate_for_start_methods {
     # Each method should return tags.
     my @methods = (
         'validate_model_is_not_disabled',
+        'validate_model_has_analysis_project',
         # 'validate_inputs_have_values' should be checked first.
         'validate_inputs_have_values',
         'inputs_have_compatible_reference',
@@ -1119,6 +1120,21 @@ sub validate_model_is_not_disabled {
             desc => 'Model has been disabled.',
         );
     }
+    return @tags;
+}
+
+sub validate_model_has_analysis_project {
+    my $self = shift;
+    my @tags;
+
+    unless ($self->model->analysis_project) {
+        push @tags, UR::Object::Tag->create(
+            type => 'error',
+            properties => ['model.analysis_project'],
+            desc => 'Model has no Analysis Project set.',
+        );
+    }
+
     return @tags;
 }
 

--- a/lib/perl/Genome/Model/Build/Command/AbandonAndQueue.t
+++ b/lib/perl/Genome/Model/Build/Command/AbandonAndQueue.t
@@ -11,6 +11,8 @@ use warnings;
 use above "Genome";
 use Test::More;
 
+use Genome::Test::Factory::AnalysisProject;
+
 use_ok("Genome::Model::Build::Command::AbandonAndQueue") or die;
 
 class Genome::Model::Tester { is => 'Genome::ModelDeprecated', };
@@ -31,6 +33,9 @@ my $m = Genome::Model::Tester->create(
 );
 ok($m, "made a test model");
 ok(!$m->build_requested, 'build is not requested');
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+$anp->add_model_bridge(model_id => $m->id);
 
 my $b1 = $m->add_build();
 ok($b1, "made test build 1");

--- a/lib/perl/Genome/Model/Build/Command/Queue.t
+++ b/lib/perl/Genome/Model/Build/Command/Queue.t
@@ -10,6 +10,8 @@ use warnings;
 use above 'Genome';
 use Test::More;
 
+use Genome::Test::Factory::AnalysisProject;
+
 use_ok('Genome::Model::Build::Command::Queue') or die;
 
 class Genome::Model::Tester { is => 'Genome::ModelDeprecated', };
@@ -29,6 +31,9 @@ my $m = Genome::Model::Tester->create(
 );
 ok($m, "made a test model");
 my $model_id = $m->id;
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+$anp->add_model_bridge(model_id => $model_id);
 
 my $reason = 'testing the queue command';
 my $cmd = Genome::Model::Build::Command::Queue->execute(

--- a/lib/perl/Genome/Model/Build/DeNovoAssembly/Allpaths.t
+++ b/lib/perl/Genome/Model/Build/DeNovoAssembly/Allpaths.t
@@ -17,6 +17,8 @@ require File::Compare;
 use File::Temp;
 use Test::More;
 
+use Genome::Test::Factory::AnalysisProject;
+
 if (Genome::Sys->arch_os ne 'x86_64') {
     plan skip_all => 'requires 64-bit machine';
 }
@@ -148,6 +150,9 @@ my $model = Genome::Model::DeNovoAssembly->create(
 
 ok($model, 'create allpaths de novo model') or die;
 ok($model->add_instrument_data($jump_inst_data), 'add jump inst data to model');
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+$anp->add_model_bridge(model_id => $model->id);
 
 my $bad_build = Genome::Model::Build::DeNovoAssembly->create(
     model => $model,

--- a/lib/perl/Genome/Model/Build/DeNovoAssembly/Soap.t
+++ b/lib/perl/Genome/Model/Build/DeNovoAssembly/Soap.t
@@ -14,6 +14,8 @@ use File::Compare;
 use File::Temp;
 use List::MoreUtils;
 
+use Genome::Test::Factory::AnalysisProject;
+
 use Test::More;
 
 if (Genome::Sys->arch_os ne 'x86_64') {
@@ -100,6 +102,9 @@ my $model = Genome::Model::DeNovoAssembly->create(
 );
 ok($model, 'soap de novo model') or die;
 ok($model->add_instrument_data($instrument_data), 'add inst data to model');
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+$anp->add_model_bridge(model_id => $model->id);
 
 my $build = Genome::Model::Build::DeNovoAssembly->create(
     model => $model,

--- a/lib/perl/Genome/Model/Build/ImportedReferenceSequence-derived_from.t
+++ b/lib/perl/Genome/Model/Build/ImportedReferenceSequence-derived_from.t
@@ -10,6 +10,8 @@ use Data::Dumper;
 use Test::More tests => 34;
 use_ok('Genome::Model::Build::ImportedReferenceSequence');
 
+use Genome::Test::Factory::AnalysisProject;
+
 # create a test annotation build and a few reference sequence builds to test compatibility with
 my @species_names = ('human', 'mouse');
 my @versions = (1, 2, 3);
@@ -98,6 +100,9 @@ sub create_reference_builds {
             subject_id          => $samples{$sn}->id,
         );
         ok($ref_model, "created reference sequence model ($sn)");
+
+        my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+        $anp->add_model_bridge(model_id => $ref_model->id);
 
         for my $v (@$versions) {
             my $rs = Genome::Model::Build::ImportedReferenceSequence->create(

--- a/lib/perl/Genome/Model/Build/ReferenceAlignment.t
+++ b/lib/perl/Genome/Model/Build/ReferenceAlignment.t
@@ -8,12 +8,16 @@ use Test::More tests => 5;
 
 use_ok('Genome::Model::Build::ReferenceAlignment');
 
+use Genome::Test::Factory::AnalysisProject;
 use Genome::Test::Factory::Build;
 use Genome::Test::Factory::InstrumentData::Solexa;
 use Genome::Test::Factory::Model::ReferenceAlignment;
 
 my $model = Genome::Test::Factory::Model::ReferenceAlignment->setup_object();
 my $other_reference = Genome::Test::Factory::Model::ReferenceAlignment->create_reference_sequence_build();
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+$anp->add_model_bridge(model_id => $model->id);
 
 my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id);
 

--- a/lib/perl/Genome/Model/ClinSeq.t
+++ b/lib/perl/Genome/Model/ClinSeq.t
@@ -13,6 +13,7 @@ use Test::More;
 use Test::Exception;
 use Genome::Model::ClinSeq;
 use Genome::Model::Build::Command::DiffBlessed;
+use Genome::Test::Factory::AnalysisProject;
 
 my $patient = Genome::Individual->get(common_name => "PNC6");
 ok($patient, "got the PNC6 patient");
@@ -60,6 +61,9 @@ my $m = $p->add_model(
     subject         => $patient,
 );
 ok($m, "created a model") or diag(Genome::Model->error_message);
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object;
+$anp->add_model_bridge(model_id => $m->id);
 
 my $i1 = $m->add_input(
     name => 'wgs_model',

--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.t
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.t
@@ -13,6 +13,7 @@ use above 'Genome';
 
 use Genome::Model::Command::Services::ListBuildQueue;
 use Genome::Test::Factory::Model::ReferenceAlignment;
+use Genome::Test::Factory::AnalysisProject;
 
 use List::MoreUtils qw(uniq);
 
@@ -38,8 +39,12 @@ do {
 };
 
 sub setup {
+    my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
     my @m = map { Genome::Test::Factory::Model::ReferenceAlignment->setup_object() } 1..3;
-    for (@m) { $_->build_requested(1) }
+    for (@m) {
+        $anp->add_model_bridge(model_id => $_->id);
+        $_->build_requested(1);
+    }
     my @model_ids = map { $_->id } @m;
     do {
         no warnings qw(once redefine);

--- a/lib/perl/Genome/Model/ImportedVariationList/Command/ImportVariants.pm
+++ b/lib/perl/Genome/Model/ImportedVariationList/Command/ImportVariants.pm
@@ -100,7 +100,7 @@ sub execute {
     );
 
     unless($imported_variationlist_definition->execute()){
-        die($self->error_message("ImportedVariationList creation commanad failed"));
+        die($self->error_message("ImportedVariationList creation command failed"));
     }
 
     $self->build($imported_variationlist_definition->build);

--- a/lib/perl/Genome/ProcessingProfile-example1.t
+++ b/lib/perl/Genome/ProcessingProfile-example1.t
@@ -13,6 +13,7 @@ BEGIN {
 use above "Genome";
 use Genome::Model;
 use Genome::Model::Build;
+use Genome::Test::Factory::AnalysisProject;
 use Genome::Test::Factory::DiskAllocation;
 
 Genome::Report::Email->silent();
@@ -111,6 +112,9 @@ my $m = $p->add_model(
 );
 ok($m, "made a new model");
 isa_ok($m,'Genome::Model::Foo',"the model is of the correct subclass");
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+$anp->add_model_bridge(model_id => $m->id);
 
 # add instrument data
 my $a = $m->add_instrument_data($i);


### PR DESCRIPTION
The long-awaited requirement!  A Model must belong to an Analysis Project (and one that's not Disabled at that!) in order to be built or queued for building.