### PR TITLE
Remove "email_pipeline_noisy" config.

### DIFF
--- a/etc/genome/spec/email_pipeline_noisy.yaml
+++ b/etc/genome/spec/email_pipeline_noisy.yaml
@@ -1,4 +1,0 @@
-# The 'email_pipeline_noisy' configuration variable holds the name of the email
-# alias used as the recepient for many system-generated emails.
---- 
-env: XGENOME_EMAIL_PIPELINE_NOISY

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -440,7 +440,6 @@ MESSAGE
                 Genome::Utility::Email::send(
                     from    => $from,
                     to      => \@to,
-                    cc      => Genome::Config::get('email_pipeline_noisy'),
                     subject => $subject,
                     body    => $data,
                 );


### PR DESCRIPTION
There was only one place left using this, and it already sends mail somewhere else in addition to this configured address.

[This is in support of our current e-mail cleanup efforts.]