### PR TITLE
The param is called "users" not "result_users" in results themselves.

### DIFF
--- a/lib/perl/Genome/Model/Build/RnaSeq.pm
+++ b/lib/perl/Genome/Model/Build/RnaSeq.pm
@@ -208,7 +208,7 @@ sub _fetch_alignment_result {
     my $alignment_class = Genome::InstrumentData::AlignmentResult->_resolve_subclass_name_for_aligner_name($self->model->read_aligner_name);
     my $alignment = join('::', 'Genome::InstrumentData::AlignmentResult', $alignment_class)->$mode(
         %$params,
-        result_users => $result_users,
+        users => $result_users,
     );
 
     return $alignment;


### PR DESCRIPTION
This fixes #1783.