### PR TITLE
Make Java heap and permgen configurable for calling Picard.

### DIFF
--- a/etc/genome/spec/java_heapspace_picard.yaml
+++ b/etc/genome/spec/java_heapspace_picard.yaml
@@ -1,0 +1,3 @@
+---
+default_value: "4"
+env: XGENOME_JAVA_HEAPSPACE_PICARD

--- a/etc/genome/spec/java_permgen_picard.yaml
+++ b/etc/genome/spec/java_permgen_picard.yaml
@@ -1,0 +1,3 @@
+---
+default_value: "64"
+env: XGENOME_JAVA_PERMGEN_PICARD

--- a/lib/perl/Genome/Model/Tools/Picard.pm
+++ b/lib/perl/Genome/Model/Tools/Picard.pm
@@ -13,8 +13,8 @@ use Genome::Utility::Email;
 use List::MoreUtils 'uniq';
 
 my $PICARD_DEFAULT = '1.46';
-my $DEFAULT_MEMORY = 4;
-my $DEFAULT_PERMGEN_SIZE = 64; #Mbytes
+my $DEFAULT_MEMORY = Genome::Config::get('java_heapspace_picard');
+my $DEFAULT_PERMGEN_SIZE = Genome::Config::get('java_permgen_picard'); #Mbytes
 my $DEFAULT_VALIDATION_STRINGENCY = 'SILENT';
 my $DEFAULT_MAX_RECORDS_IN_RAM = 500000;
 


### PR DESCRIPTION
Occasionally CollectWgsMetrics likes to exceed the default Java heap space.