### PR TITLE
Remove old, unused "log_dir" configuration variable.

### DIFF
--- a/etc/genome/spec/log_dir.yaml
+++ b/etc/genome/spec/log_dir.yaml
@@ -1,3 +1,0 @@
---- 
-env: XGENOME_LOG_DIR
-default_value: /var/log/genome/


### PR DESCRIPTION
I believe nothing uses this, and it would be beneficial to improving GMS dockerization to remove it.