### PR TITLE
Remove "dev_mode" configuration.

### DIFF
--- a/etc/genome/spec/dev_mode.yaml
+++ b/etc/genome/spec/dev_mode.yaml
@@ -1,3 +1,0 @@
---- 
-env: XGENOME_DEV_MODE
-default_value: ""

--- a/genome-webserver/solr/scripts/gcsearch_load_from_mailman.pl
+++ b/genome-webserver/solr/scripts/gcsearch_load_from_mailman.pl
@@ -26,7 +26,7 @@ my $MONTH_NAMES = month_names();
 
 
 my $lock_resource = 'gcsearch/mailman_loader';
-if (Genome::Config::get('dev_mode')) {
+if ($ENV{UR_DBI_NO_COMMIT}) {
     $lock_resource .= '_dev';
 }
 

--- a/lib/perl/Genome.pm
+++ b/lib/perl/Genome.pm
@@ -23,8 +23,8 @@ UR::Object::Type->define(
     english_name => 'genome',
 );
 
-# in dev mode we use dev search, dev wiki, dev memcache, etc, but production database still ;)
-my $dev_mode = ( Genome::Config::get('dev_mode') || UR::DBI->no_commit );
+# There is no "dev mode" anymore, but continue to produce a warning if no-commit is on
+my $dev_mode = UR::DBI->no_commit;
 if ($dev_mode) {
     my $h = Sys::Hostname::hostname;
     warn "***** GENOME_DEV_MODE ($h) *****";

--- a/lib/perl/Genome/Model/Command/Services/WebApp/Main.psgi
+++ b/lib/perl/Genome/Model/Command/Services/WebApp/Main.psgi
@@ -1,12 +1,5 @@
 #!/usr/bin/env genome-perl
 
-BEGIN {
-    require Genome::Config;
-    if (Genome::Config::get('dev_mode') ne '') {
-        Genome::Config::set_env('dev_mode', 0);
-    }
-}
-
 use Genome;
 use Web::Simple 'Genome::Model::Command::Services::WebApp::Main';
 

--- a/lib/perl/Genome/Search.pm
+++ b/lib/perl/Genome/Search.pm
@@ -13,13 +13,6 @@ class Genome::Search {
     is => 'UR::Singleton',
     doc => 'This module contains methods for adding and updating objects in the Solr search engine.',
     has => [
-        environment => {
-            is => 'Text',
-            calculate => q|
-                return 'prod' if Genome::Config::get('dev_mode');
-                return 'dev';
-            |,
-        },
         solr_server => {
             is => 'Text',
             default_value => Genome::Config::get('sys_services_solr'),
@@ -88,16 +81,6 @@ sub searchable_classes {
     );
 
     return @ordered_searchable_classes;
-}
-
-sub environment {
-    my $proto = shift;
-    my $self = $proto->_singleton_object;
-
-    if (@_ > 0) {
-        $self->_solr_server(undef);
-    }
-    return $self->__environment(@_);
 }
 
 ###  Index accessors  ###

--- a/lib/perl/Genome/Search.t
+++ b/lib/perl/Genome/Search.t
@@ -19,8 +19,6 @@ original_tests();
 done_testing();
 
 sub original_tests {
-    is(Genome::Search->environment(), 'dev', 'using dev instance of solr');
-
     my @searchable_classes = Genome::Search->searchable_classes();
     cmp_ok(scalar(@searchable_classes), '>', 1, 'found some searchable classes:');
     print Dumper \@searchable_classes;

--- a/lib/perl/Genome/Site/TGI.pm
+++ b/lib/perl/Genome/Site/TGI.pm
@@ -20,11 +20,6 @@ BEGIN {
 use lib $plugins_dir;
 
 BEGIN {
-    if (Genome::Config::get('dev_mode')) {
-        Genome::Config::set_env('sys_services_memcache', 'apipe-dev.gsc.wustl.edu:11211');
-        Genome::Config::set_env('sys_services_solr', 'http://solr-dev:8080/solr');
-    }
-
     if ($ENV{UR_DBI_NO_COMMIT}) {
         Genome::Config::set_env('statsd_host', '');
         Genome::Config::set_env('statsd_port', '');
@@ -56,7 +51,7 @@ use Genome::Sys;
 use Genome::Site::TGI::Extension::Sys;      # extensions to Genome::Sys
 
 BEGIN {
-    unless (Genome::Config::get('dev_mode')) {
+    unless ($ENV{UR_DBI_NO_COMMIT}) {
         require Genome::Site::TGI::Extension::Logger;
         Genome::Site::TGI::Extension::Logger->import();
     }

--- a/lib/perl/Genome/Wiki/Document.pm
+++ b/lib/perl/Genome/Wiki/Document.pm
@@ -27,9 +27,6 @@ class Genome::Wiki::Document {
         user          => { is => 'Text' },
     },
     has => {
-        environment => {
-             calculate => q{ Genome::Config::get('dev_mode') ? 'dev' : 'prod' },
-        },
         wiki_server_url => {
             calculate => qq{ Genome::Config::get('sys_services_wiki_url') . 'api.php' },
         },


### PR DESCRIPTION
This was previously used to switch between hard-coded server values in the code, but we are (or should be!) using config to set those server values directly instead.