### PR TITLE
Remove "ignored" from solexa update tree.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Solexa/Command.pm
+++ b/lib/perl/Genome/InstrumentData/Solexa/Command.pm
@@ -22,7 +22,7 @@ Genome::Command::Crud->init_sub_commands(
     create => {do_not_init => 1},
     delete => {do_not_init => 1},
     list => {do_not_init => 1},
-    update => {only_if_null => 1, exclude => [qw/ library full_path /]},
+    update => {only_if_null => 1, exclude => [qw/ library full_path ignored /]},
 );
 
 1;


### PR DESCRIPTION
This always has an initial value so cannot be updated due to the `only_if_null` restriction on solexa updates.  The generic instrument-data updater can be used to modify this value.