### PR TITLE
Test::Builder: Don't return before evaluating the entire expression.

### DIFF
--- a/lib/perl/Test/Builder.pm
+++ b/lib/perl/Test/Builder.pm
@@ -958,7 +958,7 @@ sub _is_dualvar {
 
     no warnings 'numeric';
     my $numval = $val + 0;
-    return $numval != 0 and $numval ne $val ? 1 : 0;
+    return ($numval != 0 and $numval ne $val) ? 1 : 0;
 }
 
 =item B<is_eq>


### PR DESCRIPTION
This module really shouldn't be in the repository to begin with... but as long as we're supporting old systems it shall remain.