### PR TITLE
AlignedBamResult: Try delegating to get the bam_path first.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignedBamResult.pm
+++ b/lib/perl/Genome/InstrumentData/AlignedBamResult.pm
@@ -25,7 +25,10 @@ class Genome::InstrumentData::AlignedBamResult {
         # from output
         bam_path => { # this is called bam_file in merged
             is_output => 1,
-            calculate => q| return $self->output_dir.'/'.$self->id.'.bam'; |, 
+            calculate => q|
+                return $self->merged_alignment_bam_path if $self->can('merged_alignment_bam_path');
+                return $self->output_dir.'/'.$self->id.'.bam';
+            |,
         },
         bam_file => { # alias
           is => 'Text',


### PR DESCRIPTION
This is to handle that some subclasses can "convert" now and store the file in other formats.