### PR TITLE
Remove all trailing slashes from host-groups... not just one!

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwa.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwa.pm
@@ -51,7 +51,7 @@ sub required_rusage {
         $host_groups = '';
     }
     else {
-        $host_groups =~ s/\/\s+/\ /;
+        $host_groups =~ s/\/\s+/\ /g;
         $host_groups =~ s/^HOSTS:\s+//;
         $host_groups =~ s/\+\d+//g;
     }

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.pm
@@ -43,7 +43,7 @@ sub required_rusage {
 
     my $host_groups;
     $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
-    $host_groups =~ s/\/\s+/\ /;
+    $host_groups =~ s/\/\s+/\ /g;
     $host_groups =~ s/^HOSTS:\s+//;
     $host_groups =~ s/\+\d+//g;
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/BwamemStream.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/BwamemStream.pm
@@ -46,7 +46,7 @@ sub required_rusage {
 
     my $host_groups;
     $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
-    $host_groups =~ s/\/\s+/\ /;
+    $host_groups =~ s/\/\s+/\ /g;
     $host_groups =~ s/^HOSTS:\s+//;
     $host_groups =~ s/\+\d+//g;
 


### PR DESCRIPTION
Tests started failing here due to a change in the host string being returned in production.  This is likely to cause real alignment failures as well...