### PR TITLE
More Efficient Synch; Temporarily Stop LimsProjectInstrumentData Synch

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.pm
@@ -17,7 +17,7 @@ our @lims_classes = (
     } (qw/ 
         OrganismTaxon OrganismIndividual PopulationGroup OrganismSample LibrarySummary
         IndexIllumina Genotyping
-        LimsProject LimsProjectSample LimsProjectInstrumentData
+        LimsProject LimsProjectSample
         InstrumentDataAnalysisProjectBridge
     /)
 );


### PR DESCRIPTION
This PR includes a few changes to stop loading as much unnecessary data during synch.  Additionally, it stops synching `LimsProjectInstrumentData` for now, as this table cannot be examined in a reasonable timeframe for the operation.