### PR TITLE
Move new BAM <=> CRAM conversion commands for command-line use.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert.pm
@@ -1,0 +1,13 @@
+package Genome::InstrumentData::Command::AlignmentResult::Convert;
+
+use strict;
+use warnings;
+
+use Genome;
+use Genome::Sys::LSF::bsub qw();
+
+class Genome::InstrumentData::Command::AlignmentResult::Convert {
+    is => 'Command::Tree',
+};
+
+1;

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/BamToCram.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/BamToCram.pm
@@ -1,12 +1,12 @@
-package Genome::InstrumentData::AlignmentResult::Command::BamToCram;
+package Genome::InstrumentData::Command::AlignmentResult::Convert::BamToCram;
 
 use strict;
 use warnings;
 
 use Genome;
 
-class Genome::InstrumentData::AlignmentResult::Command::BamToCram {
-    is => 'Genome::InstrumentData::AlignmentResult::Command::ConvertBase',
+class Genome::InstrumentData::Command::AlignmentResult::Convert::BamToCram {
+    is => 'Genome::InstrumentData::Command::AlignmentResult::Convert::Base',
 };
 
 sub shortcut {

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
@@ -1,4 +1,4 @@
-package Genome::InstrumentData::AlignmentResult::Command::ConvertBase;
+package Genome::InstrumentData::Command::AlignmentResult::Convert::Base;
 
 use strict;
 use warnings;
@@ -6,7 +6,8 @@ use warnings;
 use Genome;
 use Genome::Sys::LSF::bsub qw();
 
-class Genome::InstrumentData::AlignmentResult::Command::ConvertBase {
+class Genome::InstrumentData::Command::AlignmentResult::Convert::Base {
+    is_abstract => 1,
     is => 'Command::V2',
     has_input => [
         alignment_result => {

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/CramToBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/CramToBam.pm
@@ -1,12 +1,12 @@
-package Genome::InstrumentData::AlignmentResult::Command::CramToBam;
+package Genome::InstrumentData::Command::AlignmentResult::Convert::CramToBam;
 
 use strict;
 use warnings;
 
 use Genome;
 
-class Genome::InstrumentData::AlignmentResult::Command::CramToBam {
-    is => 'Genome::InstrumentData::AlignmentResult::Command::ConvertBase',
+class Genome::InstrumentData::Command::AlignmentResult::Convert::CramToBam {
+    is => 'Genome::InstrumentData::Command::AlignmentResult::Convert::Base',
 };
 
 sub shortcut {


### PR DESCRIPTION
There are two similar command directories, but only one of them is included when running `genome`.