### PR TITLE
Use the same criteria for checking available disk as would to allocate.

### DIFF
--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -129,19 +129,19 @@ sub candidate_volumes_without_mount_path {
     if (defined $exclude_mount_path) {
         $candidate_volume_params{'exclude'} = $exclude_mount_path;
     }
-    return $self->_get_candidate_volumes(
+    return $self->get_candidate_volumes(
         %candidate_volume_params);
 }
 
 # Returns a list of volumes that meets the given criteria
-sub _get_candidate_volumes {
-    my ($self, %params) = @_;
+sub get_candidate_volumes {
+    my ($class, %params) = @_;
 
     my $disk_group_name = delete $params{disk_group_name};
     my $exclude = delete $params{exclude};
 
     if (%params) {
-        confess "Illegal arguments to _get_candidate_volumes: "
+        confess "Illegal arguments to get_candidate_volumes: "
             . join(', ', keys %params);
     }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult.pm
@@ -533,7 +533,7 @@ sub _create_disk_allocation {
     my $estimated_kb_usage = $self->estimated_kb_usage;
     $self->debug_message("Estimated disk for this data set: " . $estimated_kb_usage . " kb");
     $self->debug_message("Check for available disk...");
-    my @available_volumes = Genome::Disk::Volume->get(disk_group_names => Genome::Config::get('disk_group_alignments'));
+    my @available_volumes = Genome::Disk::Detail::Allocation::Creator->get_candidate_volumes(disk_group_name => Genome::Config::get('disk_group_alignments'));
     $self->debug_message("Found " . scalar(@available_volumes) . " disk volumes");
     my $unallocated_kb = 0;
     for my $volume (@available_volumes) {

--- a/lib/perl/Genome/InstrumentData/IntermediateAlignmentResult.pm
+++ b/lib/perl/Genome/InstrumentData/IntermediateAlignmentResult.pm
@@ -176,7 +176,7 @@ sub verify_disk_space {
     my $estimated_kb_usage = $self->estimated_kb_usage;
     $self->debug_message("Estimated disk for this data set: " . $estimated_kb_usage . " kb");
     $self->debug_message("Check for available disk...");
-    my @available_volumes = Genome::Disk::Volume->get(disk_group_names => Genome::Config::get('disk_group_alignments')); 
+    my @available_volumes = Genome::Disk::Detail::Allocation::Creator->get_candidate_volumes(disk_group_name => Genome::Config::get('disk_group_alignments'));
     $self->debug_message("Found " . scalar(@available_volumes) . " disk volumes");
     my $unallocated_kb = 0;
     for my $volume (@available_volumes) {


### PR DESCRIPTION
The check for avaialble disk was finding volumes that were not available to be used for allocations.  To prevent this, use the same method that creating an allocation uses.