### PR TITLE
Site: Avoid using `/vol/` paths as canonical.

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Detector.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Detector.pm
@@ -191,7 +191,7 @@ sub create {
 
     for my $input ('aligned_reads_input', 'control_aligned_reads_input') {
         if($self->$input) {
-            my $canonical_path = Cwd::abs_path($self->$input);
+            my $canonical_path = Genome::Sys->abs_path($self->$input);
             unless($canonical_path) {
                 die $self->error_message('Failed to resolve real path to ' . $input);
             }

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Dispatcher.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Dispatcher.pm
@@ -10,7 +10,6 @@ use Data::Dumper;
 use JSON;
 use File::Basename;
 use Path::Class;
-use Cwd qw();
 
 class Genome::Model::Tools::DetectVariants2::Dispatcher {
     is => ['Genome::Model::Tools::DetectVariants2::Base'],
@@ -1097,7 +1096,7 @@ sub _resolve_variant_file_full_path {
 
     my $file_base;
     if (-l $file_path) {
-        $file_path = Cwd::abs_path($file_path);
+        $file_path = Genome::Sys->abs_path($file_path);
         $file_base = basename($file_path);
     } else {
         $file_base = basename($file_path);

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Utilities.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Utilities.pm
@@ -4,7 +4,6 @@ use warnings;
 use strict;
 
 use Genome;
-use Cwd qw(abs_path);
 use File::Spec;
 use List::Util qw(first);
 use List::MoreUtils qw(any uniq);
@@ -55,7 +54,7 @@ sub final_result_for_variants_directory {
 
     my $file = first { -e $_ } (File::Spec->join($dir, "$variant_type.hq"), File::Spec->join($dir, "$variant_type.hq.bed"));
     if($file) {
-        my $abs_file = abs_path($file);
+        my $abs_file = Genome::Sys->abs_path($file);
         my $alloc = Genome::Disk::Allocation->get_allocation_for_path($abs_file);
         if($alloc) {
             my $owner = $alloc->owner;

--- a/lib/perl/Genome/Ptero/Wrapper.pm
+++ b/lib/perl/Genome/Ptero/Wrapper.pm
@@ -5,7 +5,6 @@ use warnings FATAL => qw(all);
 use Genome;
 use Data::Dump qw();
 use IO::Handle;
-use Cwd qw(abs_path);
 use Genome::Utility::Text qw(
     sanitize_string_for_filesystem
 );
@@ -97,7 +96,7 @@ sub _stdout_log_path {
     my $self = shift;
 
     my $base_name = $self->execution->name;
-    my $output_log = File::Spec->join(abs_path($self->log_directory),
+    my $output_log = File::Spec->join(Genome::Sys->abs_path($self->log_directory),
         sanitize_string_for_filesystem("$base_name.out"));
 }
 
@@ -105,7 +104,7 @@ sub _stderr_log_path {
     my $self = shift;
 
     my $base_name = $self->execution->name;
-    my $output_log = File::Spec->join(abs_path($self->log_directory),
+    my $output_log = File::Spec->join(Genome::Sys->abs_path($self->log_directory),
         sanitize_string_for_filesystem("$base_name.err"));
 }
 
@@ -153,7 +152,7 @@ sub _log_execution_information {
     $self->status_message("COMMAND: PTERO_WORKFLOW_EXECUTION_URL=%s %s " .
         "ptero wrapper --command-class=\"%s\" --method=\"%s\" --log-directory=\"%s\"",
         $ENV{PTERO_WORKFLOW_EXECUTION_URL}, $0,
-        $self->command_class, $self->method, abs_path($self->log_directory));
+        $self->command_class, $self->method, Genome::Sys->abs_path($self->log_directory));
 }
 
 sub _instantiate_command {

--- a/lib/perl/Genome/Site/TGI/Extension/Sys.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/Sys.pm
@@ -22,6 +22,7 @@ use File::Find;
 use Params::Validate qw(:types);
 use IO::Socket;
 use Sys::Hostname qw(hostname);
+use Cwd qw();
 #use Archive::Extract;
 
 require MIME::Lite;
@@ -425,6 +426,21 @@ sub open_file_for_overwriting {
 
     Carp::croak("Failed to open file ($file) for over write: $!");
 }
+
+no warnings qw(redefine);
+sub abs_path {
+    my ($self, $path) = @_;
+
+    my $abs_path = Cwd::abs_path($path);
+    return unless defined $abs_path;
+
+    if ($abs_path =~ m!^/vol/aggr\d+/!) {
+        $abs_path =~ s!^/vol/aggr\d+/(?:backup/)?!/gscmnt/!;
+    }
+
+    return $abs_path;
+}
+use warnings qw(redefine);
 
 sub copy_directory {
     my ($self, $source, $dest) = @_;

--- a/lib/perl/Genome/SoftwareResult.pm
+++ b/lib/perl/Genome/SoftwareResult.pm
@@ -6,7 +6,6 @@ use warnings;
 use Genome;
 use Genome::Sys::LockProxy qw();
 use Digest::MD5 qw(md5_hex);
-use Cwd;
 use File::Basename qw(fileparse);
 use Data::Dumper;
 use Date::Manip;
@@ -1018,7 +1017,7 @@ sub _resolve_param_value_from_text_by_name_or_id {
 
     #If that didn't work, and the argument is a filename, see if it's part of our output directory.
     if(!@results and -f $param_arg) {
-        my $abs_path = Cwd::abs_path($param_arg);
+        my $abs_path = Genome::Sys->abs_path($param_arg);
         my (undef, $dir) = fileparse($abs_path);
         $dir =~ s!/$!!; #remove trailing slash!
         @results = Genome::SoftwareResult->get(output_dir => $dir);

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -203,6 +203,12 @@ sub _can_write_to_directory {
     return 1;
 }
 
+sub abs_path {
+    my ($self, $path) = @_;
+
+    return Cwd::abs_path($path);
+}
+
 # MD5
 
 sub md5sum {


### PR DESCRIPTION
This is an attempt to keep `/vol/` paths out of our local database by un-resolving the `/gscmnt/` symlinks.