### PR TITLE
Use the ordinary "debug_message" so they appear in the normal logs.

### DIFF
--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Genome;
-use Genome::Logger;
 
 use Carp qw(confess);
 use List::Util 'shuffle';
@@ -215,7 +214,7 @@ sub _get_allocation_without_lock_impl {
         ));
     }
 
-    Genome::Logger->debugf("Allocation (%s) created at %s",
+    $self->debug_message("Allocation (%s) created at %s",
         $chosen_allocation->id, $chosen_allocation->absolute_path);
 
     return $chosen_allocation;
@@ -275,7 +274,7 @@ sub _attempt_allocation_creation {
     if ($candidate_volume->is_allocated_over_soft_limit) {
         Genome::Utility::Instrumentation::inc('disk.allocation.'
             . 'get_allocation_without_lock.rollback.over_allocated');
-        Genome::Logger->debugf(
+        $self->debug_message(
                 "%s's allocated_kb exceeded soft limit (%d kB), "
                 . "rolling back allocation.",
                 $candidate_volume->mount_path,
@@ -287,7 +286,7 @@ sub _attempt_allocation_creation {
     } elsif ($candidate_volume->is_used_over_soft_limit) {
         Genome::Utility::Instrumentation::inc('disk.allocation.'
             . 'get_allocation_without_lock.rollback.over_used');
-        Genome::Logger->debugf(
+        $self->debug_message(
                 "%s's used_kb exceeded soft limit (%d %s), "
                 . "rolling back allocation.",
                 $candidate_volume->mount_path,

--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -206,14 +206,14 @@ sub _get_allocation_without_lock_impl {
     }
 
     unless (defined $chosen_allocation) {
-        Carp::confess $self->error_message(sprintf(
+        Carp::confess $self->error_message(
             "Could not create allocation for %s kilobytes at <%s> in specified disk group (%s), "
             . "which contains %d volumes:\n%s\n",
             $self->parameters->kilobytes_requested,
             $self->parameters->allocation_path,
             $self->parameters->disk_group_name, scalar(@$candidate_volumes),
             join("\n", map { $_->mount_path } @$candidate_volumes),
-        ));
+        );
     }
 
     $self->debug_message("Allocation (%s) created at %s",

--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -207,8 +207,10 @@ sub _get_allocation_without_lock_impl {
 
     unless (defined $chosen_allocation) {
         Carp::confess $self->error_message(sprintf(
-            "Could not create allocation in specified disk group (%s), "
+            "Could not create allocation for %s kilobytes at <%s> in specified disk group (%s), "
             . "which contains %d volumes:\n%s\n",
+            $self->parameters->kilobytes_requested,
+            $self->parameters->allocation_path,
             $self->parameters->disk_group_name, scalar(@$candidate_volumes),
             join("\n", map { $_->mount_path } @$candidate_volumes),
         ));


### PR DESCRIPTION
This will hopefully make it easier to track down what went wrong in cases like CIS-148.