### PR TITLE
Fix genotype for pindelRegion vcf

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/PindelRegion.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/PindelRegion.t
@@ -26,7 +26,7 @@ my $ref_seq_build = Genome::Model::Build::ImportedReferenceSequence->get($refbui
 ok($ref_seq_build, 'human36 reference sequence build') or die;
 
 my $test_base_dir  = Genome::Utility::Test->data_dir($pkg);
-my ($test_input_dir, $test_out_dir) = map{File::Spec->join($test_base_dir, $_)}qw(input expected_2); 
+my ($test_input_dir, $test_out_dir) = map{File::Spec->join($test_base_dir, $_)}qw(input expected_3); 
 
 my $region_file = File::Spec->join($test_input_dir, 'region_file.bed');
 my $tumor       = File::Spec->join($test_input_dir, 'flank_tumor_sorted.bam');

--- a/lib/perl/Genome/Model/Tools/Vcf/Convert/Indel/PindelRegion.pm
+++ b/lib/perl/Genome/Model/Tools/Vcf/Convert/Indel/PindelRegion.pm
@@ -34,6 +34,13 @@ sub execute {
         }
         else {
             map{$entry->set_sample_field($_, 'FT', '.')}qw(0 1);
+            if ($entry->sample_field(1, 'GT') eq '0/0') {
+                my $ad_str = $entry->sample_field(1, 'AD');
+                my ($ref_ct, $var_ct) = split /,/, $ad_str;
+                if ($var_ct/($ref_ct + $var_ct) >= 0.01 and $var_ct >= 5) {
+                    $entry->set_sample_field(1, 'GT', '0/1');
+                }
+            }
         }
         $out_vcf->write($entry);
     }


### PR DESCRIPTION
Currently pindel2vcf has default 0.2 for --het-cutoff (genotype 0/1), which is too stringent for pindel-region detection sensitivity. We decided that GT should be set to 0/1 if VAF >= 0.01 and var_read_cout >= 5. Refer to CI-217.