### PR TITLE
Remove spurious whitespace in regex.

### DIFF
--- a/lib/perl/Genome/Sys/LSF/JobIterator.pm
+++ b/lib/perl/Genome/Sys/LSF/JobIterator.pm
@@ -65,7 +65,7 @@ sub new {
     $jobinfo{__events} = [];
     foreach my $el (@eventlines) {
         if ( $el =~
-            /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s{1,2}(\d{1,2})\s{1,   2}(\d{1,2}):(\d{2}):(\d{2}):/
+            /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s{1,2}(\d{1,2})\s{1,2}(\d{1,2}):(\d{2}):(\d{2}):/
         )
         {
 


### PR DESCRIPTION
Perl 5.22 warns of an unescaped `{`. Seems like it was a quantifier gone wrong.  The history of this module is obscured, though.