### PR TITLE
The estimate_id column has been dropped from the Work Order table.

### DIFF
--- a/lib/perl/Genome/WorkOrder.pm
+++ b/lib/perl/Genome/WorkOrder.pm
@@ -66,10 +66,6 @@ class Genome::WorkOrder {
             to => 'external_contact_name',
             is_many => 0
         },
-        estimate_id => {
-            is => 'Text',
-            len => 32,
-        },
         is_test => {
             is => 'Integer',
             len => 1,


### PR DESCRIPTION
(This class is still pointing directly into a LIMS table.  It ought to really be converted to a `Genome::Site::TGI`-ish class or else removed entirely.)