### PR TITLE
Exclude alignment metrics from default Solexa lister.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/List.pm
+++ b/lib/perl/Genome/InstrumentData/Command/List.pm
@@ -78,8 +78,6 @@ my %DEFAULT_SHOW = (
         read_length
         is_paired_end
         clusters
-        median_insert_size
-        sd_above_insert_size
         target_region_set_name
     )],
 

--- a/lib/perl/Genome/Model/ClinSeq/Command/TestGenomeCommands.t.d/genome-instrument-data-list2.out
+++ b/lib/perl/Genome/Model/ClinSeq/Command/TestGenomeCommands.t.d/genome-instrument-data-list2.out
@@ -1,8 +1,8 @@
-ID    FLOW_CELL_ID   LANE   INDEX_SEQUENCE   SAMPLE_NAME                               LIBRARY_NAME                                   READ_LENGTH   IS_PAIRED_END   CLUSTERS   MEDIAN_INSERT_SIZE   SD_ABOVE_INSERT_SIZE   TARGET_REGION_SET_NAME
---    ------------   ----   --------------   -----------                               ------------                                   -----------   -------------   --------   ------------------   --------------------   ----------------------
--39   TEST1ABXX      1      -38              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib1   100           0               12345639   50                   85                     <NULL>
--41   TEST1ABXX      2      -40              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib1   100           0               12345637   50                   85                     <NULL>
--44   TEST1ABXX      1      -43              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib2   100           0               12345634   50                   85                     <NULL>
--46   TEST1ABXX      2      -45              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib2   100           0               12345632   50                   85                     <NULL>
--49   TEST1ABXX      1      -48              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib3   100           0               12345629   50                   85                     <NULL>
--51   TEST1ABXX      2      -50              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib3   100           0               12345627   50                   85                     <NULL>
+ID    FLOW_CELL_ID   LANE   INDEX_SEQUENCE   SAMPLE_NAME                               LIBRARY_NAME                                   READ_LENGTH   IS_PAIRED_END   CLUSTERS   TARGET_REGION_SET_NAME
+--    ------------   ----   --------------   -----------                               ------------                                   -----------   -------------   --------   ----------------------
+-39   TEST1ABXX      1      -38              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib1   100           0               12345639   <NULL>
+-41   TEST1ABXX      2      -40              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib1   100           0               12345637   <NULL>
+-44   TEST1ABXX      1      -43              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib2   100           0               12345634   <NULL>
+-46   TEST1ABXX      2      -45              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib2   100           0               12345632   <NULL>
+-49   TEST1ABXX      1      -48              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib3   100           0               12345629   <NULL>
+-51   TEST1ABXX      2      -50              H_TEST-ClinSeqGenomeCommands-tumor_cdna   H_TEST-ClinSeqGenomeCommands-tumor_cdna-lib3   100           0               12345627   <NULL>


### PR DESCRIPTION
When the LIMS was calculating these, they were quick lookups since they came as instrument data properties.  Now that they're not, there's only the hacky "default_alignment_results" to get them.  The question doesn't really make sense in a world where alignment can be done any number of ways.