### PR TITLE
change denominator for interchromosomal rate calculation

### DIFF
--- a/lib/perl/Genome/Model/Tools/Sam/Flagstat.pm
+++ b/lib/perl/Genome/Model/Tools/Sam/Flagstat.pm
@@ -119,8 +119,8 @@ sub parse_file_into_hashref {
         $data{hq_reads_mapped_in_interchromosomal_pairs} = $1 if /^(\d+) (\+\s\d+\s)?with mate mapped to a different chr \(mapQ>=5\)$/;
     }
 
-    if (defined($data{reads_mapped_in_proper_pairs}) && $data{reads_mapped_in_proper_pairs} > 0) {
-        $data{reads_mapped_in_interchromosomal_pairs_percentage} = $data{reads_mapped_in_interchromosomal_pairs} / $data{reads_mapped_in_proper_pairs};
+    if (defined($data{reads_mapped_in_pair}) && $data{reads_mapped_in_pair} > 0) {
+        $data{reads_mapped_in_interchromosomal_pairs_percentage} = $data{reads_mapped_in_interchromosomal_pairs} / $data{reads_mapped_in_pair};
     }
     else {
         $data{reads_mapped_in_interchromosomal_pairs_percentage} = 'nan';


### PR DESCRIPTION
In reviewing our QC metrics, I noticed that the denominator for calculating `reads_mapped_in_interchromosomal_pairs_percentage` is incorrect. Properly paired reads were being used as the denominator, but given that properly paired reads would exclude interchromosomal pairs then this seems incorrect.

This pull request changes the denominator to be all reads mapping in pairs.