### PR TITLE
Escape Sample Name Used as Filename in bam-readcounts

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfBase.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfBase.pm
@@ -7,7 +7,8 @@ use Genome;
 use Carp;
 use Data::Dumper;
 use Genome::Utility::Vcf ('parse_vcf_line', 'deparse_vcf_line', 'get_samples_from_header');
-
+use Genome::Utility::Text;
+use File::Spec;
 
 class Genome::Model::Tools::DetectVariants2::Filter::FalsePositiveVcfBase {
     is => 'Genome::Model::Tools::DetectVariants2::Filter::FalsePositive',
@@ -592,7 +593,10 @@ sub add_per_bam_params_to_input {
         my $bam_path = shift @$bam_paths;
 
         $self->debug_message("Running BAM Readcounts for sample $sample_name...");
-        my $readcount_file = $self->_temp_staging_directory . "/$sample_name.readcounts";  #this is suboptimal, but I want to wait until someone tells me a better way...multiple options exist
+        my $readcount_file = File::Spec->join(
+            $self->_temp_staging_directory,
+            Genome::Utility::Text::sanitize_string_for_filesystem("$sample_name.readcounts"),
+        );
         if (-f $bam_path) {
             $inputs{"bam_${sample_name}"} = $bam_path;
         } else {

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfBase.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfBase.pm
@@ -592,16 +592,17 @@ sub add_per_bam_params_to_input {
     for my $sample_name (@$sample_names) {
         my $bam_path = shift @$bam_paths;
 
-        $self->debug_message("Running BAM Readcounts for sample $sample_name...");
-        my $readcount_file = File::Spec->join(
-            $self->_temp_staging_directory,
-            Genome::Utility::Text::sanitize_string_for_filesystem("$sample_name.readcounts"),
-        );
         if (-f $bam_path) {
             $inputs{"bam_${sample_name}"} = $bam_path;
         } else {
             die "bam_file does not exist: $bam_path";
         }
+
+        $self->debug_message("Running BAM Readcounts for sample $sample_name...");
+        my $readcount_file = File::Spec->join(
+            $self->_temp_staging_directory,
+            Genome::Utility::Text::sanitize_string_for_filesystem("$sample_name.readcounts"),
+        );
         $inputs{"readcounts_${sample_name}"} = $readcount_file;
     }
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfBase.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfBase.pm
@@ -694,7 +694,6 @@ sub region_path {
 
 ##########################################################################################
 # Capture filter for high-depth, lower-breadth datasets
-# Contact: Dan Koboldt (dkoboldt@genome.wustl.edu)
 ##########################################################################################
 sub _filter_variants {
     my $self = shift;


### PR DESCRIPTION
A `/` came up in a sample name, which was causing trouble!