### PR TITLE
Make "bam_path" a property again.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/IndexIllumina.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/IndexIllumina.pm
@@ -203,6 +203,9 @@ EOS
         fwd_base_quality_sum             => { },
         rev_base_quality_sum             => { },
     ],
+    has_calculated_constant => [
+        bam_path                         => { calculate => \&_resolve_bam_path },
+    ],
     data_source => 'Genome::DataSource::Dwrac',
 };
 
@@ -277,7 +280,7 @@ sub lims_property_name_to_genome_property_name {
     return $name;
 }
 
-sub bam_path {
+sub _resolve_bam_path {
     my $self = shift;
 
     my $id = $self->id;


### PR DESCRIPTION
Calculated + constant, so it only finds the value once and otherwise treats it like a UR object property as it was before.  This fixes tests (and possibly real code :) ) that expected it to be a property.

This should resolve the issues introduced by merging #1843.