### PR TITLE
Use new canonical DGIdb.org domain.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Dgidb/Base.pm
+++ b/lib/perl/Genome/Model/Tools/Dgidb/Base.pm
@@ -8,7 +8,7 @@ use HTTP::Request::Common;
 
 
 
-my $DOMAIN   = 'http://dgidb.genome.wustl.edu/';
+my $DOMAIN   = 'http://dgidb.org/';
 
 class Genome::Model::Tools::Dgidb::Base {
     is => 'Command',


### PR DESCRIPTION
The old URL is returning 308 redirects, which this tool reports as errors.