### PR TITLE
Reset _format_key_to_idx hash properly and avoid check with autovivified hash

### DIFF
--- a/lib/perl/Genome/File/Vcf/Entry.pm
+++ b/lib/perl/Genome/File/Vcf/Entry.pm
@@ -592,7 +592,8 @@ sub add_format_field {
     else {
         my $idx = scalar @{$self->{_format}};
         push @{$self->{_format}}, $field;
-        $self->{_format_key_to_idx}{$field} = $idx;
+        my $format_idx = $self->format_field_index;
+        $self->{_format_key_to_idx} = {%$format_idx, $field => $idx};
         return $idx;
     }
 }

--- a/lib/perl/Genome/File/Vcf/Entry.pm
+++ b/lib/perl/Genome/File/Vcf/Entry.pm
@@ -593,7 +593,8 @@ sub add_format_field {
         my $idx = scalar @{$self->{_format}};
         push @{$self->{_format}}, $field;
         my $format_idx = $self->format_field_index;
-        $self->{_format_key_to_idx} = {%$format_idx, $field => $idx};
+        $format_idx->{$field} = $idx;
+        $self->{_format_key_to_idx} = $format_idx;
         return $idx;
     }
 }
@@ -624,7 +625,7 @@ sub format_field_index {
     my ($self, $key) = @_;
     my $format_idx = $self->{_format_key_to_idx};
 
-    unless (scalar keys %$format_idx) {
+    unless (defined $format_idx and %$format_idx) {
         my @format = @{$self->{_format}};
         return unless @format;
 

--- a/lib/perl/Genome/File/Vcf/Entry.pm
+++ b/lib/perl/Genome/File/Vcf/Entry.pm
@@ -622,7 +622,9 @@ an example.
 
 sub format_field_index {
     my ($self, $key) = @_;
-    if (!exists $self->{_format_key_to_idx}) {
+    my $format_idx = $self->{_format_key_to_idx};
+
+    unless (scalar keys %$format_idx) {
         my @format = @{$self->{_format}};
         return unless @format;
 

--- a/lib/perl/Genome/File/Vcf/Entry.t
+++ b/lib/perl/Genome/File/Vcf/Entry.t
@@ -279,6 +279,16 @@ subtest "add format field" => sub {
         "Expected: " . Dumper($expected_format) . "\nActual: " . Dumper($entry->format);
 };
 
+subtest "add format field (check sample_field)" => sub {
+    my @fields = ('Y', 99, 'rs123', 'CGC', 'CGA,CG', '10.2', 'PASS', '.', 'GT:DP', '0/0:10', '0/1:20');
+    my $entry_txt = join("\t", @fields);
+    my $entry = $pkg->new($header, $entry_txt);
+    ok($entry, "Created entry");
+    $entry->add_format_field("FT");
+    is($entry->sample_field(0, "GT"), '0/0', "GT=0/0 for sample #0");
+    is($entry->sample_field(1, "GT"), '0/1', "GT=0/1 for sample #1");
+};
+
 subtest "add format field (GT, special case)" => sub {
     my @fields = ( 'Y', 99, 'rs123', 'CGC', 'CGA,CG', '10.2', 'PASS', '.', 'DP', '10', '20');
     my $entry_txt = join("\t", @fields);

--- a/lib/perl/Genome/Model/Tools/Vcf/AnnotateWithReadcounts.t
+++ b/lib/perl/Genome/Model/Tools/Vcf/AnnotateWithReadcounts.t
@@ -16,7 +16,7 @@ use Genome::File::Vcf::Differ;
 my $pkg = 'Genome::Model::Tools::Vcf::AnnotateWithReadcounts';
 
 use_ok($pkg);
-my $data_dir = Genome::Utility::Test->data_dir_ok($pkg, "v6");
+my $data_dir = Genome::Utility::Test->data_dir_ok($pkg, "v7");
 
 subtest "output vcf" => sub {
     my $out = Genome::Sys->create_temp_file_path;

--- a/lib/perl/Genome/VariantReporting/Suite/BamReadcount/Expert.t
+++ b/lib/perl/Genome/VariantReporting/Suite/BamReadcount/Expert.t
@@ -28,7 +28,7 @@ use_ok($pkg) || die;
 my $factory = Genome::VariantReporting::Framework::Factory->create();
 isa_ok($factory->get_class('experts', $pkg->name), $pkg);
 
-my $VERSION = 13; # Bump these each time test data changes
+my $VERSION = 14; # Bump these each time test data changes
 my $RESOURCE_VERSION = 1;
 my $test_dir = get_test_dir($pkg, $VERSION);
 


### PR DESCRIPTION
This PR is to fix the bug. This is causing $entry->sample_field not returned correctly if add_format_field first.