### PR TITLE
Disable DV2 filter test cases dependent on purged test data.

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcf.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcf.t
@@ -233,7 +233,8 @@ is_deeply(\@alleles, \@expected_alleles, "convert_numeric_gt_to_alleles works as
 # $filter_command->filter_one_line
 # $filter_command->filter_one_sample
 
-
+SKIP: {
+skip "test BAM not available", 3;
 ok($filter_command->execute(), 'executed filter command');
 
 ok(-s $output_vcf, "output vcf exists and has size"); 
@@ -244,4 +245,6 @@ my $test_text = `zcat $output_vcf | grep -v '^##fileDate'`;
 my $output_diff = Genome::Sys->diff_text_vs_text($expected_text, $test_text);
 ok(!$output_diff, 'output file matches expected result')
     or diag("diff:\n" . $output_diff);
+}
+
 done_testing();

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfDenovo.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/FalsePositiveVcfDenovo.t
@@ -218,7 +218,8 @@ is_deeply(\@alleles, \@expected_alleles, "convert_numeric_gt_to_alleles works as
 # $filter_command->filter_one_line
 # $filter_command->filter_one_sample
 
-
+SKIP: {
+skip "test BAM not available", 3;
 ok($filter_command->execute(), 'executed filter command');
 
 ok(-s $output_vcf, "output vcf exists and has size"); 
@@ -229,4 +230,5 @@ my $test_text = `zcat $output_vcf | grep -v '^##fileDate'`;
 my $output_diff = Genome::Sys->diff_text_vs_text($expected_text, $test_text);
 ok(!$output_diff, 'output file matches expected result')
     or diag("diff:\n" . $output_diff);
+}
 done_testing();

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/PolymuttDenovo.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Filter/PolymuttDenovo.t
@@ -95,6 +95,9 @@ my $filter_command = Genome::Model::Tools::DetectVariants2::Filter::PolymuttDeno
 );
 $filter_command->dump_status_messages(1);
 isa_ok($filter_command, 'Genome::Model::Tools::DetectVariants2::Filter::PolymuttDenovo', 'created filter command');
+
+SKIP: {
+skip "test BAM not available", 2;
 ok($filter_command->execute(), 'executed filter command');
 
 $DB::single=1;
@@ -106,3 +109,4 @@ my $test_text = `zcat $output_vcf | grep -v '^##fileDate'`;
 my $output_diff = Genome::Sys->diff_text_vs_text($expected_text, $test_text);
 #ok(!$output_diff, 'output file matches expected result')
 #    or diag("diff:\n" . $output_diff);
+}


### PR DESCRIPTION
Here are another few tests where test data was recently purged.