### PR TITLE
Don't hardcode the SMTP server location.

### DIFF
--- a/lib/perl/Genome/Model/Command/Report/Mail.pm
+++ b/lib/perl/Genome/Model/Command/Report/Mail.pm
@@ -198,7 +198,7 @@ sub send_mail {
 
         my $sender = Mail::Sender->new(
                     {
-                            smtp => 'gscsmtp.wustl.edu',
+                            smtp => Genome::Config::get('email_smtp_server'),
                             to => $recipients,
                             from => Genome::Config::get('email_pipeline'),
                             subject => $subject,

--- a/lib/perl/Genome/Model/Tools/ViromeScreening.pm
+++ b/lib/perl/Genome/Model/Tools/ViromeScreening.pm
@@ -141,7 +141,7 @@ sub _send_failed_mail {
     my $mail_dest = Genome::Sys::User->get_current->email;
 
     my $sender = Mail::Sender->new({
-        smtp => 'gscsmtp.wustl.edu',
+        smtp => Genome::Config::get('email_smtp_server'),
         from => Genome::Config::get('email_virome_screening'),
         replyto => Genome::Config::get('email_virome_screening'),
     });

--- a/lib/perl/Genome/Report/Email.pm
+++ b/lib/perl/Genome/Report/Email.pm
@@ -63,7 +63,7 @@ sub send_report {
     while ($count++ < $tries and !$success)  {
         eval {
             my $sender = Mail::Sender->new({
-                    smtp => 'gscsmtp.wustl.edu',
+                    smtp => Genome::Config::get('email_smtp_server'),
                     to => $to,
                     from => $from,
                     replyto => $reply_to,


### PR DESCRIPTION
The right answer in our environment changed recently, but these spots weren't properly using configuration.