### PR TITLE
Stop swallowing errors in Model create.

### DIFF
--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -477,7 +477,7 @@ sub create {
     }
 
     my $tx = UR::Context::Transaction->begin(commit_validator => sub { 1 });
-    my $guard = Scope::Guard->new(sub { $tx->rollback });
+    my $guard = Scope::Guard->new(sub { local $@; $tx->rollback });
 
     my $self = $class->SUPER::create($bx);
     unless ($self) {


### PR DESCRIPTION
The `Scope::Guard` was preventing the message from `Carp::confess` from making it to the user.