### PR TITLE
Build `abandon()` purges the Build's Allocation(s)

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1491,7 +1491,15 @@ sub abandon {
     $self->_abandon_events
         or return;
 
-    $self->reallocate_disk_allocations;
+
+    for my $da ($self->disk_allocations) {
+        Genome::Sys::CommitAction->create(
+            on_commit => sub {
+                $da->purge('abandoning build');
+            },
+        );
+    }
+
     $self->_deactivate_software_results;
 
     my %add_note_args = (header_text => $header_text);

--- a/lib/perl/Genome/Model/Build.t
+++ b/lib/perl/Genome/Model/Build.t
@@ -122,7 +122,13 @@ no warnings;
 };
 use warnings;
 
-my $disk_allocation = Genome::Test::Factory::DiskAllocation->generate_obj(owner => $build);
+my $disk_allocation = Genome::Disk::Allocation->create(
+    kilobytes_requested => 1,
+    owner_id => $build->id,
+    owner_class_name => $build->class,
+    disk_group_name => Genome::Config::get('disk_group_models'),
+    allocation_path => 'temp/Model/Build.t_test/' . $build->id,
+);
 is($build->disk_allocation, $disk_allocation, 'disk_allocation');
 is_deeply([$build->disk_allocations], [$disk_allocation], 'disk_allocations');
 

--- a/lib/perl/Genome/Model/Build.t
+++ b/lib/perl/Genome/Model/Build.t
@@ -166,7 +166,9 @@ $disk_allocation->kilobytes_requested(2000); # reset
 ok($build->abandon, 'Abandon');
 is($build->status, 'Abandoned', 'Status is Abandoned');
 isnt($model->last_complete_build_id, $build->id, 'Model last complete build is not this build\'s id in abandon');
-isnt($disk_allocation->kilobytes_requested, 2000, 'disk_allocation reallocated');
+
+UR::Context->commit(); # triggers the allocation purge
+is($disk_allocation->status, 'purged', 'disk_allocation purged');
 
 # Init, fail and succeed a abandoned build
 ok(!$build->initialize, 'Failed to initialize an abandoned build');


### PR DESCRIPTION
We've been manually sweeping these later, but might as well take care of it right away!