### PR TITLE
Use above for loading Genome in LockProxy.t

### DIFF
--- a/lib/perl/Genome/Sys/LockProxy.t
+++ b/lib/perl/Genome/Sys/LockProxy.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Genome;
+use above 'Genome';
 use Test::More tests => 5;
 
 use Genome::Sys::Lock qw();


### PR DESCRIPTION
While testing #1632 I was briefly confounded by this test not loading my changes.  This makes it so running the test locally really uses the local codebase :smile: