### PR TITLE
Synch: SQL refactor for AnP bridge class

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/InstrumentDataAnalysisProjectBridge.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/InstrumentDataAnalysisProjectBridge.pm
@@ -11,29 +11,37 @@ class Genome::Site::TGI::Synchronize::Classes::InstrumentDataAnalysisProjectBrid
 (
     SELECT
         x.instrument_data_id instrument_data_id,
-        swo.analysis_project_id
+        x.analysis_project_id analysis_project_id
     FROM
     (
-        SELECT i.seq_id::text seq_id, i.analysis_id::text instrument_data_id FROM index_illumina i
+        SELECT i.analysis_id instrument_data_id, swo.analysis_project_id FROM index_illumina i
+        LEFT JOIN GSC.woi_sequence_product wsp ON wsp.seq_id = i.seq_id
+        LEFT JOIN work_order_item woi ON wsp.woi_id = woi.woi_id
+        LEFT JOIN setup_work_order swo ON swo.setup_wo_id = woi.setup_wo_id
+        WHERE swo.analysis_project_id IS NOT NULL
         UNION ALL
-        SELECT g.seq_id::text seq_id, g.seq_id::text instrument_data_id FROM external_genotyping g
+        SELECT g.seq_id instrument_data_id, swo.analysis_project_id FROM external_genotyping g
+        LEFT JOIN GSC.woi_sequence_product wsp ON wsp.seq_id = g.seq_id
+        LEFT JOIN work_order_item woi ON wsp.woi_id = woi.woi_id
+        LEFT JOIN setup_work_order swo ON swo.setup_wo_id = woi.setup_wo_id
+        WHERE swo.analysis_project_id IS NOT NULL
         UNION ALL
-        SELECT g.seq_id::text seq_id, g.seq_id::text instrument_data_id FROM illumina_genotyping g
+        SELECT g.seq_id instrument_data_id, swo.analysis_project_id FROM illumina_genotyping g
+        LEFT JOIN GSC.woi_sequence_product wsp ON wsp.seq_id = g.seq_id
+        LEFT JOIN work_order_item woi ON wsp.woi_id = woi.woi_id
+        LEFT JOIN setup_work_order swo ON swo.setup_wo_id = woi.setup_wo_id
+        WHERE swo.analysis_project_id IS NOT NULL
     ) x
-    LEFT JOIN GSC.woi_sequence_product wsp ON wsp.seq_id::text = x.seq_id
-    LEFT JOIN work_order_item woi ON wsp.woi_id = woi.woi_id
-    LEFT JOIN setup_work_order swo ON swo.setup_wo_id = woi.setup_wo_id
-    WHERE swo.analysis_project_id IS NOT NULL
 )
 idapp
 EOS
     ,
     id_by => [
         instrument_data_id => {
-            is => 'Text',
+            is => 'Number',
         },
         analysis_project_id => {
-            is => 'Text',
+            is => 'Number',
         },
     ],
     data_source => 'Genome::DataSource::Dwrac',


### PR DESCRIPTION
This removes a bunch of casts of numbers to text and joins to each table individually instead of operating on the union.