### PR TITLE
Support for Shortcutting the Alignment Process in SomaticValidation

### DIFF
--- a/lib/perl/Genome/Model/Build/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation.pm
@@ -93,6 +93,15 @@ class Genome::Model::Build::SomaticValidation {
             is_mutable => 1,
         },
 
+        prealigned_data => {
+            #is => 'Genome::InstrumentData::AlignedBamResult::Merged',
+            is => 'Genome::SoftwareResult',
+            via => 'inputs', to => 'value', where => [ name => 'prealigned_data' ],
+            is_many => 1,
+            is_optional => 1,
+            is_mutable => 1,
+        },
+
         merged_alignment_result => {
             is => 'Genome::InstrumentData::AlignedBamResult::Merged',
             via => 'result_users',

--- a/lib/perl/Genome/Model/Command/Define-docs.t.expected-output/somatic-validation
+++ b/lib/perl/Genome/Model/Command/Define-docs.t.expected-output/somatic-validation
@@ -3,9 +3,10 @@
  [1mgenome model define somatic-validation[0m [--auto-assign-inst-data] [--auto-build-alignments]
     --processing-profile=? [--add-to-projects=?[,?]] [--instrument-data=?[,?]]
     [--snv-variant-list=?] [--subject=?] [--groups=?[,?]] [--indel-variant-list=?] [--model-name=?]
-    [--normal-sample=?] [--known-sites=?[,?]] [--sv-variant-list=?] [--reference-sequence-build=?]
-    [--run-as=?] [--annotation-build=?] [--previously-discovered-variations-build=?]
-    [--target-region-set=?] [--region-of-interest-set=?] [--design-set=?] [--tumor-sample=?]
+    [--normal-sample=?] [--known-sites=?[,?]] [--prealigned-data=?] [--sv-variant-list=?]
+    [--reference-sequence-build=?] [--run-as=?] [--annotation-build=?]
+    [--previously-discovered-variations-build=?] [--target-region-set=?]
+    [--region-of-interest-set=?] [--design-set=?] [--tumor-sample=?]
 
 [4mSYNOPSIS[0m
   genome model define somatic-validation \
@@ -37,6 +38,8 @@
     the control sample 
   [1mknown-sites[0m
     Build[s] of known variants to use in when refining with GATK best practices. 
+  [1mprealigned-data[0m
+    pre-built alignments for skipping the built-in alignment process 
   [1msv-variant-list[0m
     prior SVs to be validated 
   [1mreference-sequence-build[0m

--- a/lib/perl/Genome/Model/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation.pm
@@ -185,6 +185,11 @@ class Genome::Model::SomaticValidation {
             is_many => 1,
             doc => 'Build[s] of known variants to use in when refining with GATK best practices.',
         },
+        prealigned_data => {
+            #is => 'Genome::InstrumentData::AlignedBamResult::Merged',
+            is => 'Genome::SoftwareResult',
+            doc => 'pre-built alignments for skipping the built-in alignment process',
+        },
     ],
     has_optional_mutable => [
         region_of_interest_set_name => {

--- a/lib/perl/Genome/Model/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/SomaticValidation.pm
@@ -236,7 +236,7 @@ sub _validate_required_for_start_properties {
     my @missing_required_properties;
     push @missing_required_properties, 'reference_sequence_build' unless ($self->reference_sequence_build);
     push @missing_required_properties, 'tumor_sample' unless ($self->tumor_sample);
-    push @missing_required_properties, 'instrument_data' unless (scalar @{[ $self->instrument_data ]} );
+    push @missing_required_properties, 'instrument_data' unless (scalar @{[ $self->instrument_data ]} or scalar @{[$self->prealigned_data]});
 
     my $tag;
     if (@missing_required_properties) {
@@ -253,7 +253,7 @@ sub _validate_required_for_start_properties {
 sub build_needed {
     my $self = shift;
 
-    return $self->SUPER::build_needed && !$self->_validate_instrument_data_present_for_each_sample;
+    return $self->SUPER::build_needed && (@{[$self->prealigned_data]} or !$self->_validate_instrument_data_present_for_each_sample);
 }
 
 sub _validate_instrument_data_present_for_each_sample {

--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.pm
@@ -81,26 +81,48 @@ sub execute {
 
     my @results = $result->_merged_results;
 
-    my $build_alignment_dir = join('/', $build->data_directory, 'alignments');
-
     for my $r (@results) {
         my @i = $r->instrument_data;
         my $sample = $i[0]->sample;
         if($sample eq $build->tumor_sample) {
-            $self->merged_alignment_result_id($r->id);
-            $self->merged_bam_path($r->bam_path);
-            $r->add_user(label => 'merged_alignment', user => $build);
-            Genome::Sys->create_symlink($r->output_dir, $build_alignment_dir . '/tumor');
+            $self->_assign_tumor_sample_alignment($r);
         } elsif ($sample eq $build->normal_sample) {
-            $self->control_merged_alignment_result_id($r->id);
-            $self->control_merged_bam_path($r->bam_path);
-            $r->add_user(label => 'control_merged_alignment', user => $build);
-            Genome::Sys->create_symlink($r->output_dir, $build_alignment_dir . '/normal');
+            $self->_assign_normal_sample_alignment($r);
         } else {
             $self->warning_message('Unexpected alignment result encountered! Check samples of instrument data.');
             $r->add_user(label => 'uses', user => $build);
         }
     }
+
+    return 1;
+}
+
+sub _assign_tumor_sample_alignment {
+    my $self = shift;
+    my $alignment = shift;
+
+    my $build = $self->build;
+    my $build_alignment_dir = join('/', $build->data_directory, 'alignments');
+
+    $self->merged_alignment_result_id($alignment->id);
+    $self->merged_bam_path($alignment->bam_path);
+    $alignment->add_user(label => 'merged_alignment', user => $build);
+    Genome::Sys->create_symlink($alignment->output_dir, $build_alignment_dir . '/tumor');
+
+    return 1;
+}
+
+sub _assign_normal_sample_alignment {
+    my $self = shift;
+    my $alignment = shift;
+
+    my $build = $self->build;
+    my $build_alignment_dir = join('/', $build->data_directory, 'alignments');
+
+    $self->control_merged_alignment_result_id($alignment->id);
+    $self->control_merged_bam_path($alignment->bam_path);
+    $alignment->add_user(label => 'control_merged_alignment', user => $build);
+    Genome::Sys->create_symlink($alignment->output_dir, $build_alignment_dir . '/normal');
 
     return 1;
 }

--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.pm
@@ -137,7 +137,7 @@ sub _find_existing_alignments {
         }
     }
 
-    return 1;
+    return @existing_alignments;
 }
 
 sub _assign_tumor_sample_alignment {

--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.pm
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.pm
@@ -5,6 +5,8 @@ use warnings;
 
 use Genome;
 
+use File::Spec;
+
 class Genome::Model::SomaticValidation::Command::AlignReads {
     is => 'Command::V2',
     has_input => [
@@ -102,12 +104,12 @@ sub _assign_tumor_sample_alignment {
     my $alignment = shift;
 
     my $build = $self->build;
-    my $build_alignment_dir = join('/', $build->data_directory, 'alignments');
+    my $build_alignment_dir = File::Spec->join($build->data_directory, 'alignments');
 
     $self->merged_alignment_result_id($alignment->id);
     $self->merged_bam_path($alignment->bam_path);
     $alignment->add_user(label => 'merged_alignment', user => $build);
-    Genome::Sys->create_symlink($alignment->output_dir, $build_alignment_dir . '/tumor');
+    Genome::Sys->create_symlink($alignment->output_dir, File::Spec->join($build_alignment_dir, 'tumor'));
 
     return 1;
 }
@@ -117,12 +119,12 @@ sub _assign_normal_sample_alignment {
     my $alignment = shift;
 
     my $build = $self->build;
-    my $build_alignment_dir = join('/', $build->data_directory, 'alignments');
+    my $build_alignment_dir = File::Spec->join($build->data_directory, 'alignments');
 
     $self->control_merged_alignment_result_id($alignment->id);
     $self->control_merged_bam_path($alignment->bam_path);
     $alignment->add_user(label => 'control_merged_alignment', user => $build);
-    Genome::Sys->create_symlink($alignment->output_dir, $build_alignment_dir . '/normal');
+    Genome::Sys->create_symlink($alignment->output_dir, File::Spec->join($build_alignment_dir, 'normal'));
 
     return 1;
 }

--- a/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.t
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/AlignReads.t
@@ -3,11 +3,60 @@
 use strict;
 use warnings;
 
-use above 'Genome';
-use Test::More tests => 1;
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
 
-# This test was auto-generated because './Model/SomaticValidation/Command/AlignReads.pm'
-# had no '.t' file beside it.  Please remove this test if you believe it was
-# created unnecessarily.  This is a bare minimum test that just compiles Perl
-# and the UR class.
-use_ok('Genome::Model::SomaticValidation::Command::AlignReads');
+use above 'Genome';
+use Test::More tests => 6;
+
+use File::Spec;
+use Test::Exception;
+
+use Genome::Test::Factory::InstrumentData::MergedAlignmentResult;
+use Genome::Test::Factory::InstrumentData::Solexa;
+use Genome::Test::Factory::Model::SomaticValidation;
+
+
+my $class = 'Genome::Model::SomaticValidation::Command::AlignReads';
+use_ok($class);
+
+#test shortcutting on prealigned data
+my $somval = Genome::Test::Factory::Model::SomaticValidation->setup_object;
+my $build = Genome::Model::Build->create(
+    model_id => $somval->id,
+    data_directory => Genome::Sys->create_temp_directory,
+);
+Genome::Sys->create_directory(File::Spec->join($build->data_directory, 'alignments'));
+
+my $cmd = $class->create(build_id => $build->id);
+isa_ok($cmd, $class, 'created command');
+
+lives_and( sub { ok !$cmd->shortcut }, 'shortcut does not succeed, but does not crash with no premade data');
+
+my $instrument_data = Genome::Test::Factory::InstrumentData::Solexa->setup_object;
+my $alignment = Genome::Test::Factory::InstrumentData::MergedAlignmentResult->setup_object(
+    output_dir => Genome::Sys->create_temp_directory,
+);
+$alignment->add_input(
+    name => 'instrument_data_id-1',
+    value_id => $instrument_data->id,
+);
+$alignment->add_param(
+    name => 'instrument_data_id_count',
+    value_id => 1,
+);
+$alignment->add_param(
+    name => 'instrument_data_id_md5',
+    value_id => Genome::Sys->md5sum_data($instrument_data->id)
+);
+
+$build->add_prealigned_data($alignment);
+
+dies_ok( sub { $cmd->shortcut }, 'shortcut dies with prealigned data for non-matching sample');
+
+$build->tumor_sample($instrument_data->sample);
+
+lives_and( sub { ok $cmd->shortcut }, 'shortcut succeededs with matching prealigned data');
+
+is($build->merged_alignment_result, $alignment, 'prealigned data gets linked as usual');


### PR DESCRIPTION
(Combined with #1719 this should allow SomaticValidation to run on externally-produced alignments.)

Issues:
* Should this really just ignore the `alignment_strategy` and assigned `instrument_data` when pre-aligned data are available?  Currently that's a "yes".
* Some of the validation realignment steps operate on instrument data, so they'd crash or use any assigned instrument data while ignoring the pre-aligned data.
* This hasn't been tested by running a build yet.