### PR TITLE
Fixes for restarting CwlPipeline builds

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/View.pm
+++ b/lib/perl/Genome/Model/Build/Command/View.pm
@@ -93,9 +93,17 @@ sub write_report {
         }
     }
 
-    my $process = $self->build->process;
-    if ($process) {
-        $self->_display_ptero_workflow($handle, $self->build->process->workflow_name);
+    my @process = $self->build->process;
+
+    if (@process > 1) {
+        @process = sort { $a->created_at cmp $b->created_at } @process;
+    }
+
+    for (@process) {
+        if (@process > 1) {
+            $handle->say("\nProcess " . $_->id . ' at ' . $_->created_at . ":");
+        }
+        $self->_display_ptero_workflow($handle, $_->workflow_name);
     }
 
     1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
@@ -71,6 +71,9 @@ sub _restart_build {
         File::Spec->join($build->data_directory, 'build.xml')
     );
 
+    my $now = time();
+    $xml =~ s/operation name="([^"]+)"/operation name="$1 - restart $now"/;
+
     return $build->_launch(\%params, $xml);
 }
 


### PR DESCRIPTION
* Handle multiple processes when viewing builds.
* Come up with a unique workflow name upon restart.