### PR TITLE
Add `set_env` to Analysis Projects

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject.pm
+++ b/lib/perl/Genome/Config/AnalysisProject.pm
@@ -154,6 +154,37 @@ sub environment_config_dir {
     return;
 }
 
+sub set_env {
+    my $self = shift;
+    my $config_dir = $self->environment_config_dir;
+    unless ($config_dir) {
+        $self->fatal_message(
+            'AnP %s does not have an envrionment configuration set.',
+            $self->__display_name__
+        );
+    }
+
+    my $env_var = 'XGENOME_CONFIG_PROJECT_DIR';
+
+    my $guard_closure;
+    if (exists $ENV{$env_var}) {
+        my $orig_value = $ENV{$env_var};
+        $guard_closure = sub { $ENV{$env_var} = $orig_value };
+    }
+    else {
+        $guard_closure = sub { delete $ENV{$env_var} };
+    }
+
+    $ENV{$env_var} = $config_dir;
+
+    if (defined wantarray) {
+        my $guard = Scope::Guard->new($guard_closure);
+        return $guard;
+    }
+
+    return 1;
+}
+
 sub system_analysis_project {
     my $class = shift;
 

--- a/lib/perl/Genome/Model/Build/Command/MoveAllocations.pm
+++ b/lib/perl/Genome/Model/Build/Command/MoveAllocations.pm
@@ -110,9 +110,7 @@ sub _resolve_disk_group_for_build {
     unless ($anp) {
         $self->fatal_message('No analysis project defined for build %s and no disk_group specified!', $build->__display_name__);
     }
-
-    my $config_dir = $anp->environment_config_dir;
-    local $ENV{XGENOME_CONFIG_PROJECT_DIR} = $config_dir;
+    my $guard = $anp->set_env;
 
     my $dg = Genome::Config::get('disk_group_models');
 

--- a/lib/perl/Genome/Model/Build/Command/Start.pm
+++ b/lib/perl/Genome/Model/Build/Command/Start.pm
@@ -131,8 +131,8 @@ sub create_and_start_build {
     my $outer_transaction = UR::Context::Transaction->begin();
     $model->build_requested(0);
     my $anp = $model->analysis_project;
-    my $config_dir = $anp? $anp->environment_config_dir : undef;
-    local $ENV{XGENOME_CONFIG_PROJECT_DIR} = $config_dir;
+    my $guard;
+    $guard = $anp->set_env if $anp;
 
     my $create_transaction = UR::Context::Transaction->begin();
     my $build = try {


### PR DESCRIPTION
This encapsulates the logic for running code in the environment of an Analysis Project.