### PR TITLE
Stop Validating Disk Groups

### DIFF
--- a/lib/perl/Genome/Disk/Group.pm
+++ b/lib/perl/Genome/Disk/Group.pm
@@ -96,49 +96,6 @@ class Genome::Disk::Group {
     doc => "Represents a disk group (eg, " . Genome::Config::get('disk_group_dev') . "), which contains any number of disk volumes",
 };
 
-
-sub create {
-    my $class = shift;
-    my $self = $class->SUPER::create(@_);
-
-    if (defined($self)) {
-        $self->validate;
-    }
-
-    return $self;
-}
-
-sub get {
-    my $class = shift;
-    if (wantarray) {
-        return $class->_get_many(@_);
-    } else {
-        return $class->_get_single(@_);
-    }
-}
-
-sub _get_many {
-    my $class = shift;
-
-    my @objs = $class->SUPER::get(@_);
-    for my $obj (@objs) {
-        $obj->validate;
-    }
-
-    return @objs;
-}
-
-sub _get_single {
-    my $class = shift;
-
-    my $self = $class->SUPER::get(@_);
-    if (defined($self)) {
-        $self->validate;
-    }
-
-    return $self;
-}
-
 sub validate {
     my $self = shift;
     my @validators = findsubmod Genome::Disk::Group::Validate;

--- a/lib/perl/Genome/Site/TGI/SiteLib/Genome/Disk/Group/Validate/GenomeDiskGroups.pm
+++ b/lib/perl/Genome/Site/TGI/SiteLib/Genome/Disk/Group/Validate/GenomeDiskGroups.pm
@@ -6,6 +6,8 @@ use warnings;
 use Carp qw(croak);
 use List::MoreUtils qw(any uniq);
 
+use Try::Tiny qw(try);
+
 sub validate {
     my $class = shift;
     my $disk_group = shift;
@@ -53,12 +55,16 @@ sub genome_disk_group_names {
         'info_genome_models',
         'info_alignments',
         'apipe_ci',
-        Genome::Config::get('disk_group_archive'),
-        Genome::Config::get('disk_group_dev'),
-        Genome::Config::get('disk_group_references'),
-        Genome::Config::get('disk_group_alignments'),
-        Genome::Config::get('disk_group_models'),
-        Genome::Config::get('disk_group_research'),
+        grep { defined $_ }
+            map { try { Genome::Config::get($_) } }
+            (
+                qw(disk_group_archive
+                disk_group_dev
+                disk_group_references
+                disk_group_alignments
+                disk_group_models
+                disk_group_research)
+            )
     );
 }
 


### PR DESCRIPTION
There is currently a problem where loading a disk group reads all of the config, which triggers an error when that config is unset.  Unfortunately that config is read while trying to set a new config file.

Either of these changes would solve the problem: the first, by no longer requiring that a disk group "validates" before loading it; the second, by ignoring errors for unset configurations.