### PR TITLE
Add IdentifyDnpResult as a SomaticValidation result class.

### DIFF
--- a/lib/perl/Genome/Model/Build/SomaticValidation.pm
+++ b/lib/perl/Genome/Model/Build/SomaticValidation.pm
@@ -360,6 +360,7 @@ sub _disk_usage_result_subclass_names {
         Genome::InstrumentData::AlignmentResult::Speedseq
         Genome::InstrumentData::AlignmentResult::Merged::Speedseq
         Genome::Qc::Result
+        Genome::Model::Build::SomaticValidation::IdentifyDnpResult
     ));
 
     return \@classes;


### PR DESCRIPTION
These were getting skipped when doing disk moves.