### PR TITLE
Specify a job group to limit concurrent MethRatio processes.

### DIFF
--- a/etc/genome/spec/lsf_resource_methratio.yaml
+++ b/etc/genome/spec/lsf_resource_methratio.yaml
@@ -1,0 +1,3 @@
+---
+default_value: "-R 'select[mem>4000 && gtmp>1] rusage[mem=4000,gtmp=1]' -g /genome/meth-ratio"
+env: XGENOME_LSF_RESOURCE_METHRATIO

--- a/lib/perl/Genome/Model/Tools/Bsmap/MethRatio.pm
+++ b/lib/perl/Genome/Model/Tools/Bsmap/MethRatio.pm
@@ -78,6 +78,11 @@ class Genome::Model::Tools::Bsmap::MethRatio {
 #                         report loci with sequencing depth>=FOLD. [default: 1]
 
     ],
+    has_param => [
+        lsf_resource => {
+            default_value => Genome::Config::get('lsf_resource_methratio'),
+        },
+    ],
 };
 
 sub available_methratio_versions {


### PR DESCRIPTION
Running too many of these is implicated in performance problems in the cluster.