### PR TITLE
Analysis Projects Require Environment Specifications

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
@@ -17,8 +17,8 @@ class Genome::Config::AnalysisProject::Command::Create {
         },
         environment => {
             is => 'Text',
-            valid_values => ['cle', 'production', 'ad-hoc'],
-            doc => 'The environment in which the analysis will be run. "cle" is for CLIA-related analysis, "production" for analysis of production sequence, and "ad-hoc" for any other analysis',
+            valid_values => ['cle', 'prod-builder', 'ad-hoc'],
+            doc => 'The environment in which the analysis will be run. "cle" is for CLIA-related analysis, "prod-builder" is for using production compute resources, and "ad-hoc" for any other analysis',
         },
         no_config => {
             is => 'Boolean',
@@ -98,7 +98,7 @@ sub _resolve_properties_for_environment {
                 is_cle => 1,
             );
         }
-        when ('production') {
+        when ('prod-builder') {
             return (
                 run_as => 'prod-builder',
                 is_cle => 0,

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Create.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Create.t
@@ -17,7 +17,7 @@ use_ok('Genome::Config::AnalysisProject::Command::Create');
 
 my $cmd = Genome::Config::AnalysisProject::Command::Create->create(
     name => 'test proj',
-    environment => 'production',
+    environment => 'prod-builder',
 );
 ok($cmd, 'constructed create command');
 isa_ok($cmd, 'Genome::Config::AnalysisProject::Command::Create');

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Release.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Release.pm
@@ -56,7 +56,17 @@ sub __errors__ {
                 desc => "Can't release analysis project " . $anp->__display_name__ . " with status: $status"
             );
         }
+
+        my $config = $anp->environment_config_dir;
+        unless ($config) {
+            push @errors, UR::Object::Tag->create(
+                type => 'error',
+                properties => ['analysis_projects'],
+                desc => "Can't release analysis project " . $anp->__display_name__ . " until an environment configuration has been set.",
+            );
+        }
     }
+
     return @errors;
 }
 

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Release.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Release.pm
@@ -46,12 +46,14 @@ sub execute {
 sub __errors__ {
     my $self = shift;
     my @errors = $self->SUPER::__errors__(@_);
-    for my $status (map{$_->status} $self->analysis_projects){
+
+    for my $anp ($self->analysis_projects) {
+        my $status = $anp->status;
         unless(grep{$_ eq $status} ("Pending", "Hold", "In Progress")){
             push @errors, UR::Object::Tag->create(
                 type => 'error',
                 properties => ['analysis_projects'],
-                desc => "Can't release analysis project with status: $status"
+                desc => "Can't release analysis project " . $anp->__display_name__ . " with status: $status"
             );
         }
     }

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Release.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Release.t
@@ -10,6 +10,9 @@ BEGIN {
 use above 'Genome';
 use Test::More tests => 5;
 
+use File::Spec;
+use Genome::Test::Factory::DiskAllocation;
+
 my $class = 'Genome::Config::AnalysisProject::Command::Release';
 use_ok($class);
 
@@ -17,6 +20,11 @@ my $ap = Genome::Config::AnalysisProject->create(
     name => 'Test Project',
     status => 'Hold',
 );
+
+use Genome::Config;
+my $da = Genome::Test::Factory::DiskAllocation->setup_object(owner => $ap);
+Genome::Sys->create_directory(File::Spec->join($da->absolute_path, Genome::Config::config_subpath));
+
 is($ap->status, 'Hold', "AnP status is 'Hold'");
 
 my $cmd = $class->execute(analysis_projects => [$ap]);


### PR DESCRIPTION
* Rename the "production" option in create to "prod-builder".
* Only allow an Analysis Project to be released if it has an environment configuration specified.

This PR doesn't enforce the contents of the environment configuration in any way.