### PR TITLE
Set SSG Test Names

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -610,6 +610,18 @@ sub _additional_associated_disk_allocations : Overrides(Genome::Role::ObjectWith
     return @allocations;
 }
 
+sub _disk_usage_result_subclass_names {
+    my $self = shift;
+
+    $self->fatal_message('Please define _disk_usage_result_subclass_names for build type \''. $self->class .'\'!');
+}
+
+sub disk_usage_results {
+    my $self = shift;
+
+    return $self->results(subclass_name => $self->_disk_usage_result_subclass_names);
+}
+
 sub disk_usage_allocations {
     my $self = shift;
 

--- a/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
+++ b/lib/perl/Genome/Model/Build/SingleSampleGenotype.pm
@@ -133,4 +133,16 @@ sub _compare_output_files {
     );
 }
 
+sub _disk_usage_result_subclass_names {
+    my $self = shift;
+
+    my @disk_usage_result_classes = (
+        'Genome::Qc::Result',
+        'Genome::InstrumentData::AlignmentResult::Speedseq',
+        'Genome::InstrumentData::AlignmentResult::Merged::Speedseq',
+        'Genome::Model::SingleSampleGenotype::Result::HaplotypeCaller',
+    );
+    return \@disk_usage_result_classes;
+}
+
 1;

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/SetTestName.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/SetTestName.pm
@@ -21,7 +21,7 @@ class Genome::Model::SingleSampleGenotype::Command::SetTestName {
         },
         abandon_builds => {
             is => 'Boolean',
-            doc => 'attempt to abando all of the builds used by these results',
+            doc => 'attempt to abandon all of the builds used by these results',
             default_value => 0,
         },
     },

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/SetTestName.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/SetTestName.pm
@@ -33,8 +33,8 @@ sub execute {
     my $result_classes_to_set_test_name = $self->_result_classes_to_set_test_name;
     my @results_to_set_test_name;
     for my $build ( $self->builds ) {
-        my @results = $build->results;
-        push @results_to_set_test_name, grep { $result_classes_to_set_test_name->{$_->class} } @results;
+        my @disk_usage_results = $build->disk_usage_results;
+        push @results_to_set_test_name, @disk_usage_results;
     }
     my $set_test_name_cmd = Genome::SoftwareResult::Command::SetTestName->create(
         software_results => \@results_to_set_test_name,
@@ -50,18 +50,5 @@ sub execute {
     return 1;
 }
 
-sub _result_classes_to_set_test_name {
-    my $self = shift;
-
-    my %result_class_status = (
-        'Genome::InstrumentData::AlignmentResult::Merged::Speedseq' => 1,
-        'Genome::InstrumentData::AlignmentResult::Speedseq' => 1,
-        'Genome::Qc::Result' => 1,
-        'Genome::Model::SingleSampleGenotype::Result::HaplotypeCaller' => 1,
-        'Genome::Model::Build::ReferenceSequence::AlignerIndex' => 0,
-        'Genome::Model::Build::ReferenceSequence::Buckets' => 0,
-    );
-    return \%result_class_status;
-}
 
 1;

--- a/lib/perl/Genome/Model/SingleSampleGenotype/Command/SetTestName.pm
+++ b/lib/perl/Genome/Model/SingleSampleGenotype/Command/SetTestName.pm
@@ -1,0 +1,67 @@
+package Genome::Model::SingleSampleGenotype::Command::SetTestName;
+
+use strict;
+use warnings;
+
+use Genome;
+
+use File::Spec;
+
+class Genome::Model::SingleSampleGenotype::Command::SetTestName {
+    is        => 'Command::V2',
+    doc       => 'Set a test name for all builds resolved',
+    has_input => {
+        builds => {
+            is      => "Genome::Model::Build::SingleSampleGenotype",
+            is_many => 1,
+        },
+        new_test_name => {
+            is  => 'String',
+            doc => 'The new test name string to set on all results'
+        },
+        abandon_builds => {
+            is => 'Boolean',
+            doc => 'attempt to abando all of the builds used by these results',
+            default_value => 0,
+        },
+    },
+};
+
+sub execute {
+    my $self = shift;
+
+    my $result_classes_to_set_test_name = $self->_result_classes_to_set_test_name;
+    my @results_to_set_test_name;
+    for my $build ( $self->builds ) {
+        my @results = $build->results;
+        push @results_to_set_test_name, grep { $result_classes_to_set_test_name->{$_->class} } @results;
+    }
+    my $set_test_name_cmd = Genome::SoftwareResult::Command::SetTestName->create(
+        software_results => \@results_to_set_test_name,
+        new_test_name => $self->new_test_name,
+        abandon_builds => $self->abandon_builds,
+    );
+    unless ($set_test_name_cmd) {
+        $self->fatal_message('Failed to create set test name command!');
+    }
+    unless ($set_test_name_cmd->execute) {
+        $self->fatal_message('Unable to execute set test name command for all build software results!');
+    }
+    return 1;
+}
+
+sub _result_classes_to_set_test_name {
+    my $self = shift;
+
+    my %result_class_status = (
+        'Genome::InstrumentData::AlignmentResult::Merged::Speedseq' => 1,
+        'Genome::InstrumentData::AlignmentResult::Speedseq' => 1,
+        'Genome::Qc::Result' => 1,
+        'Genome::Model::SingleSampleGenotype::Result::HaplotypeCaller' => 1,
+        'Genome::Model::Build::ReferenceSequence::AlignerIndex' => 0,
+        'Genome::Model::Build::ReferenceSequence::Buckets' => 0,
+    );
+    return \%result_class_status;
+}
+
+1;

--- a/lib/perl/Genome/SoftwareResult/Command/SetTestName.pm
+++ b/lib/perl/Genome/SoftwareResult/Command/SetTestName.pm
@@ -63,7 +63,7 @@ sub execute {
         my $abandon_cmd = Genome::Model::Build::Command::Abandon->create(
             builds => \@builds,
             header_text => 'Build Abandoned - SR Test Name',
-            body_text => 'Software result '. $software_result->id .' has new test name '. $self->new_test_name,
+            body_text => 'Software results have new test name '. $self->new_test_name,
         );
         unless ($abandon_cmd) {
             $self->fatal_message('Unable to create abandon builds command!');

--- a/lib/perl/Genome/SoftwareResult/Command/SetTestName.pm
+++ b/lib/perl/Genome/SoftwareResult/Command/SetTestName.pm
@@ -51,7 +51,7 @@ sub execute {
             my @builds = $software_result->builds;
             for my $build (@builds){
                 if (!exists($builds{$build->id})) {
-                    $builds{$build_>id} = $build;
+                    $builds{$build->id} = $build;
                 }
             }
         }

--- a/lib/perl/Genome/SoftwareResult/Command/SetTestName.pm
+++ b/lib/perl/Genome/SoftwareResult/Command/SetTestName.pm
@@ -31,6 +31,9 @@ sub execute {
     my $self = shift;
 
     my $new_test_name = $self->new_test_name;
+
+    my %builds;
+
     for my $software_result ($self->software_results) {
         my $sr_id = $software_result->id;
         $self->status_message(
@@ -46,19 +49,27 @@ sub execute {
         }
         if ($self->abandon_builds) {
             my @builds = $software_result->builds;
-            my @ids = map{$_->id} @builds;
-            $self->status_message('Abandoning builds: '. join(',',@ids));
-            my $abandon_cmd = Genome::Model::Build::Command::Abandon->create(
-                builds => \@builds,
-                header_text => 'Build Abandoned - SR Test Name',
-                body_text => 'Software result '. $software_result->id .' has new test name '. $self->new_test_name,
-            );
-            unless ($abandon_cmd) {
-                $self->fatal_message('Unable to create abandon builds command!');
+            for my $build (@builds){
+                if (!exists($builds{$build->id})) {
+                    $builds{$build_>id} = $build;
+                }
             }
-            unless ($abandon_cmd->execute) {
-                $self->fatal_messaage('Failed to execute abandon builds command!');
-            }
+        }
+    }
+    if ($self->abandon_builds) {
+        my @ids = keys %builds;
+        my @builds = values %builds;
+        $self->status_message('Abandoning builds: '. join(',',@ids));
+        my $abandon_cmd = Genome::Model::Build::Command::Abandon->create(
+            builds => \@builds,
+            header_text => 'Build Abandoned - SR Test Name',
+            body_text => 'Software result '. $software_result->id .' has new test name '. $self->new_test_name,
+        );
+        unless ($abandon_cmd) {
+            $self->fatal_message('Unable to create abandon builds command!');
+        }
+        unless ($abandon_cmd->execute) {
+            $self->fatal_messaage('Failed to execute abandon builds command!');
         }
     }
 


### PR DESCRIPTION
- a command to set test names on all SSG results (excluding aligner index, etc.)
- wait to abandon builds until we have a complete list and test names are set