### PR TITLE
Add UnionCnv to list of DV2 results that should get moved.

### DIFF
--- a/lib/perl/Genome/Model/Build/RunsDV2.pm
+++ b/lib/perl/Genome/Model/Build/RunsDV2.pm
@@ -105,6 +105,7 @@ sub _dv2_result_subclass_names {
         Genome::Model::Tools::DetectVariants2::Result::Combine::IntersectSnv
         Genome::Model::Tools::DetectVariants2::Result::Combine::IntersectIndel
         Genome::Model::Tools::DetectVariants2::Result::Combine::LqUnion
+        Genome::Model::Tools::DetectVariants2::Result::Combine::UnionCnv
         Genome::Model::Tools::DetectVariants2::Result::Combine::UnionSv
         Genome::Model::Tools::DetectVariants2::Result::Combine::UnionuniqueIndel
         Genome::Model::Tools::DetectVariants2::Result::Combine::UnionuniqueSnv


### PR DESCRIPTION
These are currently getting left behind by `genome model build move-allocations`.