### PR TITLE
BED-related results should use `disk_group_references`.

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
+++ b/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
@@ -61,7 +61,7 @@ sub execute {
     } else {
         Genome::Sys->shellcmd(
             cmd => ['cat', $file],
-            input_files => $file,
+            input_files => [$file],
         );
     }
 

--- a/lib/perl/Genome/FeatureList/IntervalList.pm
+++ b/lib/perl/Genome/FeatureList/IntervalList.pm
@@ -89,7 +89,7 @@ sub resolve_allocation_subdirectory {
     return File::Spec->join('model_data', 'interval-list', $self->id);
 }
 
-sub resovle_allocation_disk_group_name {
+sub resolve_allocation_disk_group_name {
     Genome::Config::get('disk_group_references');
 }
 

--- a/lib/perl/Genome/Model/Build/ReferenceSequence/ConvertedBedResult.pm
+++ b/lib/perl/Genome/Model/Build/ReferenceSequence/ConvertedBedResult.pm
@@ -76,5 +76,9 @@ sub _validate_source_bed {
     return 1;
 }
 
+sub _allocation_disk_group_name {
+    Genome::Config::get('disk_group_references');
+}
+
 1;
 


### PR DESCRIPTION
We've decided to include `ConvertedBedResult`s in the set of things that are "core".