### PR TITLE
Add GenotypeMicroarray's SR classes.

### DIFF
--- a/lib/perl/Genome/Model/Build/GenotypeMicroarray.pm
+++ b/lib/perl/Genome/Model/Build/GenotypeMicroarray.pm
@@ -176,5 +176,13 @@ sub filtered_snvs_bed {
     shift->data_directory . '/gold_snp.v2.bed';
 }
 
+sub _disk_usage_result_subclass_names {
+    my $self = shift;
+
+    return [qw(
+        Genome::InstrumentData::Microarray::Result::Vcf
+    )];
+}
+
 1;
 


### PR DESCRIPTION
This fixes `genome model build move-allocations` for GenotypeMicroarray builds.