### PR TITLE
Fix for assigning new instrument data to specified AnP.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportDataForWorkOrder.pm
@@ -205,7 +205,7 @@ sub _import_anp_associations {
     if (my $anp = $self->analysis_project) {
         my $cmd = Genome::Config::AnalysisProject::Command::AddInstrumentData->create(
             analysis_project => $anp,
-            instrument_data => \@data,
+            instrument_data => [Genome::InstrumentData->get([map $_->id, @data])],
         );
 
         unless ($cmd->execute) {


### PR DESCRIPTION
The `@data` passed in here is not the Genome object but the synch object, so we need to look up the Genome entitiy for the add command.