### PR TITLE
Fix `rsync_directory` and disable some broken tests.

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq/Command/Converge/DgidbCounts.t
+++ b/lib/perl/Genome/Model/ClinSeq/Command/Converge/DgidbCounts.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use above "Genome";
-use Test::More;
+use Test::More skip_all => 'test data was removed';
 
 my $expected_out =
     Genome::Config::get('test_inputs') . '/Genome-Model-ClinSeq-Command-Converge-DgidbCounts/2015-02-05/';

--- a/lib/perl/Genome/Model/ClinSeq/Command/Converge/DgidbGenes.t
+++ b/lib/perl/Genome/Model/ClinSeq/Command/Converge/DgidbGenes.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use above "Genome";
-use Test::More;
+use Test::More skip_all => 'test data was removed';
 
 my $expected_out = Genome::Config::get('test_inputs') . '/Genome-Model-ClinSeq-Command-Converge-DgidbGenes/2015-02-05/';
 ok(-d $expected_out, "directory of expected output exists: $expected_out") or die;

--- a/lib/perl/Genome/Model/ClinSeq/Command/GenerateSciclonePlots.t
+++ b/lib/perl/Genome/Model/ClinSeq/Command/GenerateSciclonePlots.t
@@ -9,7 +9,7 @@ BEGIN {
 }
 
 use above "Genome";
-use Test::More;
+use Test::More skip_all => 'test data was removed';
 
 use_ok('Genome::Model::ClinSeq::Command::GenerateSciclonePlots') or die;
 

--- a/lib/perl/Genome/Model/Tools/DetectVariants2/Result/Combine/LqUnion.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/Result/Combine/LqUnion.t
@@ -11,7 +11,8 @@ BEGIN {
 };
 
 use above 'Genome';
-use Test::More tests => 4;
+use Test::More skip_all => 'test data removed';
+#use Test::More tests => 4;
 
 use_ok('Genome::Model::Tools::DetectVariants2::Result::Combine::LqUnion');
 

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -857,14 +857,20 @@ sub rsync_directory {
     unless (-d $target_dir) {
         Genome::Sys->create_directory($target_dir);
     }
-    $pattern = '' unless $pattern;
 
-    my $source = join('/', $source_dir, $pattern);
+    my @pattern_option = ();
+    if ($pattern) {
+        push @pattern_option,
+            '--include=' . $pattern,
+            '--exclude=*';
+    }
+
+    $source_dir .= '/' unless substr($source_dir,-1) eq '/';
     my $rv = Genome::Sys->shellcmd(
-        cmd => ['rsync', '-rlHpgt', $source, $target_dir],
+        cmd => ['rsync', '-rlHpgt', @pattern_option, $source_dir, $target_dir],
     );
     unless ($rv) {
-        confess "Could not copy data matching pattern $source to $target_dir";
+        confess "Could not copy data from $source_dir to $target_dir";
     }
     return 1;
 }


### PR DESCRIPTION
PR #1849 broke a feature of `rsync_directory` used by `PerLaneTophat` results.  This fixes that oversight and disables some tests that depend on test build data that has been purged.