### PR TITLE
Option to Specify an AnP When Importing Work Order

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddInstrumentData.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddInstrumentData.pm
@@ -46,7 +46,7 @@ sub execute {
     my $should_assign = $desired_assigned - $already_assigned;
     my $previously_assigned = $already_assigned->intersection($desired_assigned);
 
-    $self->status_message('Asked to asssign (%s) of which (%s) were already assigned. Proceeding to assign (%s)',
+    $self->status_message('Asked to assign (%s) of which (%s) were already assigned. Proceeding to assign (%s)',
         $desired_assigned->size, $previously_assigned->size, $should_assign->size);
 
     for my $instrument_data ($should_assign->members) {

--- a/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
@@ -13,6 +13,12 @@ class Genome::Site::TGI::Command::ImportDataForWorkOrder {
             doc => 'The ID of the work order to import',
         },
     ],
+    has_optional_input => [
+        analysis_project => {
+            is => 'Genome::Config::AnalysisProject',
+            doc => 'If specified, all found instrument data for the Work Order will be linked to this Analysis Project',
+        },
+    ],
 };
 
 sub execute {
@@ -192,6 +198,17 @@ sub _import_anp_associations {
     for (@potential) {
         unless ($existing_lookup{$_->instrument_data_id}{$_->analysis_project_id}) {
             $_->create_in_genome;
+        }
+    }
+
+    if (my $anp = $self->analysis_project) {
+        my $cmd = Genome::Config::AnalysisProject::Command::AddInstrumentData->create(
+            analysis_project => $anp,
+            instrument_data => \@data,
+        );
+
+        unless ($cmd->execute) {
+            $self->fatal_message('Failed to assign instrument data to analysis project.');
         }
     }
 


### PR DESCRIPTION
This is a shortcut to avoid looking up all the instrument data via project parts after import.