### PR TITLE
Add empty _disk_usage_result_subclass_names for DifferentialExpression

### DIFF
--- a/lib/perl/Genome/Model/Build/DifferentialExpression.pm
+++ b/lib/perl/Genome/Model/Build/DifferentialExpression.pm
@@ -48,5 +48,11 @@ sub summary_report_pdf_file {
     return $self->summarize_differential_expression_directory .'/summary.pdf';
 }
 
+sub _disk_usage_result_subclass_names {
+    my $self = shift;
+
+    return [];
+}
+
 1;
 


### PR DESCRIPTION
This build type didn't get SoftwareResults added.