### PR TITLE
Add FT format field to pindelRegion vcf

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/PindelRegion.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/PindelRegion.t
@@ -25,11 +25,12 @@ my $refbuild_id = 101947881;
 my $ref_seq_build = Genome::Model::Build::ImportedReferenceSequence->get($refbuild_id);
 ok($ref_seq_build, 'human36 reference sequence build') or die;
 
-my $test_base_dir = Genome::Utility::Test->data_dir($pkg);
-my $region_file   = File::Spec->join($test_base_dir, 'region_file.bed');
+my $test_base_dir  = Genome::Utility::Test->data_dir($pkg);
+my ($test_input_dir, $test_out_dir) = map{$test_base_dir.'/'.$_}qw(input expected_2); 
 
-my $tumor  = File::Spec->join($test_base_dir, 'flank_tumor_sorted.bam');
-my $normal = File::Spec->join($test_base_dir, 'flank_normal_sorted.bam');
+my $region_file = File::Spec->join($test_input_dir, 'region_file.bed');
+my $tumor       = File::Spec->join($test_input_dir, 'flank_tumor_sorted.bam');
+my $normal      = File::Spec->join($test_input_dir, 'flank_normal_sorted.bam');
 
 my $test_working_dir = Genome::Sys->create_temp_directory();
 
@@ -58,13 +59,13 @@ subtest 'execute' => sub {
 
     for my $output_basename qw(indels.hq indels.hq.bed) {
         compare_ok(
-            File::Spec->join($test_base_dir, $output_basename),
+            File::Spec->join($test_out_dir, $output_basename),
             File::Spec->join($test_working_dir, $output_basename),
             "$output_basename as expected"
         );
     }
     my $differ = Genome::File::Vcf::Differ->new(
-        File::Spec->join($test_base_dir, 'indels.vcf.gz'), 
+        File::Spec->join($test_out_dir, 'indels.vcf.gz'), 
         File::Spec->join($test_working_dir, 'indels.vcf.gz')
     );
     my $diff = $differ->diff;

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/PindelRegion.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/PindelRegion.t
@@ -26,7 +26,7 @@ my $ref_seq_build = Genome::Model::Build::ImportedReferenceSequence->get($refbui
 ok($ref_seq_build, 'human36 reference sequence build') or die;
 
 my $test_base_dir  = Genome::Utility::Test->data_dir($pkg);
-my ($test_input_dir, $test_out_dir) = map{$test_base_dir.'/'.$_}qw(input expected_2); 
+my ($test_input_dir, $test_out_dir) = map{File::Spec->join($test_base_dir, $_)}qw(input expected_2); 
 
 my $region_file = File::Spec->join($test_input_dir, 'region_file.bed');
 my $tumor       = File::Spec->join($test_input_dir, 'flank_tumor_sorted.bam');

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Indel/PindelRegion.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Indel/PindelRegion.pm
@@ -3,12 +3,44 @@ package Genome::Model::Tools::Vcf::Convert::Indel::PindelRegion;
 use strict;
 use warnings;
 use Genome;
+use Genome::File::Vcf::Writer;
+use Genome::File::Vcf::Reader;
 
-#This module is exact copy of Genome::Model::Tools::Vcf::Convert::Indel::Pindel
 
 class Genome::Model::Tools::Vcf::Convert::Indel::PindelRegion {
     is =>  'Genome::Model::Tools::Vcf::Convert::Indel::Pindel',
 };
+
+
+sub execute {
+    my $self = shift;
+    $self->SUPER::_execute_body(@_);
+
+    my $tmp_output = Genome::Sys->create_temp_file_path;
+    Genome::Sys->move_file($self->output_file, $tmp_output);
+
+    my $in_vcf = Genome::File::Vcf::Reader->new($tmp_output);
+    my $header = $in_vcf->header;
+
+    my $FT_header_str = '<ID=FT,Number=1,Type=String,Description="Sample genotype filter">';
+    $header->add_format_str($FT_header_str);
+
+    my $out_vcf = Genome::File::Vcf::Writer->new($self->output_file, $header);
+
+    while (my $entry = $in_vcf->next) {
+        $entry->add_format_field('FT');
+        if ($entry->sample_field(0, 'GT') eq '0/0' and $entry->sample_field(1, 'GT') =~ /1/) { #Somatic
+            map{$entry->set_sample_field($_, 'FT', 'PASS')}qw(0 1);
+        }
+        else {
+            map{$entry->set_sample_field($_, 'FT', '.')}qw(0 1);
+        }
+        $out_vcf->write($entry);
+    }
+    $out_vcf->close;
+
+    return 1;
+}
 
 1;
 


### PR DESCRIPTION
Adding PASS to FT format field for somatic variants can preserve this pass status through vcf filter and joinx vcf-merge later.