### PR TITLE
Unlink the old file before reallocating.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/BamToCram.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/BamToCram.pm
@@ -41,12 +41,7 @@ sub execute {
 
     $self->_run_conversion('-C', $bam_file, $cram_file);
 
-    unless ($self->_verify_file($cram_file)) {
-        $self->fatal_message('Failed to convert to CRAM file.');
-    } else {
-        unlink $bam_file;
-        $result->filetype('cram');
-    }
+    $result->filetype('cram');
 
     return 1;
 }

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
@@ -93,6 +93,12 @@ sub _run_conversion {
 
     $self->_reindex($destination_file);
 
+    unless ($self->_verify_file($destination_file)) {
+        $self->fatal_message('Failed to convert file.');
+    } else {
+        unlink $source_file;
+    }
+
     my @alloc = $self->alignment_result->disk_allocations;
     for (@alloc) {
         $_->reallocate;

--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/CramToBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/CramToBam.pm
@@ -41,12 +41,7 @@ sub execute {
 
     $self->_run_conversion('-b', $cram_file, $bam_file);
 
-    unless ($self->_verify_file($bam_file)) {
-        $self->fatal_message('Failed to convert to BAM file.');
-    } else {
-        unlink $cram_file;
-        $result->filetype('bam');
-    }
+    $result->filetype('bam');
 
     return 1;
 }


### PR DESCRIPTION
This was reallocating while both the BAM and CRAM were present.  That's very conservative!  But also somewhat defeats the purpose of this converter :smile: 