### PR TITLE
Config: Support `input_data` within `instrument_data_properties`

### DIFF
--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -124,6 +124,12 @@ sub _prepare_configuration_hashes_for_instrument_data {
         for my $model_instance (@{$config_hash->{$model_type}}) {
             my $instrument_data_properties = delete $model_instance->{instrument_data_properties};
             if($instrument_data_properties) {
+                if(my $input_data = delete $instrument_data_properties->{input_data}) {
+                    while ((my $input_name, my $instrument_data_property) = each %$input_data) {
+                        $model_instance->{input_data}{$input_name} = $self->_value_for_instrument_data_property($instrument_data, $instrument_data_property);
+                    }
+                }
+
                 while((my $model_property, my $instrument_data_property) = each %$instrument_data_properties) {
                     $model_instance->{$model_property} = $self->_value_for_instrument_data_property($instrument_data, $instrument_data_property);
                 }

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -125,15 +125,7 @@ sub _prepare_configuration_hashes_for_instrument_data {
             my $instrument_data_properties = delete $model_instance->{instrument_data_properties};
             if($instrument_data_properties) {
                 while((my $model_property, my $instrument_data_property) = each %$instrument_data_properties) {
-                    if (ref $instrument_data_property eq 'ARRAY') {
-                        $model_instance->{$model_property} = [
-                            grep { defined($_) }
-                            map { $instrument_data->$_ }
-                            @$instrument_data_property
-                        ];
-                    } else {
-                        $model_instance->{$model_property} = $instrument_data->$instrument_data_property;
-                    }
+                    $model_instance->{$model_property} = $self->_value_for_instrument_data_property($instrument_data, $instrument_data_property);
                 }
             }
         }
@@ -141,6 +133,20 @@ sub _prepare_configuration_hashes_for_instrument_data {
         $config_hash->{$model_type} = $self->_process_mapped_samples($instrument_data, $config_hash->{$model_type}) if $model_type->requires_subject_mapping;
     }
     return $config_hash;
+}
+
+sub _value_for_instrument_data_property {
+    my ($self, $instrument_data, $instrument_data_property) = @_;
+
+    if (ref $instrument_data_property eq 'ARRAY') {
+        return [
+            grep { defined($_) }
+            map { $instrument_data->$_ }
+            @$instrument_data_property
+        ];
+    } else {
+        return $instrument_data->$instrument_data_property;
+    }
 }
 
 sub _process_mapped_samples {

--- a/lib/perl/Genome/Config/Profile_input_data.t
+++ b/lib/perl/Genome/Config/Profile_input_data.t
@@ -1,0 +1,134 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+use Test::Exception;
+use Test::More tests => 32;
+use Test::Deep qw(cmp_bag);
+
+use above 'Genome';
+
+use Genome::Test::Factory::InstrumentData::Solexa;
+use Genome::Test::Factory::Library;
+use Genome::Test::Factory::ProcessingProfile::CwlPipeline;
+use Genome::Test::Factory::Sample;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+}
+
+my $analysis_project = _setup_analysis_project();
+my $instrument_data = _setup_instrument_data($analysis_project);
+
+my $profile = Genome::Config::Profile->create_from_analysis_project($analysis_project);
+isa_ok($profile, 'Genome::Config::Profile', 'created profile');
+
+my %models;
+
+for my $set (@$instrument_data) {
+    my @next_models = $profile->process_models_for_instrument_data($set->[0]);
+    is(scalar(@next_models), 1, 'resulted in one model as expected');
+    ok(!exists $models{$next_models[0]->id}, 'model was newly created');
+    $models{$next_models[0]->id} = $next_models[0];
+
+    my @next_models2 = $profile->process_models_for_instrument_data($set->[1]);
+    is(scalar(@next_models), 1, 'resulted in one model as expected');
+    ok(exists $models{$next_models2[0]->id}, 'used existing model');
+    $models{$next_models2[0]->id} = $next_models2[0];
+
+    my @i = $next_models2[0]->instrument_data;
+    cmp_bag(\@i, $set, 'model has expected instrument data assigned');
+}
+
+is(scalar keys %models, 3, 'created expected number of models');
+
+for my $m (values %models) {
+    my @inputs = $m->inputs;
+    my %inputs = map { $_->name => $_->value_id } @inputs;
+
+    #test that static inputs were included
+    is($inputs{bird1}, 'turkey', 'set first bird input');
+    is($inputs{bird2}, 'eagle', 'set second bird input');
+    is($inputs{bird3}, 'dove', 'set third bird input');
+
+    #test that dynamic inputs were included
+    ok($inputs{library}, 'library input is set');
+    ok($inputs{flow_cell}, 'flow_cell input is set');
+}
+
+
+sub _setup_instrument_data {
+    my $anp = shift;
+
+    my $sample = Genome::Test::Factory::Sample->setup_object();
+    my $lib1 = Genome::Test::Factory::Library->setup_object(sample => $sample);
+    my $lib2 = Genome::Test::Factory::Library->setup_object(sample => $sample);
+
+    my @i_lib1 = map { Genome::Test::Factory::InstrumentData::Solexa->setup_object(library => $lib1, flow_cell_id => 'TESTCCXX123456789', lane => $_) } (1..2);
+    my @i_lib2 = map { Genome::Test::Factory::InstrumentData::Solexa->setup_object(library => $lib2, flow_cell_id => 'TESTCCXX123456789', lane => $_) } (3..4);
+    my @i_lib2_otherflowcell = map { Genome::Test::Factory::InstrumentData::Solexa->setup_object(library => $lib1, flow_cell_id => 'TESTAAXX987654321', lane => $_) } (5..6);
+
+    for (@i_lib1, @i_lib2, @i_lib2_otherflowcell) {
+        Genome::Config::AnalysisProject::InstrumentDataBridge->create(
+            instrument_data_id => $_->id,
+            analysis_project_id => $anp->id,
+        );
+    }
+
+    return [\@i_lib1, \@i_lib2, \@i_lib2_otherflowcell];
+}
+
+sub _setup_analysis_project {
+    my $anp = Genome::Config::AnalysisProject->create(
+        name => 'Test Project for input data test',
+        run_as => 'nobody'
+    );
+
+    my $pp = Genome::Test::Factory::ProcessingProfile::CwlPipeline->setup_object;
+
+    my $config_file = _config_file($pp);
+    my $menu_item = Genome::Config::AnalysisMenu::Item->create(
+        id => '-12345678',
+        file_path => $config_file,
+        name => 'input data test menu item',
+    );
+
+    my $item = Genome::Config::Profile::Item->create(
+        analysis_project => $anp,
+        analysis_menu_item => $menu_item,
+        status => 'active',
+    );
+
+    return $anp;
+}
+
+
+sub _config_file {
+    my $pp = shift;
+    my $ppid = $pp->id;
+
+    my $contents = <<YML
+rules:
+  sequencing_platform: solexa
+models:
+  'Genome::Model::CwlPipeline':
+     - processing_profile_id: $ppid
+       input_data:
+           bird1: turkey
+           bird2: eagle
+           bird3: dove
+       instrument_data_properties:
+           input_data:
+               library: library
+               flow_cell: flow_cell_id
+           subject: sample
+YML
+    ;
+
+    my $file_path = join('', Genome::Sys->create_temp_file_path(), '.yml');
+
+    Genome::Sys->write_file($file_path, $contents);
+
+    return $file_path;
+}

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -7,6 +7,7 @@ use feature qw(switch);
 use Genome;
 
 use Set::Scalar;
+use Scalar::Util qw(blessed);
 
 class Genome::Model::CwlPipeline {
     is => 'Genome::Model',
@@ -170,6 +171,11 @@ sub determine_input_object {
     my $class = shift;
     my $name = shift;
     my $value_identifier = shift;
+
+    if (blessed($value_identifier)) {
+        #already an object
+        return $value_identifier;
+    }
 
     if (ref $value_identifier eq 'HASH' and exists $value_identifier->{value_class_name} and exists $value_identifier->{value_id}) {
         my $value_class = $value_identifier->{value_class_name};


### PR DESCRIPTION
This allows configured model inputs to be dynamically determined.  Even if those inputs aren't used by the build process, this also facilitates subsetting models by particular instrument data properties.  (Read: "You can configure per-library models." :smile:)