### PR TITLE
Compatibility fixes for running with newer versions of third-party modules.

### DIFF
--- a/lib/perl/Genome/Carp-mimic.t
+++ b/lib/perl/Genome/Carp-mimic.t
@@ -31,7 +31,8 @@ is($croakf_message, $croak_message, 'croakf matches croak');
 my ($die_message, $dief_message) = map {
     exception { $_->() }
 } (sub { Caller::do_die(sprintf($template, @args)) }, sub { Caller::do_dief($template, @args) });
-{ # die/warn end the message with a period
+if ($dief_message !~ /\.\n$/) {
+    # die/warn end the message with a period, but earlier versions of Carp::croak did not.
     chomp $dief_message;
     $dief_message .= ".\n";
 }

--- a/lib/perl/Genome/Command/Crud.t
+++ b/lib/perl/Genome/Command/Crud.t
@@ -154,10 +154,10 @@ like($help_text,
     qr(USAGE\s+person create),
     'Person Create help header');
 like($help_text,
-    qr(REQUIRED PARAMS\s+name\s+Name of the person\s+title\s+Title),
+    qr(REQUIRED PARAMS(?:\s+name\s+Name of the person|\s+title\s+Title){2}),
     'Person Create help required params');
 like($help_text,
-    qr(OPTIONAL PARAMS\s+mom\s+The person's Mom\s+friends\s+Friends of this person\s+best-friend\s+Best friend of this person\s+has-pets\s+Does this person have pets\?.*?job\s+The person's job)s,
+    qr(OPTIONAL PARAMS(?:\s+mom\s+The person's Mom|\s+friends\s+Friends of this person|\s+best-friend\s+Best friend of this person|\s+has-pets\s+Does this person have pets\?.*?|\s+job\s+The person's job){5})s,
     'Person Create help optional params');
 like($help_text,
     qr(DESCRIPTION\s+This command creates a person\.),

--- a/lib/perl/Genome/ConfigValidator/Numeric.t
+++ b/lib/perl/Genome/ConfigValidator/Numeric.t
@@ -16,7 +16,13 @@ my @tests = (
     ['123 abc', 0],
 );
 for my $test (@tests) {
-    my ($value, $expected) = @{$test};
-    my $message = sprintf(q('%s' should %s check), $value, ($expected ? 'pass' : 'fail'));
-    is($validator->check($value), $expected, $message);
+    my ($value, $expected_to_validate) = @{$test};
+    my $message = sprintf(q('%s' should %s check), $value, ($expected_to_validate ? 'pass' : 'fail'));
+
+    my $validates = $validator->check($value);
+    if ($expected_to_validate) {
+        ok($validates, $message);
+    } else {
+        ok(!$validates, $message);
+    }
 }

--- a/lib/perl/Genome/FeatureList.t
+++ b/lib/perl/Genome/FeatureList.t
@@ -109,7 +109,7 @@ my $single_track_bed = $feature_list_2->get_target_track_only('target_region');
 my $expected_single_track_bed = File::Spec->join($test_dir, "single_track_of_multi_track.bed");
 compare_ok($single_track_bed, $expected_single_track_bed, name => "get_target_track_only returned the expected file");
 
-dies_ok {$feature_list_2->get_target_track_only('does not exist')}, "get_target_track_only dies when provided with a bad track name";
+dies_ok sub {$feature_list_2->get_target_track_only('does not exist')}, "get_target_track_only dies when provided with a bad track name";
 
 my $feature_list_3 = Genome::FeatureList->create(
     name => 'GFL test unknown format feature-list',
@@ -127,7 +127,7 @@ my $processed_bed_file;
 eval{$processed_bed_file = $feature_list_3->processed_bed_file};
 ok(!$processed_bed_file, 'attempt to process bed file did not return a bed file');
 
-lives_ok {$feature_list_3->_check_bed_list_is_on_correct_reference}, "_check_bed_list_is_on_correct_reference worked";
+lives_ok sub {$feature_list_3->_check_bed_list_is_on_correct_reference}, "_check_bed_list_is_on_correct_reference worked";
 
 is_deeply([$feature_list_2->chromosome_list],[qw(1 2 X)], "list_chromosomes returns the expected list");
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bsmap.pm
@@ -77,7 +77,7 @@ sub _run_aligner {
     # This is (another) temporary directory. The difference between this and the scratch directory is that
     # this is blown away between calls of _run_aligner when running in force_fragment mode, while
     # the scratch directory will stick around.
-    my $temporary_directory = File::Temp->tempdir("_run_aligner_XXXXX", DIR => $scratch_directory);
+    my $temporary_directory = File::Temp::tempdir("_run_aligner_XXXXX", DIR => $scratch_directory);
 
     # This is the alignment output directory.  Whatever you put here will be synced up to the
     # final alignment directory that gets a disk allocation.

--- a/lib/perl/Genome/InstrumentData/Imported/View/Solr/Xml.t
+++ b/lib/perl/Genome/InstrumentData/Imported/View/Solr/Xml.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
 use above 'Genome';
 use Test::More tests => 2;
 

--- a/lib/perl/Genome/InstrumentData/Solexa/View/Solr/Xml.t
+++ b/lib/perl/Genome/InstrumentData/Solexa/View/Solr/Xml.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
 use above 'Genome';
 use Test::More tests => 2;
 

--- a/lib/perl/Genome/Library/View/Solr/Xml.t
+++ b/lib/perl/Genome/Library/View/Solr/Xml.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
 use above 'Genome';
 use Test::More tests => 2;
 

--- a/lib/perl/Genome/Logger.t
+++ b/lib/perl/Genome/Logger.t
@@ -6,6 +6,8 @@ use Test::Fatal qw(exception);
 
 use Memoize qw();
 
+use above 'Genome';
+
 use_ok('Genome::Logger');
 
 subtest 'non-color screen' => sub {

--- a/lib/perl/Genome/Model/Build/View/Solr/Xml.t
+++ b/lib/perl/Genome/Model/Build/View/Solr/Xml.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
 use above 'Genome';
 use Test::More tests => 2;
 

--- a/lib/perl/Genome/Model/View/Solr/Xml.t
+++ b/lib/perl/Genome/Model/View/Solr/Xml.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
 use above 'Genome';
 use Test::More tests => 2;
 

--- a/lib/perl/Genome/ModelGroup/View/Solr/Xml.t
+++ b/lib/perl/Genome/ModelGroup/View/Solr/Xml.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
 use above 'Genome';
 use Test::More tests => 2;
 

--- a/lib/perl/Genome/Role/Logger.pm
+++ b/lib/perl/Genome/Role/Logger.pm
@@ -14,7 +14,11 @@ use Module::Runtime qw(module_notional_filename use_package_optimistically);
 
 my @log_levels;
 BEGIN {
-    @log_levels = keys %Log::Dispatch::LEVELS;
+    @log_levels = keys %Log::Dispatch::CanonicalLevelNames;
+    unless (@log_levels) {
+        #older versions stored this differently
+        @log_levels = keys %Log::Dispatch::LEVELS;
+    }
 }
 
 role Genome::Role::Logger {

--- a/lib/perl/Genome/Sample/View/Solr/Xml.t
+++ b/lib/perl/Genome/Sample/View/Solr/Xml.t
@@ -3,6 +3,10 @@
 use strict;
 use warnings;
 
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
 use above 'Genome';
 use Test::More tests => 2;
 


### PR DESCRIPTION
* Handle newer versions of `Log::Dispatch`, `Carp`, and `Scalar::Util`.
* More consistent test results by using `above` and setting no commit.
* Looser matching of expected help text in test.