### PR TITLE
New command to purge allocations for a build.

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1782,6 +1782,29 @@ sub add_from_build { # rename "add an underlying build" or something...
     return $bridge;
 }
 
+sub purge {
+    my $self = shift;
+
+    $self->_deactivate_software_results;
+
+    my $reason = 'purging build ' . $self->__display_name__;
+
+    for my $result ($self->disk_usage_results) {
+
+        my @active_users = grep { $_->active } $result->users;
+
+        unless (@active_users) { #nothing else still actively uses this, so go ahead and remove
+            $result->disk_allocation->purge($reason);
+        }
+    }
+
+    for my $alloc ($self->disk_allocations) {
+        $alloc->purge($reason);
+    }
+
+    return 1;
+}
+
 sub delete {
     my $self = shift;
 

--- a/lib/perl/Genome/Model/Build/Command/Purge.pm
+++ b/lib/perl/Genome/Model/Build/Command/Purge.pm
@@ -26,6 +26,8 @@ sub execute {
     for my $build (@builds) {
         $build->purge or $self->fatal_message('Failed to purge build %s', $build->__display_name__);
     }
+
+    return 1;
 }
 
 1;

--- a/lib/perl/Genome/Model/Build/Command/Purge.pm
+++ b/lib/perl/Genome/Model/Build/Command/Purge.pm
@@ -1,0 +1,31 @@
+package Genome::Model::Build::Command::Purge;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::Build::Command::Purge {
+    is => 'Command::V2',
+    has         => [
+        builds => {
+            is                  => 'Genome::Model::Build',
+            is_many             => 1,
+            shell_args_position => 1,
+            doc                 => "Builds whose data to purge",
+            require_user_verify => 1,
+        },
+    ],
+};
+
+sub execute {
+    my $self = shift;
+
+    my @builds = $self->builds;
+
+    for my $build (@builds) {
+        $build->purge or $self->fatal_message('Failed to purge build %s', $build->__display_name__);
+    }
+}
+
+1;


### PR DESCRIPTION
It grabs a similar list of results to the `genome model build move-allocations` command, but only removes found results if they have no other active users.