### PR TITLE
Fill in `result_users` hash before getting/creating alignments

### DIFF
--- a/lib/perl/Genome/Model/Build/RnaSeq.pm
+++ b/lib/perl/Genome/Model/Build/RnaSeq.pm
@@ -203,9 +203,12 @@ sub _fetch_alignment_result {
     my @instrument_data_inputs = $self->instrument_data_inputs;
     my ($params) = $self->model->params_for_alignment(@instrument_data_inputs);
 
+    my $result_users = Genome::SoftwareResult::User->user_hash_for_buld($self);
+
     my $alignment_class = Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($self->model->read_aligner_name);
     my $alignment = join('::', 'Genome::InstrumentData::AlignmentResult', $alignment_class)->$mode(
         %$params,
+        result_users => $result_users,
     );
 
     return $alignment;

--- a/lib/perl/Genome/Model/Build/RnaSeq.pm
+++ b/lib/perl/Genome/Model/Build/RnaSeq.pm
@@ -216,7 +216,7 @@ sub _fetch_alignment_result {
 
 sub delete {
     my $self = shift;
-    
+
     # if we have an alignments directory, nuke it first since it has its own allocation
     if (-e $self->accumulated_alignments_directory ||
         -e $self->accumulated_fastq_directory ||
@@ -231,14 +231,14 @@ sub delete {
             return;
         };
     }
-    
+
     $self->SUPER::delete(@_);
 }
 
 # nuke the accumulated alignment directory
 sub eviscerate {
     my $self = shift;
-    
+
     $self->debug_message('Entering eviscerate for build:' . $self->id);
 
 


### PR DESCRIPTION
This codepath is only used by processing profiles that perform Tophat 1 alignments.