### PR TITLE
Add "GMAF=" before value when parsing CAFs

### DIFF
--- a/lib/perl/Genome/Model/Tools/Annotate/AddRsid.pm
+++ b/lib/perl/Genome/Model/Tools/Annotate/AddRsid.pm
@@ -126,6 +126,10 @@ sub execute {
                         }
                     }
 
+                    unless ($GMAF eq '-') {
+                        $GMAF = "GMAF=$GMAF";
+                    }
+
                     my $RSid_var_allele = $var_alleles[$i];
                     unless($RSid_var_allele){
                         $self->warning_message("RDis_var_allele undefined, i: $i, var_alleles: @var_alleles");

--- a/lib/perl/Genome/Model/Tools/Annotate/AddRsid.pm
+++ b/lib/perl/Genome/Model/Tools/Annotate/AddRsid.pm
@@ -118,6 +118,7 @@ sub execute {
                         $GMAF = $af[$i];
                         unless($GMAF){
                             $self->warning_message("CAF undefined for allele, i: $i, CAF values undefined: $caf_string, non-reference AFs: @af");
+                            $GMAF = '-';
                         }
                         # Empty allele frequencies are designated with a . instead of our convention - 
                         if($GMAF eq '.'){


### PR DESCRIPTION
The downstream steps expect GMAFs to be stored as `GMAF=$value` in the AddRsid bed file output.