### PR TITLE
Update blessed ClinSeq test build.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
@@ -1,7 +1,7 @@
 ---
 apipe-test-amplicon-assembly: 133133151
 apipe-test-clinseq-v1: 133114501
-apipe-test-clinseq-wer: 0bc8c6ff5d4c4fc0ae645335f738a29d
+apipe-test-clinseq-wer: 7aef823fb1a24ebeaa40a0c2d3873325
 apipe-test-de-novo-soap: 137388725
 apipe-test-de-novo-velvet: 79a406fcf18c46e090dec62342b2c4ae
 apipe-test-gene-prediction-bacterial: 4ddaecaa52364dd09b3a4d7709ddfc3b


### PR DESCRIPTION
The old samstat HTML for the tumor RnaSeq result is no longer available.  This updates the expected case to not include it.