### PR TITLE
New SR and Command for getting IntervalLists from FeatureLists

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
+++ b/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
@@ -1,0 +1,71 @@
+package Genome::FeatureList::Command::DumpIntervalList;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::FeatureList::Command::DumpIntervalList {
+    is => 'Command::V2',
+    has_input => {
+        feature_list => {
+            is => 'Genome::FeatureList',
+            doc => 'the feature list to convert to interval list',
+        },
+        reference_build => {
+            is => 'Genome::Model::Build::ReferenceSequence',
+            doc => 'the reference for which to produce the interval list',
+        },
+        track_name => {
+            is => 'Text',
+            doc => 'For multi-tracked BED files, which track to use',
+            valid_values => Genome::FeatureList::IntervalList->__meta__->property(property_name => 'track_name')->valid_values,
+        },
+        merge => {
+            is => 'Boolean',
+            doc => 'whether to merge adjacent regions of the BED file',
+            default => 1,
+        },
+    },
+    has_optional_output => {
+        output_path => {
+            is => 'Path',
+            doc => 'where to write the interval_list (default: STDOUT)',
+        },
+    },
+};
+
+sub execute {
+    my $self = shift;
+
+    my $result_users = {
+        sponsor => Genome::Config::AnalysisProject->system_analysis_project,
+        requestor => $self->reference_build,
+    };
+
+    my $sr = Genome::FeatureList::IntervalList->get_or_create(
+        feature_list => $self->feature_list,
+        reference_build => $self->reference_build,
+        track_name => $self->track_name,
+        merge => $self->merge,
+        users => $result_users,
+    );
+
+    unless($sr) {
+        $self->fatal_message('Failed to get or create interval list.');
+    }
+    my $file = $sr->interval_list;
+
+    if ($self->output_path) {
+        Genome::Sys->copy_file($file, $self->output_path);
+    } else {
+        Genome::Sys->shellcmd(
+            cmd => ['cat', $file],
+            input_files => $file,
+        );
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/FeatureList/Command/DumpIntervalList.t
+++ b/lib/perl/Genome/FeatureList/Command/DumpIntervalList.t
@@ -1,0 +1,64 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+use Genome::Test::Factory::AnalysisProject;
+use Test::More tests => 6;
+use Genome::Utility::Test qw(compare_ok);
+
+my $class = 'Genome::FeatureList::Command::DumpIntervalList';
+
+use_ok($class);
+
+Genome::Test::Factory::AnalysisProject->setup_system_analysis_project;
+my $reference= Genome::Model::Build::ReferenceSequence->get(name => 'GRCh37-lite-build37');
+
+my $bed_path = Genome::Sys->create_temp_file_path;
+Genome::Sys->write_file($bed_path,
+    "1\t11\t12\tregion1\n",
+    "1\t40\t50\tregion2\n",
+);
+my $fl_cmd = Genome::FeatureList::Command::Create->create(
+    name => 'test feature list for dump-interval-list',
+    format => 'true-BED',
+    file_path => $bed_path,
+    content_type => 'targeted',
+    description => 'just a test',
+    source => 'GMS',
+    reference => $reference,
+);
+my $test_fl = $fl_cmd->execute;
+isa_ok($test_fl, 'Genome::FeatureList', 'setup test feature-list');
+
+my $interval_list_path = Genome::Sys->create_temp_file_path;
+my $dump_command = $class->create(
+    feature_list => $test_fl,
+    reference_build => $reference,
+    track_name => 'target_region',
+    output_path => $interval_list_path,
+);
+isa_ok($dump_command, $class, 'created interval-list command');
+ok($dump_command->execute, 'executed interval-list command');
+
+ok(-e $interval_list_path, 'created interval-list');
+
+my $expected_file = Genome::Sys->create_temp_file_path;
+Genome::Sys->write_file($expected_file,
+"\@HD	VN:1.4	SO:unsorted\n",
+"\@SQ etc. etc.\n" x 84,
+"1	12	12	+	r0\n",
+"1	41	50	+	r1\n"
+);
+
+compare_ok($interval_list_path, $expected_file, 
+    name => 'produced expected interval-list',
+    filters => [qr/\@SQ.*?$/],
+);
+
+

--- a/lib/perl/Genome/FeatureList/IntervalList.pm
+++ b/lib/perl/Genome/FeatureList/IntervalList.pm
@@ -1,0 +1,96 @@
+package Genome::FeatureList::IntervalList;
+
+use strict;
+use warnings;
+
+use Genome;
+
+use File::Spec;
+
+class Genome::FeatureList::IntervalList {
+    is => ['Genome::SoftwareResult::StageableSimple', 'Genome::SoftwareResult::WithNestedResults'],
+    has_input => {
+        feature_list => {
+            is => 'Genome::FeatureList',
+            doc => 'the feature list to convert to interval list',
+        },
+        reference_build => {
+            is => 'Genome::Model::Build::ReferenceSequence',
+            doc => 'the reference in which to produce the interval list',
+        },
+    },
+    has_param => [
+        track_name => {
+            is => 'Text',
+            doc => 'For multi-tracked BED files, which track to use',
+            valid_values => Genome::FeatureList::Command::DumpMergedList->__meta__->property(property_name => 'track_name')->valid_values,
+        },
+        merge => {
+            is => 'Boolean',
+            doc => 'whether to merge adjacent regions of the BED file',
+            default => 1,
+        },
+    ],
+};
+
+sub interval_list {
+    my $self = shift;
+
+    return File::Spec->join($self->output_dir, $self->_file_name);
+}
+
+sub _file_name {
+    my $self = shift;
+    my $fl = $self->feature_list;
+
+    return $fl->id . '.interval_list';
+}
+
+sub _run {
+    my $self = shift;
+
+    my $dumped_bed_path = Genome::Sys->create_temp_file_path;
+
+    my @alt_reference;
+    if ($self->reference_build ne $self->feature_list->reference) {
+        @alt_reference = (alternate_reference => $self->reference_build);
+    }
+
+    my $bed_dumper = Genome::FeatureList::Command::DumpMergedList->create(
+        output_path => $dumped_bed_path,
+        feature_list => $self->feature_list,
+        track_name => $self->track_name,
+        merge => $self->merge,
+        result_users => $self->_user_data_for_nested_results,
+        @alt_reference,
+    );
+    unless ($bed_dumper and $bed_dumper->execute) {
+        $self->fatal_message('Failed to get dumped BED file for conversion');
+    }
+
+    my $interval_list_path = File::Spec->join($self->temp_staging_directory, $self->_file_name);
+
+    my $converter = Genome::Model::Tools::Picard::BedToIntervalList->create(
+        input => $dumped_bed_path,
+        output => $interval_list_path,
+        sequence_dictionary => $self->reference_build->sequence_dictionary_path('sam'),
+        use_version => '1.124',
+    );
+    unless($converter and $converter->execute) {
+        $self->fatal_message('Failed to convert BED to interval list');
+    }
+
+    return 1;
+}
+
+sub resolve_allocation_subdirectory {
+    my $self = shift;
+
+    return File::Spec->join('model_data', 'interval-list', $self->id);
+}
+
+sub resovle_allocation_disk_group_name {
+    Genome::Config::get('disk_group_references');
+}
+
+1;


### PR DESCRIPTION
New pipelines tend to need interval lists, so this is intended as a mechanism for generating them for the target region sets for instrument data.