### PR TITLE
Use simpler means of validating LSF queue.

### DIFF
--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -159,13 +159,8 @@ sub _args_spec {
 sub _valid_lsf_queue {
     my $requested_queue = shift;
 
-    return any { $requested_queue eq $_ } _queues();
-}
-
-sub _queues {
-    my @output = Genome::Sys->capture('bqueues', '-l');
-    my @queues = map { (/^QUEUE:\s+(\S+)/)[0] } @output;
-    return @queues;
+    system(qq(bqueues $requested_queue 1> /dev/null 2>&1));
+    return $? == 0;
 }
 
 1;


### PR DESCRIPTION
Idea borrowed from `Genome::ConfigValidator::LSFQueue`.  That module cannot "use Genome;" so can't be changed to refer to this version instead.

Why change this?  The old version is causing segfaults sometimes.