### PR TITLE
(Re)index the converted alignment file.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
@@ -92,6 +92,11 @@ sub _run_conversion {
     );
 
     $self->_reindex($destination_file);
+
+    my @alloc = $self->alignment_result->disk_allocations;
+    for (@alloc) {
+        $_->reallocate;
+    }
 }
 
 sub _reindex {

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
@@ -90,6 +90,22 @@ sub _run_conversion {
         queue => Genome::Config::get('lsf_queue_build_worker'),
         wait_for_completion => 1,
     );
+
+    $self->_reindex($destination_file);
+}
+
+sub _reindex {
+    my $self = shift;
+    my $file = shift;
+
+    my $cmd = ['index', $file];
+
+    my $guard = Genome::Config::set_env('lsb_sub_additional', 'docker(mgibio/samtools:1.3.1)');
+    Genome::Sys::LSF::bsub::bsub(
+        cmd => $cmd,
+        queue => Genome::Config::get('lsf_queue_build_worker'),
+        wait_for_completion => 1,
+    );
 }
 
 sub _verify_file {


### PR DESCRIPTION
The conversion process may not produce an identical file, so we can't trust the existing index to still be valid.

Closes #1773.