### PR TITLE
More build restart fixes

### DIFF
--- a/lib/perl/Genome/Model/Build/Process.pm
+++ b/lib/perl/Genome/Model/Build/Process.pm
@@ -19,7 +19,8 @@ class Genome::Model::Build::Process {
 
 sub workflow_name {
     my $self = shift;
-    return $self->build->workflow_name;
+
+    return join(" - ", $self->build->workflow_name, $self->id);
 }
 
 sub lsf_project_name {

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
@@ -63,6 +63,10 @@ sub _restart_build {
         die 'Can only restart failed builds.';
     }
 
+    my $anp = $build->model->analysis_project;
+    my $guard;
+    $guard = $anp->set_env if $anp;
+
     $build->status('Scheduled');
     $build->date_completed(undef);
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
@@ -71,9 +71,6 @@ sub _restart_build {
         File::Spec->join($build->data_directory, 'build.xml')
     );
 
-    my $now = time();
-    $xml =~ s/operation name="([^"]+)"/operation name="$1 - restart $now"/;
-
     return $build->_launch(\%params, $xml);
 }
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.t
@@ -20,6 +20,13 @@ my $class = 'Genome::Model::CwlPipeline::Command::Restart';
 use_ok($class);
 
 my $anp = Genome::Test::Factory::AnalysisProject->setup_object;
+my $env_file = Genome::Sys->create_temp_file_path;
+Genome::Sys->write_file($env_file, "testing: 123\n");
+Genome::Config::AnalysisProject::Command::AddEnvironmentFile->execute(
+    environment_file => $env_file,
+    analysis_project => $anp,
+);
+
 my $model = Genome::Test::Factory::Model::CwlPipeline->setup_object(
     name => 'testing restart command',
 );


### PR DESCRIPTION
Inspired by #1826.

The one downside of this approach is old builds/processes won't be able to display their workflows anymore, since the name doesn't match. Alternatives might include storing the name in the database or adding some date logic to decide which name to generate... but those are a lot more complex solutions to the problem.