### PR TITLE
Disable importing genotype data in `import-data-for-work-order`.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
@@ -38,9 +38,10 @@ sub execute {
     $self->_import_indexillumina($_) for @ii;
     $self->_import_anp_associations(@ii);
 
-    my @g = Genome::Site::TGI::Synchronize::Classes::Genotyping->get(id => [map $_->entity_id, @to_import]);
-    $self->_import_genotyping($_) for @g;
-    $self->_import_anp_associations(@g);
+    #disabled for lack of mechanism for getting the genotype file path
+    #my @g = Genome::Site::TGI::Synchronize::Classes::Genotyping->get(id => [map $_->entity_id, @to_import]);
+    #$self->_import_genotyping($_) for @g;
+    #$self->_import_anp_associations(@g);
 
     return 1;
 }


### PR DESCRIPTION
The normal synch process loads PIDFAs to find the file paths, but those are not guaranteed to exist for these data.

An alternative approach might be to create a new synch class with a query that attempts to capture the relevant information.  For now, disabling genotype import fixes importing other data for work orders with genotype information.