### PR TITLE
First version of BAM <=> CRAM conversion for Merged AlignmentResults

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/BamToCram.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/BamToCram.pm
@@ -1,0 +1,45 @@
+package Genome::InstrumentData::AlignmentResult::Command::BamToCram;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::InstrumentData::AlignmentResult::Command::BamToCram {
+    is => 'Genome::InstrumentData::AlignmentResult::Command::ConvertBase',
+};
+
+sub shortcut {
+    my $self = shift;
+
+    return $self->_is_currently_cram;
+}
+
+sub execute {
+    my $self = shift;
+
+    return 1 if $self->_is_currently_cram;
+
+    unless($self->_is_currently_bam) {
+        $self->fatal_message("This result cannot be converted to CRAM.");
+    }
+
+    my $result = $self->alignment_result;
+    my $bam_file = $result->bam_file;
+
+    my $cram_file = $bam_file;
+    $cram_file =~ s/bam$/cram/;
+
+    $self->_run_conversion('-C', $bam_file, $cram_file);
+
+    unless ($self->_verify_file($cram_file)) {
+        $self->fatal_message('Failed to convert to CRAM file.');
+    } else {
+        unlink $bam_file;
+        $result->filetype('cram');
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/BamToCram.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/BamToCram.pm
@@ -18,6 +18,8 @@ sub shortcut {
 sub execute {
     my $self = shift;
 
+    my $guard = $self->_lock()->unlock_guard;
+
     return 1 if $self->_is_currently_cram;
 
     unless($self->_is_currently_bam) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/ConvertBase.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/ConvertBase.pm
@@ -1,0 +1,68 @@
+package Genome::InstrumentData::AlignmentResult::Command::ConvertBase;
+
+use strict;
+use warnings;
+
+use Genome;
+use Genome::Sys::LSF::bsub qw();
+
+class Genome::InstrumentData::AlignmentResult::Command::ConvertBase {
+    is => 'Command::V2',
+    has_input => [
+        alignment_result => {
+            is => 'Genome::InstrumentData::AlignmentResult::Merged',
+            doc => 'result to convert',
+        },
+    ],
+    doc => 'Convert an alignment result.',
+};
+
+sub _is_currently_bam {
+    my $self = shift;
+
+    my $result = $self->alignment_result;
+
+    my $filetype = $result->filetype;
+
+    return 1 unless $filetype;
+    return $filetype eq 'bam';
+}
+
+sub _is_currently_cram {
+    my $self = shift;
+
+    my $result = $self->alignment_result;
+
+    my $filetype = $result->filetype;
+
+    return 0 unless $filetype;
+    return $filetype eq 'cram';
+}
+
+sub _run_conversion {
+    my $self = shift;
+    my $output_format_flag = shift;
+    my $source_file = shift;
+    my $destination_file = shift;
+
+    my $reference = $self->result->reference_build;
+    my $fasta = $reference->full_consensus_path('fa');
+
+    my $cmd = ['view', '-T', $fasta, $output_format_flag, '-o', $destination_file, $source_file];
+
+    my $guard = Genome::Config->set_env('lsb_sub_additional', 'mgibio/samtools:1.3.1');
+    Genome::Sys::LSF::bsub::bsub(
+        cmd => $cmd,
+        queue => Genome::Config::get('lsf_queue_build_worker'),
+        wait_for_completion => 1,
+    );
+}
+
+sub _verify_file {
+    my $self = shift;
+    my $file = shift;
+
+    return -e $file;
+}
+
+1;

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/CramToBam.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/CramToBam.pm
@@ -18,6 +18,8 @@ sub shortcut {
 sub execute {
     my $self = shift;
 
+    my $guard = $self->_lock()->unlock_guard;
+
     return 1 if $self->_is_currently_bam;
 
     unless($self->_is_currently_cram) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Command/CramToBam.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Command/CramToBam.pm
@@ -1,0 +1,45 @@
+package Genome::InstrumentData::AlignmentResult::Command::CramToBam;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::InstrumentData::AlignmentResult::Command::CramToBam {
+    is => 'Genome::InstrumentData::AlignmentResult::Command::ConvertBase',
+};
+
+sub shortcut {
+    my $self = shift;
+
+    return $self->_is_currently_bam;
+}
+
+sub execute {
+    my $self = shift;
+
+    return 1 if $self->_is_currently_bam;
+
+    unless($self->_is_currently_cram) {
+        $self->fatal_message("This result cannot be converted to BAM.");
+    }
+
+    my $result = $self->alignment_result;
+    my $cram_file = $result->bam_file;
+
+    my $bam_file = $cram_file;
+    $bam_file =~ s/cram$/bam/;
+
+    $self->_run_conversion('-b', $cram_file, $bam_file);
+
+    unless ($self->_verify_file($bam_file)) {
+        $self->fatal_message('Failed to convert to BAM file.');
+    } else {
+        unlink $cram_file;
+        $result->filetype('bam');
+    }
+
+    return 1;
+}
+
+1;


### PR DESCRIPTION
Here are a couple commands for converting merged alignment results between BAM and CRAM format.  This still needs to be tested more before being widely used!

Potential Shortcomings:
* There's no automatic CRAM => BAM reconversion for converted things if the result is called in a situation that requires BAM.
* It might be nice to be more thorough with verifying the transformation.  This could incorporate a flagstat comparison at the cost of spinning up a second/third LSF job.