### PR TITLE
Update homo_polymer list with min_length 7

### DIFF
--- a/lib/perl/Genome/Site/TGI/CleTest.pm.yaml
+++ b/lib/perl/Genome/Site/TGI/CleTest.pm.yaml
@@ -50,7 +50,7 @@ feature_lists:
     - a2733b8111c24110805025137c878e13 #Full ROI
     - 0e4973c600244c3f804d54bee6f81145 #RMG ROI
     - ef6583623a614c8ebaea471a4c9748fc #AML Complex Mutation Region ROI
-    - 696318bab30d47d49fab9afa845691b7 #homopolymer regions from G::VR::C::Wrapper::ModelPair
+    - 7f05e8fad6b6465a9f5bd6155dc88135 #homopolymer regions from G::VR::C::Wrapper::ModelPair
     - 4e77d10f29f44a0792ebc8d6ea0c4a2b #segdups my $b = Genome::Model::Build->get('26e65adaa8034dd99ef92b27f61ad862'); $b->get_feature_list("segmental_duplications")->id
 processing_profiles:
     - a813f8067a8c4c9791fec53dd29d85ca #somatic CLE PP

--- a/lib/perl/Genome/Site/TGI/CleTest.t
+++ b/lib/perl/Genome/Site/TGI/CleTest.t
@@ -68,7 +68,7 @@ my $expected_config = {
         'a2733b8111c24110805025137c878e13',
         '0e4973c600244c3f804d54bee6f81145',
         'ef6583623a614c8ebaea471a4c9748fc',
-        '696318bab30d47d49fab9afa845691b7',
+        '7f05e8fad6b6465a9f5bd6155dc88135',
         '4e77d10f29f44a0792ebc8d6ea0c4a2b'
     ],
     processing_profiles => [

--- a/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPair.pm
+++ b/lib/perl/Genome/VariantReporting/Command/Wrappers/ModelPair.pm
@@ -178,7 +178,7 @@ sub generate_translations_file {
     # TODO: There has to be a better way...
     $feature_list_ids{AML_RMG} = '0e4973c600244c3f804d54bee6f81145';
     $translations->{feature_list_ids} = \%feature_list_ids;
-    $translations->{homopolymer_list_id} = '696318bab30d47d49fab9afa845691b7';
+    $translations->{homopolymer_list_id} = '7f05e8fad6b6465a9f5bd6155dc88135';
 
     $translations->{reference_fasta} = $self->reference_sequence_build->full_consensus_path("fa");
 


### PR DESCRIPTION
The current homo polymer list has homo polymers of min_length 6, which filters out some real indel variants. The new list has homo polymers of min_length 7 with about 4 million length_6 polymers removed. The indel counts of trio report using the new list look fine. Refer to https://jira.gsc.wustl.edu/browse/CI-191  Diff is expected for regression test.