### PR TITLE
Treat empty strings like undef values in LIMS objects.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/LimsBase.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/LimsBase.pm
@@ -50,6 +50,7 @@ sub params_for_create_in_genome {
         else {
             my $value = $self->$name;
             next if not defined $value;
+            next if $value eq '';
             $params{$name} = $value;
         }
     }


### PR DESCRIPTION
The LIMS system has started storing empty strings in columns sometimes when they mean `NULL`, so treat them the same.