### PR TITLE
Better CwlPipeline model naming.

### DIFF
--- a/lib/perl/Genome/Model.pm
+++ b/lib/perl/Genome/Model.pm
@@ -867,6 +867,7 @@ sub default_model_name {
         'reference alignment' => 'refalign',
         'de novo assembly' => 'denovo',
         'metagenomic composition 16s' => 'mc16s',
+        'cwl pipeline' => 'cwl',
     );
     $name .= ( exists $short_names{$type_name} )
     ? $short_names{$type_name}

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -18,6 +18,11 @@ class Genome::Model::CwlPipeline {
             is => 'Text',
             doc => 'docker image for the main toil worker jobs',
         },
+        short_pipeline_name => {
+            is => 'Text',
+            is_optional => 1,
+            doc => 'short name for pipeline to include in default model names',
+        },
     },
 };
 
@@ -200,5 +205,15 @@ sub determine_input_object {
     return;
 }
 
+sub _additional_parts_for_default_name {
+    my $self = shift;
+
+    my @parts;
+    my $name = $self->processing_profile->short_pipeline_name;
+
+    push @parts, $name if $name;
+
+    return @parts;
+}
 
 1;

--- a/lib/perl/Genome/Model/CwlPipeline.t
+++ b/lib/perl/Genome/Model/CwlPipeline.t
@@ -11,7 +11,7 @@ use above 'Genome';
 use Genome::Test::Factory::InstrumentData::Solexa;
 use Genome::Test::Factory::Individual;
 
-use Test::More tests => 7;
+use Test::More tests => 9;
 
 my $class = 'Genome::Model::CwlPipeline';
 use_ok($class);
@@ -19,7 +19,11 @@ use_ok($class);
 my $instrument_data = Genome::Test::Factory::InstrumentData::Solexa->setup_object;
 my $arbitrary_object = Genome::Test::Factory::Individual->setup_object;
 
-my $pp = Genome::ProcessingProfile::CwlPipeline->__define__(id => -100);
+my $pp = Genome::ProcessingProfile::CwlPipeline->__define__(
+    id => -100,
+    type_name => 'cwl pipeline',
+    short_pipeline_name => 'testing'
+);
 
 my @params = (
     processing_profile_id => $pp->id,
@@ -35,6 +39,9 @@ my @params = (
 );
 my $model = $class->create(@params);
 isa_ok($model, $class, 'created model');
+
+like($model->name, qr(cwl(?!_pipeline)), 'model name contains shortened cwl name');
+like($model->name, qr(testing), 'model name contains short pipeline name');
 
 my @inputs = $model->inputs;
 is(scalar(@inputs), 3, 'created inputs with model');

--- a/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.pm
+++ b/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.pm
@@ -22,6 +22,11 @@ class Genome::ProcessingProfile::Command::Create::CwlPipeline {
             doc => 'docker image for the main toil worker jobs',
             example_values => ['docker(mgibio/rnaseq)'],
         },
+        short_pipeline_name => {
+            is => 'Text',
+            is_optional => 1,
+            doc => 'short name for pipeline to include in default model names',
+        },
     ],
     has_transient_optional => [
         based_on => {


### PR DESCRIPTION
Since CwlPipeline encompasses many different workflows, it is more common to have multiple models per subject.  Having them named "cwl_pipeline-1" through "cwl_pipeline-6" is less than ideal, so this provides a way to distinguish them based on the workflows they run.