### PR TITLE
Stop using cwltoil's --stats option.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -110,7 +110,7 @@ sub run_toil {
     Genome::Sys->shellcmd(
         cmd => [
             'cwltoil',
-            '--disableCaching', '--stats', '--logLevel=DEBUG',
+            '--disableCaching', '--logLevel=DEBUG',
             @restart,
             '--workDir', $tmp_dir,
             '--jobStore', $jobstore_dir,


### PR DESCRIPTION
It's not worth the additional disk usage to use by default.