### PR TITLE
CwlPipeline Cleanup

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Cleanup.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Cleanup.pm
@@ -40,12 +40,14 @@ sub execute {
         my $results_dir = File::Spec->join($data_directory, 'results');
 
         my $tmp_dir = Genome::Sys->create_temp_directory($build->id);
+
         my $results_dir_mode = mode($results_dir);
         $results_dir_mode->add_user_writable();
+        my $guard = Scope::Guard->new(sub { $results_dir_mode->rm_user_writable(); });
+
         unless (Genome::Model::CwlPipeline::Command::Run->cleanup($tmp_dir, $results_dir)) {
             $self->fatal_message("Failed to cleanup build tmp dir '%s' and results dir '%s'", $tmp_dir, $results_dir);
         }
-        $results_dir_mode->rm_user_writable();
 
         my $allocation_path = File::Spec->join('model_data',$build->model->id,'build'. $build->id);
         my $allocation = Genome::Disk::Allocation->get(allocation_path => $allocation_path);

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Cleanup.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Cleanup.pm
@@ -29,7 +29,10 @@ sub execute {
     my $self = shift;
 
     for my $build ($self->builds) {
-
+        unless ($build->status eq 'Succeeded') {
+            $self->fatal_message("Unable to run cleanup on '%s' build with id '%s'. For Failed builds, please abandon instead once troubleshooting is complete.",$build->status,$build->id);
+        }
+        
         my $data_directory = $build->data_directory;
 
         my $results_dir = File::Spec->join($data_directory, 'results');

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Cleanup.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Cleanup.pm
@@ -49,12 +49,7 @@ sub execute {
             $self->fatal_message("Failed to cleanup build tmp dir '%s' and results dir '%s'", $tmp_dir, $results_dir);
         }
 
-        my $allocation_path = File::Spec->join('model_data',$build->model->id,'build'. $build->id);
-        my $allocation = Genome::Disk::Allocation->get(allocation_path => $allocation_path);
-        unless ($allocation) {
-            $self->fatal_message("Failed to find allocation by allocation path '%s'.", $allocation_path);
-        }
-        $allocation->reallocate();
+        $build->reallocate_disk_allocations();
     }
 
     return 1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Cleanup.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Cleanup.pm
@@ -1,0 +1,54 @@
+package Genome::Model::CwlPipeline::Command::Cleanup;
+
+use strict;
+use warnings;
+
+use File::Spec;
+use Genome;
+
+class Genome::Model::CwlPipeline::Command::Cleanup {
+    is => 'Command::V2',
+    has => [
+        builds => {
+            is => 'Genome::Model::Build::CwlPipeline',
+            is_many => 1,
+            doc => 'The build(s) to cleanup disk.',
+        },
+    ],
+    doc => 'cleanup disk for older CwlPipeline builds.',
+};
+
+sub help_detail {
+    return <<EOHELP
+Remove the tmp* directories and the content of those directories from the build data directory. Also reallocate the size after removal.
+EOHELP
+    ;
+}
+
+sub execute {
+    my $self = shift;
+
+    for my $build ($self->builds) {
+
+        my $data_directory = $build->data_directory;
+
+        my $results_dir = File::Spec->join($data_directory, 'results');
+
+        my $tmp_dir = Genome::Sys->create_temp_directory($build->id);
+        unless (Genome::Model::CwlPipeline::Command::Run->cleanup($tmp_dir, $results_dir)) {
+            $self->fatal_message("Failed to cleanup build tmp dir '%s' and results dir '%s'", $tmp_dir, $results_dir);
+        }
+
+        my $allocation_path = File::Spec->join('model_data',$build->model->id,'build'. $build->id);
+        my $allocation = Genome::Disk::Allocation->get(allocation_path => $allocation_path);
+        unless ($allocation) {
+            $self->fatal_message("Failed to find allocation by allocation path '%s'.", $allocation_path);
+        }
+        $allocation->reallocate();
+    }
+
+    return 1;
+}
+
+
+1;


### PR DESCRIPTION
A quick tool to help cleanup older CwlPipeline builds.

I'm getting errors like:
```
2018/01/03 15:39:50 Genome::Sys: Problems encountered removing /gscmnt/gc2568/techd/model_data/4e699a3f32a243c48cda2ecaa374da56/build65eb643b64ac4ed38475751b8285bb75/results/tmp4CoNwC
File /gscmnt/gc2568/techd/model_data/4e699a3f32a243c48cda2ecaa374da56/build65eb643b64ac4ed38475751b8285bb75/results/tmp4CoNwC, message: cannot remove directory: Permission denied
```

NOTE: This was run as the prod-builder user

When I cleanup the tmp* directories as prod-builder user I usually have to:
chmod u+w $data_directory/results
chmod -R u+w $data_directory/results/tmp*
rm -fR $data_directory/results/tmp*
chmod u-w $data_directory/results

I'm not entirely sure how `Genome::Sys->remove_directory_tree()` works on restricted permission files and directories. After looking at an example directory that failed to be removed the files are gone.
  
See #1815 for real solution.