### PR TITLE
Stop synching genotype data.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.pm
@@ -16,7 +16,7 @@ our @lims_classes = (
         'Genome::Site::TGI::Synchronize::Classes::'.$_
     } (qw/ 
         OrganismTaxon OrganismIndividual PopulationGroup OrganismSample LibrarySummary
-        IndexIllumina Genotyping
+        IndexIllumina
         LimsProject LimsProjectSample
         InstrumentDataAnalysisProjectBridge
     /)

--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.t
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.t
@@ -13,7 +13,7 @@ my $class_mapping = Genome::Site::TGI::Synchronize::Classes::Dictionary->get;
 ok($class_mapping, 'get class mapping');
 
 my @entities_to_sync = $class_mapping->entity_names;
-is(@entities_to_sync, 10, 'entity names');
+is(@entities_to_sync, 9, 'entity names');
 
 ok(!eval{$class_mapping->lims_class_for_entity_name;}, 'failed to get lims class for undef entity');
 is($class_mapping->error_message, 'No entity name given to get LIMS class!', 'correct error');


### PR DESCRIPTION
~It can still be imported as needed via the import-data-for-work-order command.~ It won't be able to be imported anymore without manual intervention.