### PR TITLE
Update blessed builds

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
@@ -14,7 +14,7 @@ apipe-test-reference-alignment: dc0be865a3f64f58ae6762e6d3bab3bc
 apipe-test-rnaseq: f7c55980a3d3484f9f895834d22fe721
 apipe-test-single-sample-genotype: adbc003ccb3a4af89770731db5959076
 apipe-test-somatic-validation-sv: fca9bd3a029d48099f07092c19989d16
-apipe-test-somatic-validation: 750be33ae59f4a588b87a587d9df22bb
-apipe-test-somatic-variation-short: 82be34202d0141f3ae2b2c37e0ec2b7d
+apipe-test-somatic-validation: cf057c39c4294e0098f7aad7cd414828
+apipe-test-somatic-variation-short: 495e7a2f9b3a492cb30a2a3074803f9b
 apipe-test-somatic-variation-sv-detection: 2a046f43a086479b9d6c957b9d977312
 apipe-test-somatic-variation: b396a01c42ea42249422e1a69f10195d 


### PR DESCRIPTION
All diff is caused by newly fixed GatkSomaticIndel vcf format (https://github.com/genome/genome/pull/1561)and the diff is fine. This PR is to update the blessed builds so Jenkins Genome-Model-Tests can pass.