### PR TITLE
Fix an error_rate bug

### DIFF
--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignmentStatsSummary.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignmentStatsSummary.pm
@@ -231,13 +231,13 @@ sub _alignment_metrics_from_result {
 sub _get_error_rate_avg {
     my ($self, $qc_result) = @_;
     my %result_metrics = $qc_result->get_unflattened_metrics;
-    my ($read_1_pct_mismatch, $read_2_pct_mismatch) = ($result_metrics{FIRST_OF_PAIR}->{PF_MISMATCH_RATE}, $result_metrics{SECOND_OF_PAIR}->{PF_MISMATCH_RATE});
+    my ($read_1_mismatch_rate, $read_2_mismatch_rate) = ($result_metrics{FIRST_OF_PAIR}->{PF_MISMATCH_RATE}, $result_metrics{SECOND_OF_PAIR}->{PF_MISMATCH_RATE});
 
-    if (defined $read_1_pct_mismatch and defined $read_2_pct_mismatch) {
-        return ($read_1_pct_mismatch + $read_2_pct_mismatch)/2;
+    if (defined $read_1_mismatch_rate and defined $read_2_mismatch_rate) {
+        return ($read_1_mismatch_rate + $read_2_mismatch_rate)/2;
     }
-    elsif (defined $read_1_pct_mismatch or defined $read_2_pct_mismatch) {
-        return defined $read_1_pct_mismatch ? $read_1_pct_mismatch : $read_2_pct_mismatch;
+    elsif (defined $read_1_mismatch_rate or defined $read_2_mismatch_rate) {
+        return defined $read_1_mismatch_rate ? $read_1_mismatch_rate : $read_2_mismatch_rate;
     }
     else {
         return;

--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignmentStatsSummary.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignmentStatsSummary.pm
@@ -153,7 +153,7 @@ sub _alignment_metrics_from_result {
             if (@QC_results == 1) {
                 my $error_rate_avg = $self->_get_error_rate_avg($QC_results[0]);
                 if ($error_rate_avg) {
-                    $mismatches += $lane->total_base_count * $error_rate_avg / 100;
+                    $mismatches += $lane->total_base_count * $error_rate_avg;
                 }
                 else {
                     $self->warning_message('Fail to get any PF_MISMATCH_RATE for QC_result '.$QC_results[0]->id);

--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignmentStatsSummary.t
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignmentStatsSummary.t
@@ -110,7 +110,7 @@ my $expected_metrics = {
         'Total Unique Mapped Bases' => "-20",
         'Aligned %' => "94.82",
         'Unique %' => "94.28",
-        'Error Rate' => "0.04",
+        'Error Rate' => "4.00",
         'Total # Reads' => "4688",
         '%pairs mapping across chromosomes' => "1.64",
 };


### PR DESCRIPTION
PF_MISMATCH_RATE from picard is the rate not percentage. read_1/2_pct_mismatch = PF_MISMATCH_RATE * 100.