### PR TITLE
Bless new build for apipe-test-somatic-variation

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
@@ -17,4 +17,4 @@ apipe-test-somatic-validation-sv: fca9bd3a029d48099f07092c19989d16
 apipe-test-somatic-validation: cf057c39c4294e0098f7aad7cd414828
 apipe-test-somatic-variation-short: 495e7a2f9b3a492cb30a2a3074803f9b
 apipe-test-somatic-variation-sv-detection: 2a046f43a086479b9d6c957b9d977312
-apipe-test-somatic-variation: b396a01c42ea42249422e1a69f10195d 
+apipe-test-somatic-variation: 7eb8f15ec5d449f2bb06953a606004bf


### PR DESCRIPTION
The diff is from missing TCGA sample fields in vcf header, which is caused by turnning off the outdated OpenSSL TCGA web queries and disabling the TCGA compliance support. The commit is 1933bbaeb0cbf7bbebf11315ccbb9d628a77c14e for Genome/Model/Tools/Vcf/Convert/Base.pm on 07/25/2016. The vcf header for non-TCGA sample is still fine.