### PR TITLE
Draft CWL Pipeline type.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -9,6 +9,10 @@ class Genome::Model::CwlPipeline {
         main_workflow_file => {
             is => 'Text',
         },
+        primary_docker_image => {
+            is => 'Text',
+            doc => 'docker image for the main toil worker jobs',
+        },
     },
 };
 

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -3,6 +3,9 @@ package Genome::Model::CwlPipeline;
 use strict;
 use warnings;
 
+use feature qw(switch);
+use Genome;
+
 class Genome::Model::CwlPipeline {
     is => 'Genome::Model',
     has_param => {
@@ -50,5 +53,53 @@ sub _resolve_workflow_for_build {
 
     return $wf;
 }
+
+
+#handle specification of inputs such as might be found in an AnP Config YAML
+sub process_input_data {
+    my $self = shift;
+    my %data = @_;
+
+    for my $name (keys %data) {
+        my $value = $self->determine_input_object($name, $data{$name});
+        unless ($value) {
+            $self->fatal_message('Failed to determine input for name "%s" and value "%s".', $name, $data{$name});
+        }
+
+        $self->add_input(
+            name => $name,
+            value_id => $value->id,
+            value_class_name => $value->class,
+        );
+    }
+
+    return 1;
+}
+
+sub determine_input_object {
+    my $self = shift;
+    my $name = shift;
+    my $value_identifier = shift;
+
+    #This could use something like Command::Dispatch::Shell->resolve_param_value_from_text
+    #to allow for non-ID values
+    for ($name) {
+        when ('instrument_data')          {
+            return Genome::InstrumentData->get($value_identifier);
+        }
+        when ('reference_build')          {
+            return Genome::Model::Build::ReferenceSequence->get($value_identifier);
+        }
+        when ('annotation_build')         {
+            return Genome::Model::Build::ImportedAnnotation->get($value_identifier);
+        }
+        default                           {
+            return UR::Value::Text->get($value_identifier);
+        }
+    }
+
+    return;
+}
+
 
 1;

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -1,0 +1,50 @@
+package Genome::Model::CwlPipeline;
+
+use strict;
+use warnings;
+
+class Genome::Model::CwlPipeline {
+    is => 'Genome::Model',
+    has_param => {
+        main_workflow_file => {
+            is => 'Text',
+        },
+    },
+};
+
+sub map_workflow_inputs {
+    my $self = shift;
+    my $build = shift;
+
+    return (build => $build);
+}
+
+sub _resolve_workflow_for_build {
+    my $self = shift;
+    my $build = shift;
+
+    my $wf = Genome::WorkflowBuilder::DAG->create(
+        name => $build->workflow_name,
+        log_dir => $build->log_directory,
+    );
+
+    my $cmd = Genome::WorkflowBuilder::Command->create(
+        name => 'Toil Runner',
+        command => 'Genome::Model::CwlPipeline::Command::Run',
+    );
+    $wf->add_operation($cmd);
+    $wf->connect_input(
+        input_property => 'build',
+        destination => $cmd,
+        destination_property => 'build'
+    );
+    $wf->connect_output(
+        source => $cmd,
+        source_property => 'result',
+        output_property => 'result',
+    );
+
+    return $wf;
+}
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -37,6 +37,12 @@ sub create {
         $bx = $class->define_boolexpr($bx->params_list, %extra); #to throw errors for other extras
     }
 
+    unless ($inputs) {
+        return $class->SUPER::create(@_);
+    }
+
+    $bx = $bx->remove_filter('input_data');
+
     my $tx = UR::Context::Transaction->begin(commit_validator => sub { 1 });
     my $guard = Scope::Guard->new(sub { local $@; $tx->rollback });
 
@@ -62,6 +68,7 @@ sub get {
         $bx = $class->define_boolexpr($bx->params_list, %extra); #to throw errors for other extras
     }
 
+    $bx = $bx->remove_filter('input_data');
     my $input_info = $class->determine_input_objects(%$input_data);
     my @input_values = values %$input_info;
     for my $v (@input_values) {

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -33,10 +33,6 @@ sub create {
     my ($bx, %extra) = $class->define_boolexpr(@_);
 
     my $inputs = delete $extra{input_data};
-    if (%extra) {
-        $bx = $class->define_boolexpr($bx->params_list, %extra); #to throw errors for other extras
-    }
-
     unless ($inputs) {
         return $class->SUPER::create(@_);
     }
@@ -62,10 +58,6 @@ sub get {
     my $input_data = delete $extra{input_data};
     unless($input_data) {
         return $class->SUPER::get(@_);
-    }
-
-    if (%extra) {
-        $bx = $class->define_boolexpr($bx->params_list, %extra); #to throw errors for other extras
     }
 
     $bx = $bx->remove_filter('input_data');

--- a/lib/perl/Genome/Model/CwlPipeline.t
+++ b/lib/perl/Genome/Model/CwlPipeline.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+use Genome::Test::Factory::InstrumentData::Solexa;
+
+use Test::More tests => 5;
+
+my $class = 'Genome::Model::CwlPipeline';
+use_ok($class);
+
+my $instrument_data = Genome::Test::Factory::InstrumentData::Solexa->setup_object;
+
+my $pp = Genome::ProcessingProfile::CwlPipeline->__define__(id => -100);
+
+my $model = $class->create(
+    processing_profile_id => $pp->id,
+    subject => $instrument_data->sample,
+    input_data => {
+        instrument_data => [$instrument_data->id],
+        awesomeness     => 'lots',
+    },
+);
+isa_ok($model, $class, 'created model');
+
+my @inputs = $model->inputs;
+is(scalar(@inputs), 2, 'created inputs with model');
+
+my ($ii) = grep { $_->name eq 'instrument_data' } @inputs;
+is($ii->value, $instrument_data, 'set instrument data input to object');
+
+my ($ai) = grep { $_->name eq 'awesomeness' } @inputs;
+is($ai->value, 'lots', 'created text input');

--- a/lib/perl/Genome/Model/CwlPipeline.t
+++ b/lib/perl/Genome/Model/CwlPipeline.t
@@ -10,7 +10,7 @@ BEGIN {
 use above 'Genome';
 use Genome::Test::Factory::InstrumentData::Solexa;
 
-use Test::More tests => 5;
+use Test::More tests => 6;
 
 my $class = 'Genome::Model::CwlPipeline';
 use_ok($class);
@@ -19,7 +19,7 @@ my $instrument_data = Genome::Test::Factory::InstrumentData::Solexa->setup_objec
 
 my $pp = Genome::ProcessingProfile::CwlPipeline->__define__(id => -100);
 
-my $model = $class->create(
+my @params = (
     processing_profile_id => $pp->id,
     subject => $instrument_data->sample,
     input_data => {
@@ -27,6 +27,7 @@ my $model = $class->create(
         awesomeness     => 'lots',
     },
 );
+my $model = $class->create(@params);
 isa_ok($model, $class, 'created model');
 
 my @inputs = $model->inputs;
@@ -37,3 +38,6 @@ is($ii->value, $instrument_data, 'set instrument data input to object');
 
 my ($ai) = grep { $_->name eq 'awesomeness' } @inputs;
 is($ai->value, 'lots', 'created text input');
+
+my $model2 = $class->get(@params);
+is($model2, $model, 'got our model that we created');

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input.pm
@@ -2,6 +2,7 @@ package Genome::Model::CwlPipeline::Command::Input;
 
 class Genome::Model::CwlPipeline::Command::Input {
     is => 'Command::Tree',
+    doc => 'commands for working with inputs to cwl-pipeline models',
 };
 
 1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input.pm
@@ -1,0 +1,7 @@
+package Genome::Model::CwlPipeline::Command::Input;
+
+class Genome::Model::CwlPipeline::Command::Input {
+    is => 'Command::Tree',
+};
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.pm
@@ -1,0 +1,47 @@
+package Genome::Model::CwlPipeline::Command::Input::Add;
+
+class Genome::Model::CwlPipeline::Command::Input::Add {
+    is => 'Command::V2',
+    has_input => [
+        model => {
+            is => 'Genome::Model::CwlPipeline',
+            doc => 'the model(s) to which to add inputs',
+            is_many => 1,
+            shell_args_position => 1,
+        },
+        name => {
+            is => 'Text',
+            doc => 'name of the input(s) to set',
+            shell_args_position => 2,
+        },
+        value => {
+            is => 'Text',
+            is_many => 1,
+            doc => 'value(s) to set as input(s)',
+            shell_args_position => 3,
+        },
+    ],
+    doc => 'add inputs to the model',
+};
+
+sub sub_command_category { 'input tools' }
+
+sub help_detail {
+    return <<EOHELP
+Add input values to a model.  Certain names will cause the value to be parsed into the relevant objects in the system; all other inputs will be added directly as strings.
+EOHELP
+}
+
+sub execute {
+    my $self = shift;
+
+    for my $m ($self->model) {
+        $m->process_input_data(
+            $self->name, [$self->value]
+        );
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+use Genome::Test::Factory::InstrumentData::Solexa;
+
+use Test::More tests => 5;
+
+my $class = 'Genome::Model::CwlPipeline::Command::Input::Add';
+use_ok($class);
+
+my $value = Genome::Test::Factory::InstrumentData::Solexa->setup_object;
+
+my $m = Genome::Model::CwlPipeline->__define__(
+    name => 'cwl pipeline input add test model',
+);
+
+
+my $add_cmd = $class->create(
+    model => $m,
+    name => 'instrument_data',
+    value => $value->id,
+);
+isa_ok($add_cmd, $class, 'created command');
+
+ok($add_cmd->execute, 'executed command');
+
+my @inputs = $m->inputs;
+is(scalar(@inputs), 1, 'added an input');
+is($inputs[0]->value, $value, 'input has correct value');

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/List.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/List.pm
@@ -1,0 +1,42 @@
+package Genome::Model::CwlPipeline::Command::Input::List;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::CwlPipeline::Command::Input::List {
+    is => 'UR::Object::Command::List',
+    has => [
+        subject_class_name => {
+            is_constant => 1,
+            is => 'Text',
+            value => 'Genome::Model::Input',
+        },
+    ],
+    has_input => [
+        model => {
+            is => 'Genome::Model::CwlPipeline',
+            doc => 'the model whose inputs to list',
+        },
+    ],
+    has_param => [
+        show => {
+            is => 'Text',
+            default => 'name,value',
+        },
+    ],
+    doc => 'list the inputs for the model',
+};
+
+sub sub_command_category { 'input tools' }
+
+sub _resolve_boolexpr {
+    my $self = shift;
+
+    return Genome::Model::Input->define_boolexpr(
+        model_id => $self->model->id,
+    );
+}
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.pm
@@ -1,0 +1,58 @@
+package Genome::Model::CwlPipeline::Command::Input::Remove;
+
+class Genome::Model::CwlPipeline::Command::Input::Remove {
+    is => 'Command::V2',
+    has_input => [
+        model => {
+            is => 'Genome::Model::CwlPipeline',
+            doc => 'the model(s) from which to remove inputs',
+            is_many => 1,
+            shell_args_position => 1,
+        },
+        name => {
+            is => 'Text',
+            doc => 'name of the input(s) to unset',
+            shell_args_position => 2,
+        },
+        value => {
+            is => 'Text',
+            is_many => 1,
+            doc => 'value(s) to set as input(s)',
+            shell_args_position => 3,
+        },
+    ],
+    doc => 'remove inputs from the model',
+};
+
+sub sub_command_category { 'input tools' }
+
+sub execute {
+    my $self = shift;
+
+    my $count = 0;
+
+    for my $model ($self->model) {
+        for my $value_identifier ($self->value) {
+            my $value = $model->determine_input_object($self->name, $value_identifier);
+
+            if ($value) {
+                my @input = Genome::Model::Input->get(
+                    model_id => $model->id,
+                    value_id => $value->id,
+                    value_class_name => $value->class,
+                    name => $self->name
+                );
+
+                for my $i (@input) {
+                    $i->delete;
+                    $count++;
+                }
+            }
+        }
+    }
+
+    $self->status_message('Removed %s input(s).', $count);
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.pm
@@ -26,6 +26,14 @@ class Genome::Model::CwlPipeline::Command::Input::Remove {
 
 sub sub_command_category { 'input tools' }
 
+sub help_detail {
+    return <<EOHELP
+Remove input values from a model.
+
+For simple string inputs, the "value" should be the string itself.  For object inputs, the "value" should be the ID of the object to remove as an input.
+EOHELP
+}
+
 sub execute {
     my $self = shift;
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+use Genome::Test::Factory::InstrumentData::Solexa;
+
+use Test::More tests => 6;
+
+my $class = 'Genome::Model::CwlPipeline::Command::Input::Remove';
+use_ok($class);
+
+my $value = Genome::Test::Factory::InstrumentData::Solexa->setup_object;
+my $other_value = Genome::Test::Factory::InstrumentData::Solexa->setup_object;
+
+my $m = Genome::Model::CwlPipeline->__define__(
+    name => 'cwl pipeline input remove test model',
+);
+
+for my $v ($value, $other_value) {
+    my $input = Genome::Model::Input->create(
+        name => 'instrument_data',
+        value_id => $v->id,
+        value_class_name => $v->class,
+        model_id => $m->id,
+    );
+}
+
+my @prior_inputs = $m->inputs;
+is(scalar(@prior_inputs), 2, 'inputs initially exist');
+
+my $remove_cmd = $class->create(
+    model => $m,
+    name => 'instrument_data',
+    value => $value->id,
+);
+isa_ok($remove_cmd, $class, 'created command');
+
+ok($remove_cmd->execute, 'executed command');
+
+my @inputs = $m->inputs;
+is(scalar(@inputs), 1, 'removed one input');
+is($inputs[0]->value, $other_value, 'other input remains');

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
@@ -1,0 +1,77 @@
+package Genome::Model::CwlPipeline::Command::Restart;
+
+use strict;
+use warnings;
+
+use File::Spec;
+use Genome;
+
+class Genome::Model::CwlPipeline::Command::Restart {
+    is => 'Command::V2',
+    has => [
+        builds => {
+            is => 'Genome::Model::Build::CwlPipeline',
+            is_many => 1,
+            doc => 'The build(s) to restart',
+        },
+    ],
+    doc => 'relaunch a failed build',
+};
+
+sub help_detail {
+    return <<EOHELP
+Restart a build process after a failure has occurred.  This will attempt to resume the in-progress workflow.
+EOHELP
+    ;
+}
+
+sub execute {
+    my $self = shift;
+
+    my @builds = $self->builds;
+    my $build_count = scalar(@builds);
+    my @errors;
+    for my $build (@builds) {
+        my $transaction = UR::Context::Transaction->begin();
+        local $@;
+        my $successful = eval { $self->_restart_build($build) };
+        my $error = $@ // "";
+        if ($successful and $transaction->commit) {
+            $self->status_message(
+                'Build (%s) restarted. An initialization email will be sent once the build begins running.',
+                $build->__display_name__,
+            );
+        }
+        else {
+            $self->error_message(
+                'Failed to restart build (%s): %s.',
+                $build->__display_name__,
+                $error
+            );
+            $transaction->rollback;
+        }
+    }
+
+    return !scalar(@errors);
+}
+
+sub _restart_build {
+    my $self = shift;
+    my $build = shift;
+
+    unless($build->status eq 'Failed') {
+        die 'Can only restart failed builds.';
+    }
+
+    $build->status('Scheduled');
+    $build->date_completed(undef);
+
+    my %params; #need to pass empty hash to launch
+    my $xml = Genome::Sys->read_file(
+        File::Spec->join($build->data_directory, 'build.xml')
+    );
+
+    return $build->_launch(\%params, $xml);
+}
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.t
@@ -1,0 +1,54 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+use above 'Genome';
+
+use Genome::Model::CwlPipeline::Command::Run; #to override later
+use Genome::Test::Factory::AnalysisProject;
+use Genome::Test::Factory::Model::CwlPipeline;
+
+use Sub::Install;
+use Test::More tests => 4;
+
+my $class = 'Genome::Model::CwlPipeline::Command::Restart';
+use_ok($class);
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object;
+my $model = Genome::Test::Factory::Model::CwlPipeline->setup_object(
+    name => 'testing restart command',
+);
+$model->add_analysis_project_bridge(analysis_project_id => $anp->id);
+my $build = Genome::Model::Build::CwlPipeline->create(
+    model_id => $model->id,
+);
+
+Genome::Report::Email->silent;
+my $guard = Genome::Config::set_env('workflow_builder_backend', 'inline');
+my $override = Sub::Install::reinstall_sub({
+    into => 'Genome::Model::CwlPipeline::Command::Run',
+    as => '_execute_body',
+    code => sub { return; }, #let's fail.
+});
+
+$build->start;
+$build->status('Failed'); #inline test ends up unstartable, but this is atypical.
+
+undef $override;
+$override = Sub::Install::reinstall_sub({
+    into => 'Genome::Model::CwlPipeline::Command::Run',
+    as => '_execute_body',
+    code => sub { return 1; }, #let's succeed.
+});
+my $cmd = $class->create(
+    builds => [$build],
+);
+isa_ok($cmd, $class, 'created command');
+ok($cmd->execute, 'executed command, and it succeeded');
+
+is($build->status, 'Succeeded', 'build succeeded on second attempt');

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -87,10 +87,11 @@ sub run_toil {
     my $results_dir = shift;
 
     my $build = $self->build;
+    my $model = $build->model;
     my $jobstore_dir = File::Spec->join($build->data_directory, 'jobstore');
     my $log_file = File::Spec->join($build->log_directory, 'toil.log');
 
-    my $primary_docker_image = $build->model->primary_docker_image;
+    my $primary_docker_image = $model->primary_docker_image;
     local $ENV{LSB_SUB_ADDITIONAL} = $primary_docker_image;
 
     Genome::Sys->shellcmd(
@@ -102,10 +103,10 @@ sub run_toil {
             "--logFile=$log_file",
             "--outdir=$results_dir",
             '--batchSystem', 'lsf',
-            $build->main_workflow_file,
+            $model->main_workflow_file,
             $yaml
         ],
-        input_files => [$build->main_workflow_file, $yaml],
+        input_files => [$model->main_workflow_file, $yaml],
     );
 }
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -102,6 +102,9 @@ sub run_toil {
     my $default_queue = Genome::Config::get('lsf_queue_build_worker_alt');
     local $ENV{LSB_DEFAULTQUEUE} = $default_queue;
 
+    #toil relies on reading the output from bsub
+    delete local $ENV{BSUB_QUIET};
+
     Genome::Sys->shellcmd(
         cmd => [
             'cwltoil',

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -18,6 +18,8 @@ class Genome::Model::CwlPipeline::Command::Run {
     doc => 'wrapper command to run "cwltoil"'
 };
 
+sub sub_command_category { 'pipeline steps' }
+
 sub execute {
     my $self = shift;
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -90,6 +90,9 @@ sub run_toil {
     my $jobstore_dir = File::Spec->join($build->data_directory, 'jobstore');
     my $log_file = File::Spec->join($build->log_directory, 'toil.log');
 
+    my $primary_docker_image = $build->model->primary_docker_image;
+    local $ENV{LSB_SUB_ADDITIONAL} = $primary_docker_image;
+
     Genome::Sys->shellcmd(
         cmd => [
             'cwltoil',

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -38,8 +38,12 @@ sub prepare_yaml {
 
     for my $input ($build->inputs) {
         my $key = $input->name;
-        $inputs{$key} = $build->$key;
-        #TODO handle complex inputs
+        if ($input->value_class_name->isa('UR::Value')) {
+            $inputs{$key} = $input->value_id;
+        } else {
+            #TODO handle complex inputs
+            $self->fatal_message('Cannot handle object inputs yet!');
+        }
     }
 
     my $yaml = File::Spec->join($build->data_directory, 'inputs.yaml');

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -94,6 +94,9 @@ sub run_toil {
     my $primary_docker_image = $model->primary_docker_image;
     local $ENV{LSB_SUB_ADDITIONAL} = $primary_docker_image;
 
+    my $default_queue = Genome::Config::get('lsf_queue_build_worker_alt');
+    local $ENV{LSB_DEFAULTQUEUE} = $default_queue;
+
     Genome::Sys->shellcmd(
         cmd => [
             'cwltoil',

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -91,6 +91,11 @@ sub run_toil {
     my $jobstore_dir = File::Spec->join($build->data_directory, 'jobstore');
     my $log_file = File::Spec->join($build->log_directory, 'toil.log');
 
+    my @restart;
+    if (-e $jobstore_dir) {
+        push @restart, '--restart';
+    }
+
     my $primary_docker_image = $model->primary_docker_image;
     local $ENV{LSB_SUB_ADDITIONAL} = $primary_docker_image;
 
@@ -101,6 +106,7 @@ sub run_toil {
         cmd => [
             'cwltoil',
             '--disableCaching', '--stats', '--logLevel=DEBUG',
+            @restart,
             '--workDir', $tmp_dir,
             '--jobStore', $jobstore_dir,
             "--logFile=$log_file",

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -1,0 +1,109 @@
+package Genome::Model::CwlPipeline::Command::Run;
+
+use strict;
+use warnings;
+
+use File::Spec;
+use Genome;
+use Genome::Utility::File::Mode qw();
+use YAML;
+
+class Genome::Model::CwlPipeline::Command::Run {
+    is => 'Command::V2',
+    has => [
+        build => {
+            is => 'Genome::Model::Build::CwlPipeline',
+        },
+    ],
+    doc => 'wrapper command to run "cwltoil"'
+};
+
+sub execute {
+    my $self = shift;
+
+    my $yaml = $self->prepare_yaml;
+    my ($tmp_dir, $results_dir) = $self->prepare_directories;
+    $self->run_toil($yaml, $tmp_dir, $results_dir);
+    $self->preserve_results($results_dir);
+    $self->cleanup($tmp_dir);
+
+    return 1;
+}
+
+sub prepare_yaml {
+    my $self = shift;
+    my $build = $self->build;
+
+    my %inputs;
+
+    for my $input ($build->inputs) {
+        my $key = $input->name;
+        $inputs{$key} = $build->$key;
+        #TODO handle complex inputs
+    }
+
+    my $yaml = File::Spec->join($build->data_directory, 'inputs.yaml');
+    YAML::DumpFile($yaml, \%inputs);
+    return $yaml;
+}
+
+sub prepare_directories {
+    my $self = shift;
+    my $build = $self->build;
+
+    my $data_directory = $build->data_directory;
+
+    my $tmp_dir = File::Spec->join($data_directory, 'tmp');
+    my $results_dir = File::Spec->join($data_directory, 'results');
+
+    Genome::Sys->create_directory($tmp_dir);
+    Genome::Sys->create_directory($results_dir);
+
+    return ($tmp_dir, $results_dir);
+}
+
+sub run_toil {
+    my $self = shift;
+    my $yaml = shift;
+    my $tmp_dir = shift;
+    my $results_dir = shift;
+
+    my $build = $self->build;
+    my $jobstore_dir = File::Spec->join($build->data_directory, 'jobstore');
+    my $log_file = File::Spec->join($build->log_directory, 'toil.log');
+
+    Genome::Sys->shellcmd(
+        cmd => [
+            'cwltoil',
+            '--disableCaching', '--stats', '--logLevel=DEBUG',
+            '--workDir', $tmp_dir,
+            '--jobStore', $jobstore_dir,
+            "--logFile=$log_file",
+            "--outdir=$results_dir",
+            '--batchSystem', 'lsf',
+            $build->main_workflow_file,
+            $yaml
+        ],
+        input_files => [$build->main_workflow_file, $yaml],
+    );
+}
+
+sub preserve_results {
+    my $self = shift;
+    my $results_dir = shift;
+
+    for my $file ($results_dir, glob("$results_dir/*")) {
+        Genome::Utility::File::Mode::mode($file)->rm_all_writable;
+    }
+
+    return 1;
+}
+
+sub cleanup {
+    my $self = shift;
+    my $tmp_dir = shift;
+
+    return Genome::Sys->remove_directory_tree($tmp_dir);
+}
+
+1;

--- a/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.pm
+++ b/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.pm
@@ -17,6 +17,11 @@ class Genome::ProcessingProfile::Command::Create::CwlPipeline {
             is => 'Text',
             doc => 'name of the main workflow file within the directory',
         },
+        primary_docker_image => {
+            is => 'Text',
+            doc => 'docker image for the main toil worker jobs',
+            example_values => ['docker(mgibio/rnaseq)'],
+        },
     ],
     has_transient_optional => [
         based_on => {

--- a/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.pm
+++ b/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.pm
@@ -1,0 +1,76 @@
+package Genome::ProcessingProfile::Command::Create::CwlPipeline;
+
+use strict;
+use warnings;
+
+use File::Spec;
+use Genome;
+
+class Genome::ProcessingProfile::Command::Create::CwlPipeline {
+    is => 'Genome::ProcessingProfile::Command::Create::Base',
+    has_input => [
+        cwl_directory => {
+            is => 'Directory',
+            doc => 'a directory of CWL for the pipeline',
+        },
+        main_workflow_file => {
+            is => 'Text',
+            doc => 'name of the main workflow file within the directory',
+        },
+    ],
+    has_transient_optional => [
+        based_on => {
+            value => undef,
+            doc => 'the based_on option is unavailable for this type of processing profile',
+        },
+    ],
+};
+
+sub _target_class_name {
+    return 'Genome::ProcessingProfile::CwlPipeline';
+}
+
+sub execute {
+    my $self = shift;
+
+    $self->_verify_entrypoint_exists;
+
+    my $ok = $self->SUPER::_execute_body;
+    my $new_pp = $self->created_processing_profile;
+    unless ($ok and $new_pp) {
+        $self->fatal_message('Not uploading workflow files due to error creating processing profile.');
+    }
+
+    my $cwl_directory = $self->cwl_directory;
+    my $da = Genome::Disk::Allocation->create(
+        owner_id => $new_pp->id,
+        owner_class_name => $new_pp->class,
+        kilobytes_requested => Genome::Sys->disk_usage_for_path($cwl_directory),
+        disk_group_name => Genome::Config::get('disk_group_references'),
+        allocation_path => 'processing-profile/cwl-pipeline/' . $new_pp->id,
+    );
+    #FIXME deallocate on rsync errors or on PP delete
+    Genome::Sys->rsync_directory(
+        source_directory => $cwl_directory,
+        target_directory => $da->absolute_path,
+    );
+
+    $new_pp->main_workflow_file(
+        File::Spec->join($da->absolute_path, $self->main_workflow_file)
+    );
+
+    return 1;
+}
+
+sub _verify_entrypoint_exists {
+    my $self = shift;
+
+    my $entrypoint = File::Spec->join($self->cwl_directory, $self->main_workflow_file);
+    unless (-e $entrypoint) {
+        $self->fatal_message('Specified main workflow file not found in CWL directory.  Does <%s> exist?', $entrypoint);
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.t
+++ b/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+
+use File::Spec;
+use Test::More tests => 5;
+
+my $class = 'Genome::ProcessingProfile::Command::Create::CwlPipeline';
+use_ok($class);
+
+my $dir = Genome::Sys->create_temp_directory;
+my $filename = 'main.cwl';
+my $file = File::Spec->join($dir, $filename);
+
+Genome::Sys->write_file($file, 'fake');
+
+my $cmd = $class->create(
+    name => 'test for cwl-pipeline pp create',
+    cwl_directory => $dir,
+    main_workflow_file => $filename,
+    primary_docker_image => 'docker(mgibio/tabix)',
+);
+isa_ok($cmd, $class, 'created command');
+
+ok($cmd->execute, 'executed command');
+my $pp = $cmd->created_processing_profile;
+
+isa_ok($pp, $class->_target_class_name, 'created processing profile');
+
+my $diff = Genome::Sys->diff_file_vs_file($file, $pp->main_workflow_file);
+ok(!$diff, 'file faithfully copied')
+    or diag('diff: ' . $diff);

--- a/lib/perl/Genome/Sys/LSF/ResourceParser.pm
+++ b/lib/perl/Genome/Sys/LSF/ResourceParser.pm
@@ -30,8 +30,8 @@ sub parse_resource_requirements {
     # Compound syntax
     # num1*{simple_string1} + num2*{simple_string2} + ...
     my $compound_string = qr/
-        \d+\*{$simple_string}
-        (\s*\+\s*\d+\*{$simple_string})*
+        \d+\*\{$simple_string\}
+        (\s*\+\s*\d+\*\{$simple_string\})*
     /xms;
 
     my $admissable_res_req = qr/^( | $simple_string | $compound_string )$/xms;

--- a/lib/perl/Genome/Test/Factory/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Test/Factory/Model/CwlPipeline.pm
@@ -1,0 +1,30 @@
+package Genome::Test::Factory::Model::CwlPipeline;
+use Genome::Test::Factory::Model;
+@ISA = (Genome::Test::Factory::Model);
+
+use strict;
+use warnings;
+
+use Genome;
+use Genome::Test::Factory::Sample;
+use Genome::Test::Factory::ProcessingProfile::CwlPipeline;
+
+our @required_params = qw(subject_id);
+
+sub create_processing_profile_id {
+    my $p = Genome::Test::Factory::ProcessingProfile::CwlPipeline->setup_object;
+    return $p->id;
+}
+
+sub generate_obj {
+    my $self = shift;
+    my $m = Genome::Model::CwlPipeline->create(@_);
+    return $m;
+}
+
+sub create_subject_id {
+    my $subject = Genome::Test::Factory::Sample->setup_object();
+    return $subject->id;
+}
+
+1;

--- a/lib/perl/Genome/Test/Factory/ProcessingProfile/CwlPipeline.pm
+++ b/lib/perl/Genome/Test/Factory/ProcessingProfile/CwlPipeline.pm
@@ -1,0 +1,15 @@
+package Genome::Test::Factory::ProcessingProfile::CwlPipeline;
+use Genome::Test::Factory::ProcessingProfile;
+@ISA = (Genome::Test::Factory::ProcessingProfile);
+
+our @required_params = qw(name main_workflow_file primary_docker_image);
+
+sub create_main_workflow_file {
+    return '/dev/null/main.yml';
+}
+
+sub create_primary_docker_image {
+    return 'mgibio/docker-test';
+}
+
+1;


### PR DESCRIPTION
Here's what one version of a CWL model type could look like.  It needs a few more commands (convenient ways to define PPs and models) to be useful, and the YAML generation needs some fleshing out.  But this combined with relevant environment variables could theoretically be used to run a CWL pipeline tracked as a build within the GMS.