### PR TITLE
Disk Allocation move: Report correct new path in error message.

### DIFF
--- a/lib/perl/Genome/Disk/Detail/Allocation/Mover.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Mover.pm
@@ -106,7 +106,7 @@ sub move {
                 "Could not move shadow allocation path (%s) to final path (%s)."
                 . "  This should never happen, even when 100%% full.",
                 $shadow_allocation_abs_path,
-                $allocation_object->absolute_path)));
+                $new_volume_final_path)));
     }
 
     # Change the shadow allocation to reserve some disk on the old volume until


### PR DESCRIPTION
This error is reported before we would've updated the allocation object itself to the new location, so we can't rely on it to get the destination path.