### PR TITLE
Surface different CWL pipeline types in Solr search.

### DIFF
--- a/lib/perl/Genome/Model/View/Solr/Xml.pm
+++ b/lib/perl/Genome/Model/View/Solr/Xml.pm
@@ -30,6 +30,8 @@ class Genome::Model::View::Solr::Xml {
                     $solr_type = 'model - ClinSeq';
                 } elsif ($pp_type =~ /microarray/i) {
                     $solr_type = 'model - microarray';
+                } elsif ($pp_type eq 'cwl pipeline') {
+                    $solr_type = $model->short_pipeline_name() || 'cwl';
                 } else {
                     $solr_type = 'model - other';
                 }


### PR DESCRIPTION
In a recent meeting there was a comment that all CWL models were being lumped into `other`.  This splits them out into their own categories or at least highlights they are CWL models.