### PR TITLE
Remove the source file's index when we remove the source file.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
+++ b/lib/perl/Genome/InstrumentData/Command/AlignmentResult/Convert/Base.pm
@@ -97,6 +97,9 @@ sub _run_conversion {
         $self->fatal_message('Failed to convert file.');
     } else {
         unlink $source_file;
+        for $extra in (qw(.bai .crai)) {
+            unlink $source_file . $extra if -e $source_file . $extra;
+        }
     }
 
     my @alloc = $self->alignment_result->disk_allocations;


### PR DESCRIPTION
This is a rather brute-force implementation :smile:  Alternatively, we could examine the filename or call `_is_currently_bam` and `_is_currently_cram` to decide which index to remove.