### PR TITLE
Update blessed clinseq-wer build.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
+++ b/lib/perl/Genome/Model/Build/Command/DiffBlessed.pm.YAML
@@ -1,7 +1,7 @@
 ---
 apipe-test-amplicon-assembly: 133133151
 apipe-test-clinseq-v1: 133114501
-apipe-test-clinseq-wer: 2fef0a48459842a4b2b5622dee69d2b7
+apipe-test-clinseq-wer: f1add76001974a54b45a754eddb439f1
 apipe-test-de-novo-soap: 137388725
 apipe-test-de-novo-velvet: 79a406fcf18c46e090dec62342b2c4ae
 apipe-test-gene-prediction-bacterial: 4ddaecaa52364dd09b3a4d7709ddfc3b


### PR DESCRIPTION
Files are being moved, so the paths in the IGV XML are changing.  (This seems likely to be a recurring issue for awhile as data is migrated.)