### PR TITLE
Update blessed process object for Jenkins genome-process-test

### DIFF
--- a/lib/perl/Genome/Process/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Process/Command/DiffBlessed.pm.YAML
@@ -1,2 +1,2 @@
 ---
-trio_main: fd7c4ed8dca74ae7b78836f4a782318a
+trio_main: aeb18d990fcb4932931404cbc9c0efe6


### PR DESCRIPTION
All diff is caused by recently changed homo_polymer list in trio report and a bug fix of format_field_index in Genome::File::Vcf::Entry. This PR needs early merge to make Jenkins test pass.