### PR TITLE
Change columntype for AnP ID back to text.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/InstrumentDataAnalysisProjectBridge.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/InstrumentDataAnalysisProjectBridge.pm
@@ -41,7 +41,7 @@ EOS
             is => 'Number',
         },
         analysis_project_id => {
-            is => 'Number',
+            is => 'Text',
         },
     ],
     data_source => 'Genome::DataSource::Dwrac',


### PR DESCRIPTION
This one really holds non-numeric data, so should not have changed it in b0a14a85.