### PR TITLE
Trust that symlinks are mounted.

### DIFF
--- a/lib/perl/Genome/Disk/Volume.pm
+++ b/lib/perl/Genome/Disk/Volume.pm
@@ -273,6 +273,10 @@ sub is_mounted {
         return 1;
     }
 
+    if (-l $self->mount_path) {
+        return 1; #trust that symlinks are mounted
+    }
+
     # We can't use Filesys::Df::df because it doesn't report the mount path only the stats.
     my $mount_path = $self->mount_path;
     my @df_output = qx(df -P $mount_path 2> /dev/null);


### PR DESCRIPTION
The `is_mounted` method is premised that each mount path is automounted.  If a mount_path is a symlink, instead assume that it is part of a larger mount that already is mounted--someone should check that larger mount's path directly if they care.

(I'm not sure this is the best solution to this problem, but it seems to solve the problem of making allocations under the new scheme.)