### PR TITLE
WIP: Short Name option for interval list creation

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
+++ b/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
@@ -21,6 +21,11 @@ class Genome::FeatureList::Command::DumpIntervalList {
             doc => 'For multi-tracked BED files, which track to use',
             valid_values => Genome::FeatureList::IntervalList->__meta__->property(property_name => 'track_name')->valid_values,
         },
+        short_name => {
+            is => 'Boolean',
+            doc => 'whether to replace region names with short names',
+            default => 1,
+        },
         merge => {
             is => 'Boolean',
             doc => 'whether to merge adjacent regions of the BED file',
@@ -48,6 +53,7 @@ sub execute {
         reference_build => $self->reference_build,
         track_name => $self->track_name,
         merge => $self->merge,
+        short_name => $self->short_name,
         users => $result_users,
     );
 

--- a/lib/perl/Genome/FeatureList/IntervalList.pm
+++ b/lib/perl/Genome/FeatureList/IntervalList.pm
@@ -30,6 +30,11 @@ class Genome::FeatureList::IntervalList {
             doc => 'whether to merge adjacent regions of the BED file',
             default => 1,
         },
+        short_name => {
+            is => 'Boolean',
+            doc => 'whether to replace region names with short names',
+            default => 1,
+        },
     ],
 };
 
@@ -61,6 +66,7 @@ sub _run {
         feature_list => $self->feature_list,
         track_name => $self->track_name,
         merge => $self->merge,
+        short_name => $self->short_name,
         result_users => $self->_user_data_for_nested_results,
         @alt_reference,
     );


### PR DESCRIPTION
add short_name option for interal list generation.

I labeled this WIP since I can't confirm this worked. when I went to set a test name I couldn't determine the existing result ID.