### PR TITLE
Fixing problems with rsID annotation code

### DIFF
--- a/lib/perl/Genome/Model/Tools/Annotate/AddRsid.pm
+++ b/lib/perl/Genome/Model/Tools/Annotate/AddRsid.pm
@@ -92,11 +92,12 @@ sub execute {
             my @var_alleles = @tmp1;
             @var_alleles = @tmp2 if (scalar(@tmp2) > scalar(@tmp1));
 
+            # Script not designed to handle indels, ignores them if present
             my $is_indel = 0;
             for (@var_alleles) {
-                $is_indel = 1 if scalar($_) > 1;
+                $is_indel = 1 if length($_) > 1;
             }
-            if (scalar($ref) > 1 || $is_indel == 1) {
+            if (length($ref) > 1 || $is_indel == 1) {
                 next;
             }
 
@@ -205,12 +206,15 @@ sub print_annotation{
             next;
         }
 
-        my ($chr, $pos, $var) = (split(/\t/, $line))[0, 1, 4];
+        my ($chr, $pos, $ref, $var) = (split(/\t/, $line))[0, 1, 3, 4];
         my $key = RSid_key($chr, $pos);
 
         my $suffix = "-\t-";
-        if(defined($vcf_vals->{$key}->{$var})){
-            $suffix = $vcf_vals->{$key}->{$var}->{"rsID"} . "\t" . $vcf_vals->{$key}->{$var}->{"GMAF"};
+
+        unless($ref eq "-" || $var eq "-" ) {       # Indels are not handled correctly so ignores them
+            if(defined($vcf_vals->{$key}->{$var})){
+                $suffix = $vcf_vals->{$key}->{$var}->{"rsID"} . "\t" . $vcf_vals->{$key}->{$var}->{"GMAF"};
+            }
         }
         print $output_fh $line . "\t" . $suffix . "\n";
 

--- a/lib/perl/Genome/Model/Tools/Annotate/AddRsid.pm
+++ b/lib/perl/Genome/Model/Tools/Annotate/AddRsid.pm
@@ -91,7 +91,6 @@ sub execute {
             @var_alleles = @tmp2 if (scalar(@tmp2) > scalar(@tmp1));
 
             my @dbSNPids = split_dbSNPBuildID($INFO);
-            my $RSid_var_allele;
 
             if($file_format eq "CAF") {
                 # Gets the list of allele frequencies if CAF nomenclature is used
@@ -115,7 +114,7 @@ sub execute {
                         }   
                     }
 
-                    $RSid_var_allele = $var_alleles[$i];
+                    my $RSid_var_allele = $var_alleles[$i];
                     unless($RSid_var_allele){
                         $self->warning_message("RDis_var_allele undefined, i: $i, var_alleles: @var_alleles");
                     }
@@ -132,7 +131,7 @@ sub execute {
 
                     next unless $dbSNPids[$i] =~ /^\d+$/;
 
-                    $RSid_var_allele = $var_alleles[$i];
+                    my $RSid_var_allele = $var_alleles[$i];
                     unless($RSid_var_allele){
                         $self->warning_message("RDis_var_allele undefined, i: $i, var_alleles: @var_alleles");
                     }

--- a/lib/perl/Genome/Model/Tools/Validation/ProcessSomaticValidation.pm
+++ b/lib/perl/Genome/Model/Tools/Validation/ProcessSomaticValidation.pm
@@ -1089,7 +1089,7 @@ sub execute {
 
       if($line =~ /^chrom/){
           print OUTFILE $line . "\tstatus\n";
-          $headerAdded=0;
+          $headerAdded=1;
           next;
       }
       print OUTFILE2 join("\t",(@F,$indel_type)) . "\n";


### PR DESCRIPTION
Allows for the use of both older-style dbSNP VCFs that use the GMAF convention and newer ones with CAF convention. 

In both cases, we are now also ignoring indels. This code was never designed to annotate indels. 

The older versions also often provide the incorrect allele frequency because the minor allele is actually the reference allele and only 1 AF is provided in GMAF-style VCFs. It is definitely advisable to use the CAF versions. Just a warning in case anyone else ever sees this.