### PR TITLE
Ignore our own AnP when deciding if a result is still in use.

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1793,6 +1793,14 @@ sub purge {
 
         my @active_users = grep { $_->active } $result->users;
 
+        if(@active_users) {
+            my $anp = $self->model->analysis_project;
+            if ($anp) {
+                #ignore our own AnP when checking for other users
+                @active_users = grep { $_->user_id ne $anp->id } @active_users;
+            }
+        }
+
         unless (@active_users) { #nothing else still actively uses this, so go ahead and remove
             $result->disk_allocation->purge($reason);
         }


### PR DESCRIPTION
If other builds in the AnP are still using the result, they'll still be in the active users.  This does mean a result used by two AnPs still cannot be purged via this mechanism.