### PR TITLE
SnvIndelReport standalone support

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/Converge/SnvIndelReport.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/Converge/SnvIndelReport.pm
@@ -14,18 +14,16 @@ class Genome::Model::ClinSeq::Command::Converge::SnvIndelReport {
             is  => 'FilesystemPath',
             doc => 'Directory where output files will be written',
         },
-    ],
-    has_optional_input => [
         target_gene_list => {
             is => 'FilesystemPath',
-            doc =>
-                'Genes of interest to be highlighted (e.g. AML RMG list).  Tab delimited file with ENSGs in first column',
+            doc => 'Genes of interest to be highlighted (e.g. AML RMG list).  Tab delimited file with ENSGs in first column',
         },
         target_gene_list_name => {
             is      => 'Text',
             doc     => 'Human readable name used to refer to the target gene list',
-            default => 'AML_RMG',
         },
+    ],
+    has_optional_input => [
         variant_filter_list => {
             is => 'FileSystemPath',
             doc =>

--- a/lib/perl/Genome/Model/ClinSeq/Command/Converge/SnvIndelReport.pm
+++ b/lib/perl/Genome/Model/ClinSeq/Command/Converge/SnvIndelReport.pm
@@ -468,13 +468,18 @@ sub gather_variants {
             unless (-e $indels_file) {
                 die $self->error_message("Could not find expected file:\n$indels_file");
             }
-            my $vcf_result_accessor = "_${somatic_build_type}_annotated_snvs_vcf_result";
-            my $vcf_file;
-            if (my $result = $self->$vcf_result_accessor) {
-                $vcf_file = $result->file_path;
-            }
-            else {
-                $vcf_file = $somatic_build->snvs_annotated_variants_vcf_file;
+            my $annotated_snvs_vcf_result_cmd = Genome::Model::ClinSeq::Command::AnnotateSnvsVcf->create(somatic_build => $somatic_build);
+            my $users = Genome::SoftwareResult::User->user_hash_for_build($somatic_build);
+            my $annotated_snvs_vcf_result = $annotated_snvs_vcf_result_cmd->shortcut(result_users => $users);
+            my $vcf_file = $annotated_snvs_vcf_result->file_path;
+            unless ($vcf_file) {
+                my $vcf_result_accessor = "_${somatic_build_type}_annotated_snvs_vcf_result";
+                if (my $result = $self->$vcf_result_accessor) {
+                    $vcf_file = $result->file_path;
+                }
+                else {
+                    $vcf_file = $somatic_build->snvs_annotated_variants_vcf_file;
+                }
             }
             $bed_files{$snvs_file}{somatic_build_id}   = $somatic_build_id;
             $bed_files{$snvs_file}{var_type}           = "snv";


### PR DESCRIPTION
Allow for the lookup/shorcut of the AnnotatedSnvsVcf result instead of relying on it as an input. This command can now be run standalone as long as a previous build succeeded at generating the result.

Please take a look @tmooney and @susannasiebert 