### PR TITLE
For the local cache to be usable, it must be a directory.

### DIFF
--- a/lib/perl/Genome/Model/Build/ReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence.pm
@@ -651,7 +651,7 @@ sub chromosome_array_ref {
 sub cached_full_consensus_path {
     my ($self, $format) = @_;
 
-    unless ($self->local_cache_basedir and -e $self->local_cache_basedir) {
+    unless ($self->local_cache_basedir and -d $self->local_cache_basedir) {
         $self->status_message('Using original full consensus path.');
 
         return $self->full_consensus_path($format);


### PR DESCRIPTION
Say, for example, someone sets this to `/dev/null` to turn off caching.  It'd be better if it didn't try to `mkdir /dev/null/foo`!