### PR TITLE
Add ClinSeq's SR classes.

### DIFF
--- a/lib/perl/Genome/Model/Build/ClinSeq.pm
+++ b/lib/perl/Genome/Model/Build/ClinSeq.pm
@@ -117,4 +117,12 @@ sub normal_microarray_build {
     }
 }
 
+sub _disk_usage_result_subclass_names {
+    my $self = shift;
+
+    return [qw(
+        Genome::Model::ClinSeq::Command::AnnotateSnvsVcf::Result
+    )];
+}
+
 1;


### PR DESCRIPTION
This fixes `genome model build move-allocations` for ClinSeq builds.