### PR TITLE
Remove old build workflow configuration.

### DIFF
--- a/etc/genome/spec/lsf_queue_build_workflow.yaml
+++ b/etc/genome/spec/lsf_queue_build_workflow.yaml
@@ -1,5 +1,0 @@
-# Specifies the LSF queue to submit build workflow jobs.
---- 
-env: XGENOME_LSF_QUEUE_BUILD_WORKFLOW
-validators:
-  - LSFQueue


### PR DESCRIPTION
Support for `Workflow` is gone as of #1559, so this variable is no longer used by anything.