### PR TITLE
Update the group_subdirectory to match our new location.

### DIFF
--- a/lib/perl/Genome/Disk/Detail/Allocation/Mover.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Mover.pm
@@ -113,6 +113,7 @@ sub move {
     # those files are deleted.
     my $old_mount_path = $allocation_object->mount_path;
     $allocation_object->mount_path($shadow_allocation->mount_path);
+    $allocation_object->group_subdirectory($shadow_allocation->group_subdirectory);
     $shadow_allocation->mount_path($old_mount_path);
 
     # This is here because certain objects (Build & SoftwareResult) don't


### PR DESCRIPTION
When we moved the allocation into place from the shadow allocation, we adopted its group_subdirectory, so be sure to save it into ourself!