### PR TITLE
Increate PerLaneTophat LSF RAM to 64GB from 32GB

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/PerLaneTophat.pm
@@ -28,7 +28,7 @@ sub required_arch_os { 'x86_64' }
 sub required_rusage {
     my $class = shift;
 
-    my $mem_mb = 32000;
+    my $mem_mb = 64000;
     my $mem_kb = $mem_mb*1024;
     my $tmp_gb = 400;
     my $cpus = 4;


### PR DESCRIPTION
Ideally this would be configurable. For now, increase to 64GB of RAM as read trimming will become more common with longer read RNA-seq data.