### PR TITLE
`genome model cwl-pipeline` usability improvements

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command.pm
@@ -1,0 +1,16 @@
+package Genome::Model::CwlPipeline::Command;
+
+use Genome;
+
+use strict;
+use warnings;
+
+class Genome::Model::CwlPipeline::Command {
+    is => 'Command::Tree',
+    doc => 'operate on cwl-pipeline models',
+};
+
+sub sub_command_category { 'type specific' }
+
+1;
+

--- a/lib/perl/Genome/Model/CwlPipeline/Command/PrepForTransfer.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/PrepForTransfer.pm
@@ -13,6 +13,7 @@ class Genome::Model::CwlPipeline::Command::PrepForTransfer {
             is => 'Genome::Model::Build::CwlPipeline',
             is_many => 1,
             doc => 'The build(s) to prepare for data transfer',
+            shell_args_position => 1,
         },
         directory => {
             is => 'Text',

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
@@ -13,6 +13,7 @@ class Genome::Model::CwlPipeline::Command::Restart {
             is => 'Genome::Model::Build::CwlPipeline',
             is_many => 1,
             doc => 'The build(s) to restart',
+            shell_args_position => 1,
         },
     ],
     doc => 'relaunch a failed build',


### PR DESCRIPTION
* Make `builds` a positional parameter when useful.
* Add the base of the command tree so tab-completion can find these commands and they appear in help.