### PR TITLE
Support "Speedseq" merged alignments in format converters.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged/Speedseq.pm
@@ -55,6 +55,12 @@ class Genome::InstrumentData::AlignmentResult::Merged::Speedseq {
             doc=>'Version of picard to use when creating bam files',
         },
     ],
+    has_optional_metric => [
+        filetype => {
+            is => 'Text',
+            doc => 'the type of alignment file ("bam" assumed if not present")',
+        },
+    ],
     has_calculated => [
         _final_bam_file => {
             is => 'Text', calculate_from => ['temp_staging_directory', 'id',],
@@ -62,7 +68,7 @@ class Genome::InstrumentData::AlignmentResult::Merged::Speedseq {
         },
         merged_alignment_bam_path => {
             is => 'Text', calculate_from => ['output_dir', 'id'],
-            calculate => q{ return join('/', $output_dir, $id . '.bam'); }
+            calculate => q{ return join('/', $output_dir, $id . '.' . ($self->filetype // 'bam')); }
         },
     ]
 };

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/BamToCram.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/BamToCram.pm
@@ -18,6 +18,13 @@ sub shortcut {
 sub execute {
     my $self = shift;
 
+    unless($self->_is_convertable_result) {
+        $self->fatal_message(
+            "This converter currently does not support results of type %s",
+            $self->alignment_result->class
+        );
+    }
+
     my $guard = $self->_lock()->unlock_guard;
 
     return 1 if $self->_is_currently_cram;

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
@@ -11,12 +11,21 @@ class Genome::InstrumentData::Command::AlignmentResult::Convert::Base {
     is => 'Command::V2',
     has_input => [
         alignment_result => {
-            is => 'Genome::InstrumentData::AlignmentResult::Merged',
+            is => 'Genome::SoftwareResult',
             doc => 'result to convert',
         },
     ],
     doc => 'Convert an alignment result.',
 };
+
+sub _is_convertable_result {
+    my $self = shift;
+
+    my $alignment_result = $self->alignment_result;
+
+    return unless $alignment_result->isa('Genome::InstrumentData::AlignedBamResult::Merged');
+    return $alignment_result->can('filetype');
+}
 
 sub _lock {
     my $self = shift;

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/CramToBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/CramToBam.pm
@@ -18,6 +18,13 @@ sub shortcut {
 sub execute {
     my $self = shift;
 
+    unless($self->_is_convertable_result) {
+        $self->fatal_message(
+            "This converter currently does not support results of type %s",
+            $self->alignment_result->class
+        );
+    }
+
     my $guard = $self->_lock()->unlock_guard;
 
     return 1 if $self->_is_currently_bam;


### PR DESCRIPTION
Since Speedseq doesn't use the normal merged alignment class, these were failing to be found (and wouldn't have been able to store the format if they were).