### PR TITLE
Also disconnect the OLTP handle when disconnecting for long-running ops.

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1761,7 +1761,7 @@ sub capture {
 sub disconnect_default_handles {
     my $class = shift;
 
-    for my $ds (qw(Genome::DataSource::GMSchema)) {
+    for my $ds (qw(Genome::DataSource::GMSchema Genome::DataSource::Oltp)) {
         if($ds->has_default_handle) {
             $class->debug_message("Disconnecting $ds default handle.");
             $ds->disconnect_default_dbh();


### PR DESCRIPTION
We've been encountering some failures where this connection was left open and then closed by the remote server.