### PR TITLE
Make normal/tumor sample field real

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/GatkSomaticIndel.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/GatkSomaticIndel.t
@@ -28,7 +28,7 @@ my $ref_seq_build = Genome::Model::Build::ImportedReferenceSequence->get($refbui
 ok($ref_seq_build, 'human36 reference sequence build') or die;
 
 my $test_data = Genome::Config::get('test_inputs') . "/Genome-Model-Tools-DetectVariants2-GatkSomaticIndel/inputs/2013-06-12";
-my $expected_data = Genome::Config::get('test_inputs') . "/Genome-Model-Tools-DetectVariants2-GatkSomaticIndel/expected_10";
+my $expected_data = Genome::Config::get('test_inputs') . "/Genome-Model-Tools-DetectVariants2-GatkSomaticIndel/expected_11";
 my $tumor =  $test_data.'/true_positive_tumor_validation.bam';
 my $normal = $test_data.'/true_positive_normal_validation.bam';
 
@@ -46,8 +46,8 @@ my $gatk_somatic_indel = Genome::Model::Tools::DetectVariants2::GatkSomaticIndel
         output_directory => $tmpdir, 
         mb_of_ram => 3500,
         version => 5336,
-        aligned_reads_sample => 'TEST_tumor',
-        control_aligned_reads_sample => 'TEST_normal',
+        aligned_reads_sample => 'H_GV-933124G-S.17384',
+        control_aligned_reads_sample => 'H_HI-933124G-S.9017',
         result_users => $result_users,
 );
 

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Indel/GatkSomaticIndel.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Indel/GatkSomaticIndel.t
@@ -13,15 +13,15 @@ if (Genome::Sys->arch_os ne 'x86_64') {
 use_ok('Genome::Model::Tools::Vcf::Convert::Indel::GatkSomaticIndel');
 
 my $test_dir = Genome::Config::get('test_inputs') . '/Genome-Model-Tools-Vcf-Convert-Indel-GatkSomaticIndel';
-my $expected_file = "$test_dir/expected.v2/indels.vcf.gz";
+my $expected_file = "$test_dir/expected.v3/indels.vcf.gz";
 my $input_file    = "$test_dir/indels.hq";
 my $output_file   = Genome::Sys->create_temp_file_path;
 
 my $command = Genome::Model::Tools::Vcf::Convert::Indel::GatkSomaticIndel->create( 
     input_file  => $input_file,
     output_file => $output_file,
-    aligned_reads_sample         => "TUMOR_SAMPLE_123",
-    control_aligned_reads_sample => "CONTROL_SAMPLE_123",
+    aligned_reads_sample         => "H_LB-667720-1006021",
+    control_aligned_reads_sample => "H_LB-667720-S.21118",
     reference_sequence_build_id  => 101947881
 );
 


### PR DESCRIPTION
GatkSomaticIndel sometimes swaps the normal and tumor columns in its own vcf output that this vcf converter is based on. Aka, column 9 is not always for tumor. This fix replaces the hardcoded normal/tumor column index with a better way to secure the normal/tumor columns.