### PR TITLE
Import Requires Base Working Directory

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic.pm
@@ -25,6 +25,10 @@ class Genome::InstrumentData::Command::Import::Basic {
             is_many => 1,
             doc => 'Source files to import. If importing fastqs, put the file containing the forward [read 1] reads first.',
         },
+        base_working_directory => {
+            is => 'Text',
+            doc => 'Base working directory to use when running the import. A temporary directory will be made inside this directory, and removed when the import fails or completes.',
+        },
     ],
     has_optional_input => {
         description  => {
@@ -35,10 +39,6 @@ class Genome::InstrumentData::Command::Import::Basic {
             is => 'Text',
             is_many => 1,
             doc => 'Name and value pairs to add to the instrument data. Separate name and value with an equals (=) and name/value pairs with a comma (,).',
-        },
-        base_working_directory => {
-            is => 'Text',
-            doc => 'Base working directory to use when running the import. A temporary directory will be made inside this directory, and removed when the import fails or completes.',
         },
     },
     has_optional_transient => [

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam.t
@@ -31,13 +31,16 @@ my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Comma
 my $source_bam = $test_dir.'/input.bam';
 ok(-s $source_bam, 'source bam exists') or die;
 
+my $wd = Genome::Sys->create_temp_directory();
+
 my $cmd = Genome::InstrumentData::Command::Import::Basic->create(
     analysis_project => $analysis_project,
     library => $library,
     source_files => [$source_bam],
     import_source_name => 'broad',
     instrument_data_properties => [qw/ lane=2 flow_cell_id=XXXXXX /],
-    description => 'We took some DNA and sheared it and sequenced it.'
+    description => 'We took some DNA and sheared it and sequenced it.',
+    base_working_directory => $wd,
 );
 ok($cmd, "create import command");
 ok($cmd->execute, "execute import command");

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_downsample.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_downsample.t
@@ -31,6 +31,8 @@ my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Comma
 my $source_bam = $test_dir.'/input.bam';
 ok(-s $source_bam, 'source bam exists') or die;
 
+my $wd = Genome::Sys->create_temp_directory();
+
 my $cmd = Genome::InstrumentData::Command::Import::Basic->create(
     analysis_project => $analysis_project,
     library => $library,
@@ -38,6 +40,7 @@ my $cmd = Genome::InstrumentData::Command::Import::Basic->create(
     import_source_name => 'broad',
     downsample_ratio => .25,
     instrument_data_properties => [qw/ lane=2 flow_cell_id=XXXXXX /],
+    base_working_directory => $wd,
 );
 ok($cmd, "create import command");
 ok($cmd->execute, "execute import command");

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_multi_groups.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_bam_multi_groups.t
@@ -30,12 +30,15 @@ my $test_dir = Genome::Utility::Test->data_dir_ok('Genome::InstrumentData::Comma
 my $source_bam = $test_dir.'/input.multi-rg.bam';
 ok(-s $source_bam, 'source bam exists') or die;
 
+my $wd = Genome::Sys->create_temp_directory();
+
 my $cmd = Genome::InstrumentData::Command::Import::Basic->create(
     analysis_project => $analysis_project,
     library => $library,
     source_files => [$source_bam],
     import_source_name => 'broad',
     instrument_data_properties => [qw/ lane=2 flow_cell_id=XXXXXX /],
+    base_working_directory => $wd,
 );
 ok($cmd, "create import command");
 ok($cmd->execute, "execute import command");

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_fastq.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_fastq.t
@@ -33,12 +33,15 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
+my $wd = Genome::Sys->create_temp_directory();
+
 my $cmd = Genome::InstrumentData::Command::Import::Basic->create(
     analysis_project => $analysis_project,
     library => $library,
     source_files => \@source_files,
     import_source_name => 'broad',
     instrument_data_properties => [qw/ lane=2 flow_cell_id=XXXXXX /],
+    base_working_directory => $wd,
 );
 ok($cmd, "create import command");
 ok($cmd->execute, "execute import command");

--- a/lib/perl/Genome/InstrumentData/Command/Import/Basic_sra.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Basic_sra.t
@@ -30,12 +30,15 @@ my $library = Genome::Library->create(
 );
 ok($library, 'Create library');
 
+my $wd = Genome::Sys->create_temp_directory();
+
 my $cmd = Genome::InstrumentData::Command::Import::Basic->create(
     analysis_project => $analysis_project,
     library => $library,
     source_files => [$source_sra],
     import_source_name => 'sra',
     instrument_data_properties => [qw/ lane=2 flow_cell_id=XXXXXX /],
+    base_working_directory => $wd,
 );
 ok($cmd, "create import command");
 ok($cmd->execute, "execute import command") or die;


### PR DESCRIPTION
Add base_working_directory as a required property. Imports fail without it defined.