### PR TITLE
Debug message for the resource when locking.

### DIFF
--- a/lib/perl/Genome/Sys/LockProxy.pm
+++ b/lib/perl/Genome/Sys/LockProxy.pm
@@ -76,6 +76,7 @@ sub lock {
         params => \@_,
         spec => Genome::Sys::Lock::PROXY_LOCK_PARAMS_SPEC(),
     );
+    STDERR->say(sprintf 'DEBUG: Attempting to lock (in scope "%s"): %s', $self->scope, $self->resource) if $ENV{UR_DUMP_DEBUG_MESSAGES};
     my $locked = Genome::Sys::Lock->lock_resource(%params,
         resource_lock => $self->resource,
         scope => $self->scope,


### PR DESCRIPTION
This should make it easier to find out what we're waiting on when something else has the lock.  This replaces the earlier pre-backend message that would output the entire contents of the file lock.  (Unlike the previous message, this message gets included even if we do get the lock immediately.)