### PR TITLE
Canonicalize the data path.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Picard/ConcatenateMetricsFiles.t
+++ b/lib/perl/Genome/Model/Tools/Picard/ConcatenateMetricsFiles.t
@@ -11,7 +11,7 @@ use File::Spec qw();
 my $pkg = 'Genome::Model::Tools::Picard::ConcatenateMetricsFiles';
 use_ok($pkg);
 
-my $data_dir = sprintf "%s.d", __FILE__;
+my $data_dir = File::Spec->canonpath( sprintf "%s.d", __FILE__ );
 
 my @metrics = qw/
    CollectAlignmentSummaryMetrics


### PR DESCRIPTION
If the test is run as, e.g., "./ConcatenateMetricFiles.t", the data directory would have the "./" but the files written out would not, thwarting the replace in the comparison.