### PR TITLE
Add debug message with current stats when volume too full.

### DIFF
--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -202,6 +202,14 @@ sub _get_allocation_without_lock_impl {
                 );
                 last;
             }
+        } else {
+            $self->debug_message(
+                'Insufficient space on <%s>. (%s KB used, %s KB allocated, %s KB soft limit)',
+                $candidate_volume->mount_path,
+                $candidate_volume->used_kb,
+                scalar($candidate_volume->allocated_kb),
+                $candidate_volume->soft_limit_kb,
+            );
         }
     }
 


### PR DESCRIPTION
The current logging tells us how big the request was that failed, but often the state of the volumes has changed to where the request seems fulfillable.  This will hopefully help capture how much space pressure is being felt.