### PR TITLE
New AnP Commands to "Take Ownership" or "Uncomplete" AnPs.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/TakeOwnership.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/TakeOwnership.pm
@@ -1,0 +1,68 @@
+package Genome::Config::AnalysisProject::Command::TakeOwnership;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Config::AnalysisProject::Command::TakeOwnership {
+    is => 'Command::V2',
+    has_input => [
+       analysis_projects  => {
+            is                  => 'Genome::Config::AnalysisProject',
+            doc                 => 'the analysis projects to complete',
+            is_many             => 1,
+            shell_args_position => 1,
+            require_user_verify => 1,
+        }
+    ],
+};
+
+sub help_brief {
+    return 'take analysis projects';
+}
+
+sub help_synopsis {
+    return "genome config analysis-project take <analysis-projects>";
+}
+
+sub help_detail {
+    return <<"EOS"
+Given some analysis projects, this will update the "created_by" to the current user.
+EOS
+}
+
+sub execute {
+    my $self = shift;
+
+    for my $ap ($self->analysis_projects) {
+        $ap->created_by(Genome::Sys->username);
+    }
+
+    return 1;
+}
+
+sub __errors__ {
+    my $self = shift;
+    my @errors = $self->SUPER::__errors__(@_);
+    for my $anp ($self->analysis_projects){
+        if ($anp->is_cle) {
+            push @errors, UR::Object::Tag->create(
+                type => 'error',
+                properties => ['analysis_projects'],
+                desc => 'Cannot take CLE analysis project ' . $anp->id,
+            );
+        }
+
+        if (Genome::Sys->user_has_role($anp->created_by, 'production')) {
+            push @errors, UR::Object::Tag->create(
+                type => 'error',
+                properties => ['analysis_projects'],
+                desc => 'Cannot take production analysis project ' . $anp->id,
+            );
+        }
+    }
+    return @errors;
+}
+
+1;

--- a/lib/perl/Genome/Config/AnalysisProject/Command/TakeOwnership.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/TakeOwnership.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+use Test::More tests => 5;
+
+my $class = 'Genome::Config::AnalysisProject::Command::TakeOwnership';
+use_ok($class);
+
+my $ap = Genome::Config::AnalysisProject->create(
+    name => 'Test Project',
+    status => 'In Progress',
+);
+$ap->created_by('nobody');
+
+my $cmd = $class->execute(analysis_projects => [$ap]);
+ok($cmd->result, 'execute cmd');
+is($ap->created_by, Genome::Sys->username, "AnP owner updated to current user");
+
+my $cle_ap = Genome::Config::AnalysisProject->create(
+    name => 'Test CLE Project',
+    status => 'Pending',
+    is_cle => 1,
+);
+$cle_ap->created_by('nobody');
+
+my $cmd2 = $class->create(analysis_projects => [$cle_ap]);
+isa_ok($cmd2, $class, 'created command');
+my @errors = $cmd2->__errors__;
+is(scalar(@errors), 1, 'found an error');
+
+done_testing();

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Uncomplete.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Uncomplete.pm
@@ -1,0 +1,68 @@
+package Genome::Config::AnalysisProject::Command::Uncomplete;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Config::AnalysisProject::Command::Uncomplete {
+    is => 'Command::V2',
+    has_input => [
+       analysis_projects  => {
+            is                  => 'Genome::Config::AnalysisProject',
+            doc                 => 'the analysis projects to complete',
+            is_many             => 1,
+            shell_args_position => 1,
+            require_user_verify => 1,
+        }
+    ],
+};
+
+sub help_brief {
+    return 'uncomplete this analysis project';
+}
+
+sub help_synopsis {
+    return "genome config analysis-project uncomplete <analysis-projects>";
+}
+
+sub help_detail {
+    return <<"EOS"
+Given some analysis projects you created, this will revert them to "In Progress" from a completed state.
+EOS
+}
+
+sub execute {
+    my $self = shift;
+
+    for my $ap ($self->analysis_projects) {
+        $ap->status('In Progress');
+        $self->status_message("Reverted AnP to 'In Progress': %s", $ap->__display_name__);
+    }
+
+    return 1;
+}
+
+sub __errors__ {
+    my $self = shift;
+    my @errors = $self->SUPER::__errors__(@_);
+    for my $anp ($self->analysis_projects) {
+        unless($anp->status eq "Completed"){
+            push @errors, UR::Object::Tag->create(
+                type => 'error',
+                properties => ['analysis_projects'],
+                desc => 'Cannot process incomplete analysis project ' . $anp->id,
+            );
+        }
+        unless($anp->created_by eq Genome::Sys->username){
+            push @errors, UR::Object::Tag->create(
+                type => 'error',
+                properties => ['analysis_projects'],
+                desc => 'Cannot process analysis project created by someone else: ' . $anp->id,
+            );
+        }
+    }
+    return @errors;
+}
+
+1;

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Uncomplete.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Uncomplete.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+use Test::More tests => 6;
+
+my $class = 'Genome::Config::AnalysisProject::Command::Uncomplete';
+use_ok($class);
+
+my $ap = Genome::Config::AnalysisProject->create(
+    name => 'Test Project',
+    status => 'Completed',
+);
+is($ap->status, 'Completed', "AnP status is 'In Progress'");
+
+my $cmd = $class->execute(analysis_projects => [$ap]);
+ok($cmd->result, 'execute cmd');
+my $expected_status = 'In Progress';
+is($ap->status, $expected_status, "AnP status set to '$expected_status'");
+
+my $other_ap = Genome::Config::AnalysisProject->create(
+    name => 'Test Project',
+    status => 'Completed',
+);
+$other_ap->created_by('nobody');
+
+my $cmd2 = $class->create(analysis_projects => [$other_ap]);
+isa_ok($cmd2, $class, 'created command');
+my @errors = $cmd2->__errors__;
+is(scalar(@errors), 1, 'found an error');
+
+done_testing();


### PR DESCRIPTION
* Only take non-CLE projects.
* Only "uncomplete" projects that you've created or taken.