### PR TITLE
Include the tag name in the default AnP config lister.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/ShowConfig.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/ShowConfig.pm
@@ -18,7 +18,7 @@ class Genome::Config::AnalysisProject::Command::ShowConfig {
             value => 'Genome::Config::Profile::Item',
         },
         show => {
-            default_value => 'id,file_path,updated_at,is_concrete,analysis_menu_item.name,status',
+            default_value => 'id,file_path,updated_at,is_concrete,analysis_menu_item.name,status,tags.name',
         },
     ],
     has_optional_input => [


### PR DESCRIPTION
Tags can be the sole factor that prevents a particular configuration from matching, so it'd be helpful to offer a bit more visibility.