### PR TITLE
Treat "errored" PTero status as a failure condition.

### DIFF
--- a/lib/perl/Genome/Command/PteroWorkflowMixin.pm
+++ b/lib/perl/Genome/Command/PteroWorkflowMixin.pm
@@ -336,7 +336,7 @@ sub _method_is_active {
     my ($method, $color) = @_;
 
     my $execution = $method->{executions}->{$color};
-    return (defined($execution) && $execution->{status} ne 'failed');
+    return (defined($execution) && ($execution->{status} ne 'failed' and $execution->{status} ne 'errored'));
 }
 
 sub _method_is_failed {
@@ -344,7 +344,7 @@ sub _method_is_failed {
     my ($method, $color) = @_;
 
     my $execution = $method->{executions}->{$color};
-    return (defined($execution) && $execution->{status} eq 'failed');
+    return (defined($execution) && ($execution->{status} eq 'failed' or $execution->{status} eq 'errored'));
 }
 
 sub _write_ptero_command_details_shortcut {


### PR DESCRIPTION
We will now display the "execute" attempt if the "shortcut" attempt errors out.  (Previously, the errored shortcut would be displayed even if the execute is running smoothly.)