### PR TITLE
Import Genotype Data, AnP links, and Sample links for Work Order.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
@@ -19,8 +19,9 @@ sub execute {
     my $self = shift;
 
     my $wo = $self->_resolve_work_order;
-    my @items = $self->_resolve_items;
+    $self->_resolve_samples;
 
+    my @items = $self->_resolve_instrument_data;
     my @existing = Genome::InstrumentData->get(id => [map $_->entity_id, @items]);
 
     $self->status_message(
@@ -61,7 +62,7 @@ sub _resolve_work_order {
     return $existing_project;
 }
 
-sub _resolve_items {
+sub _resolve_instrument_data {
     my $self = shift;
 
     my @existing_items = Genome::ProjectPart->get(
@@ -80,6 +81,37 @@ sub _resolve_items {
     for my $item (@to_import) {
         push @existing_items, $item->create_in_genome;
     }
+
+    return @existing_items;
+}
+
+sub _resolve_samples {
+    my $self = shift;
+
+    my @existing_items = Genome::ProjectPart->get(
+        label => 'sample',
+        project_id => $self->work_order_id,
+    );
+
+    my @importable_items = Genome::Site::TGI::Synchronize::Classes::LimsProjectSample->get(
+        project_id => $self->work_order_id,
+    );
+
+    my %found;
+    $found{$_->entity_id}++ for @existing_items;
+    my @to_import = grep { !$found{$_->entity_id} } @importable_items;
+
+    for my $item (@to_import) {
+        push @existing_items, $item->create_in_genome;
+    }
+
+    my @existing_samples = Genome::Sample->get(id => [map $_->entity_id, @existing_items]);
+
+    my %found_samples;
+    $found_samples{$_->id}++ for @existing_samples;
+    my @samples_to_import = grep { !$found_samples{$_->entity_id} } @existing_items;
+    my @os = Genome::Site::TGI::Synchronize::Classes::OrganismSample->get(id => [map $_->entity_id, @samples_to_import]);
+    $self->_import_organismsample($_) for @os;
 
     return @existing_items;
 }

--- a/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
@@ -37,6 +37,10 @@ sub execute {
     $self->_import_indexillumina($_) for @ii;
     $self->_import_anp_associations(@ii);
 
+    my @g = Genome::Site::TGI::Synchronize::Classes::Genotyping->get(id => [map $_->entity_id, @to_import]);
+    $self->_import_genotyping($_) for @g;
+    $self->_import_anp_associations(@g);
+
     return 1;
 }
 
@@ -160,6 +164,19 @@ sub _import_anp_associations {
     }
 
     return 1;
+}
+
+sub _import_genotyping {
+    my $self = shift;
+    my $g = shift;
+
+    my $existing_sample = Genome::Sample->get($g->sample_id);
+    unless ($existing_sample) {
+        my $os = Genome::Site::TGI::Synchronize::Classes::OrganismSample->get($g->sample_id);
+        $self->_import_organismsample($os);
+    }
+
+    $g->create_in_genome;
 }
 
 1;

--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/Genotyping.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/Genotyping.pm
@@ -11,7 +11,7 @@ class Genome::Site::TGI::Synchronize::Classes::Genotyping { # EXTERNAL 287713868
     (
         select g.seq_id id, g.status status,
          g.organism_sample_id sample_id, s.full_name sample_name,
-	     lower(p.name) sequencing_platform, p.chip_type chip_name, p.version version,
+	     lower(p.name) sequencing_platform, p.chip_type chip_name, p.version as version,
          'external' import_source_name
 	    from external_genotyping g
         join genotyping_platform p on p.genotyping_platform_id = g.genotyping_platform_id
@@ -19,7 +19,7 @@ class Genome::Site::TGI::Synchronize::Classes::Genotyping { # EXTERNAL 287713868
         union all
         select g.seq_id id, g.status status,
          g.organism_sample_id sample_id, s.full_name sample_name,
-	     lower(p.name) sequencing_platform, p.chip_type chip_name, p.version version,
+	     lower(p.name) sequencing_platform, p.chip_type chip_name, p.version as version,
          'wugc' import_source_name
         from illumina_genotyping g
         join genotyping_platform p on p.genotyping_platform_id = g.genotyping_platform_id
@@ -29,11 +29,11 @@ class Genome::Site::TGI::Synchronize::Classes::Genotyping { # EXTERNAL 287713868
 SQL
     ,
     id_by => [
-        id => { is => 'Text', },
+        id => { is => 'Number', },
     ],
     has => [
         status => { is => 'Text', },
-        sample_id => { is => 'Text', },
+        sample_id => { is => 'Number', },
         sample_name => { is => 'Text', },
         sequencing_platform => { is => 'Text', },
         chip_name => { is => 'Text', },


### PR DESCRIPTION
The first version of this command worked to import instrument data assuming the synchronization cron was otherwise running to bring across other associations.  This adds features to make the data import more complete independent of synching.