### PR TITLE
Pass the corrected sample name to the FinalPassOnly tool.

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Dispatcher.pm
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Dispatcher.pm
@@ -1033,7 +1033,7 @@ sub _create_final_pass_vcf {
     my $cmd = Genome::Model::Tools::Vcf::FinalPassOnly->create(
         input_file  => $source_vcf,
         output_file => $pass_vcf,
-        sample_name => $self->aligned_reads_sample,
+        sample_name => Genome::Sample->sample_name_to_name_in_vcf($self->aligned_reads_sample),
     );
     unless ($cmd->execute) {
         $self->fatal_message("Failed to run FinalPassOnly command.");


### PR DESCRIPTION
This is an alternate to #1761.  It has more parallels to the `_create_bed_from_vcf` in the dispatcher. It also allows the final pass tool to remain unaware of the complexities of samples, since it is only passed a string.