### PR TITLE
Fixes for CwlPipeline Input Processing

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -157,7 +157,7 @@ sub determine_input_objects {
     for my $name (keys %data) {
         my $value = $class->determine_input_object($name, $data{$name});
         unless($value) {
-            $class->fatal_message('Unable to determine input for name "%s" and value "%s".', $name, $data{name});
+            $class->fatal_message('Unable to determine input for name "%s" and value "%s".', $name, $data{$name});
         }
 
         $inputs{$name} = $value;

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -156,7 +156,7 @@ sub determine_input_objects {
     my %inputs;
     for my $name (keys %data) {
         my $value = $class->determine_input_object($name, $data{$name});
-        unless($value) {
+        unless(defined $value) {
             $class->fatal_message('Unable to determine input for name "%s" and value "%s".', $name, $data{$name});
         }
 


### PR DESCRIPTION
This was failing when given `0` as an input value.