### PR TITLE
Helper class for processing inputs in `process_inputs.pl`.

### DIFF
--- a/lib/perl/Genome/Model/Build/CwlPipeline/InputProcessor.pm
+++ b/lib/perl/Genome/Model/Build/CwlPipeline/InputProcessor.pm
@@ -1,0 +1,111 @@
+package Genome::Model::Build::CwlPipeline::InputProcessor;
+
+use strict;
+use warnings;
+
+use feature qw(switch);
+
+use Genome;
+
+class Genome::Model::Build::CwlPipeline::InputProcessor {
+    is_abstract => 1,
+    is => 'UR::Value::Text',
+    attributes_have => [
+        is_input => { is => 'Boolean', is_optional => 1 },
+        is_simple => { is => 'Boolean', is_optional => 1 },
+        input_type => { is => 'Text', is_optional => 1 },
+    ],
+    subclass_description_preprocessor => 'Genome::Model::Build::_preprocess_subclass_description',
+    has => [
+        id => {
+            is => 'UR::Value::Text',
+        },
+        build => {
+            is => 'Genome::Model::Build::CwlPipeline',
+            id_by => 'build_id',
+        },
+        build_id => {
+            via => '__self__',
+            to => 'id',
+        },
+    ],
+};
+
+sub simple_inputs {
+    my $self = shift;
+
+    my %inputs;
+    for my $input ($self->__meta__->properties(is_input => 1, is_simple => 1)) {
+        my $name = $input->property_name;
+        my $type = $input->input_type;
+
+        for ($type) {
+            when ('File') {
+                $inputs{$name} = {
+                    class => 'File',
+                    path => '' . $self->$name,
+                };
+            }
+            when ('Text') {
+                $inputs{$name} = '' . $self->$name;
+            }
+            when ('Number') {
+                $inputs{$name} = 0 + $self->$name;
+            }
+            default {
+                $self->fatal_message('Unknown input type %s in simple input %s.', $type, $name);
+            }
+        }
+    }
+
+    return \%inputs;
+}
+
+
+sub _preprocess_subclass_description {
+    my ($class, $desc) = @_;
+
+    my @names = keys %{ $desc->{has} };
+    for my $prop_name (@names) {
+        my $prop_desc = $desc->{has}{$prop_name};
+
+        # skip old things for which the developer has explicitly set-up indirection
+        next if $prop_desc->{id_by};
+        next if $prop_desc->{via};
+        next if $prop_desc->{reverse_as};
+        next if $prop_desc->{implied_by};
+
+        if ($prop_desc->{'is_input'}) {
+            my $assoc = $prop_name . '_association' . ($prop_desc->{is_many} ? 's' : '');
+            next if $desc->{has}{$assoc};
+
+            if ($prop_desc->{'data_type'}) {
+                my $prop_class = UR::Object::Property->_convert_data_type_for_source_class_to_final_class(
+                    $prop_desc->{'data_type'},
+                    $class
+                );
+            }
+
+            $desc->{has}{$assoc} = {
+                property_name => $assoc,
+                implied_by => $prop_name,
+                is => 'Genome::Model::Build::Input',
+                via => 'build',
+                to => 'inputs',
+                where => [ name => $prop_name ],
+                is_mutable => $prop_desc->{is_mutable},
+                is_optional => $prop_desc->{is_optional},
+                is_many => 1, #$prop_desc->{is_many},
+            };
+
+            %$prop_desc = (%$prop_desc,
+                via => $assoc,
+                to => Genome::Model->_resolve_to_for_prop_desc($prop_desc),
+            );
+        }
+    }
+
+    return $desc;
+}
+
+1;

--- a/lib/perl/Genome/Model/Build/CwlPipeline/InputProcessor.t
+++ b/lib/perl/Genome/Model/Build/CwlPipeline/InputProcessor.t
@@ -1,0 +1,98 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+
+use Genome::Test::Factory::Build;
+use Genome::Test::Factory::Model::CwlPipeline;
+
+use Test::More tests => 11;
+
+my $class = 'Genome::Model::Build::CwlPipeline::InputProcessor';
+
+use_ok($class);
+
+my $model = Genome::Test::Factory::Model::CwlPipeline->setup_object();
+my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id);
+
+for my $n (qw(alpha bravo charlie)) {
+    Genome::Model::Build::Input->create(
+        name => $n,
+        value_id => 'some string value ' . $n,
+        value_class_name => 'UR::Value::Text',
+        build_id => $build->id,
+    );
+}
+
+my $i =0;
+for my $n (qw(first second third)) {
+    Genome::Model::Build::Input->create(
+        name => $n,
+        value_id => ++$i,
+        value_class_name => 'UR::Value::Number',
+        build_id => $build->id,
+    );
+}
+
+for my $n (qw(in out)) {
+    Genome::Model::Build::Input->create(
+        name => $n,
+        value_id => Genome::Sys->create_temp_file_path,
+        value_class_name => 'UR::Value::FilePath',
+        build_id => $build->id,
+    );
+}
+
+Genome::Model::Build::Input->create(
+    name => 'silly_link_back_to_model',
+    value_id => $model->id,
+    value_class_name => $model->class,
+    build_id => $build->id,
+);
+
+{
+    package InputProcessor;
+    class InputProcessor {
+        is => $class,
+        has_simple_input => [
+            alpha => { input_type => 'Text' },
+            bravo => { input_type => 'Text' },
+            charlie => { input_type => 'Text' },
+
+            first => { input_type => 'Number' },
+            second => { input_type => 'Number' },
+            third => { input_type => 'Number' },
+
+            in => { input_type => 'File' },
+            out => { input_type => 'File' },
+        ],
+        has_input => [
+            silly_link_back_to_model => { is => 'Genome::Model' },
+        ],
+    };
+}
+
+my $input_processor = InputProcessor->get($build->id);
+isa_ok($input_processor, $class);
+
+is($input_processor->build, $build, 'created input processor for build');
+
+my $simple_inputs = $input_processor->simple_inputs;
+isa_ok($simple_inputs, 'HASH', 'got back hash of inputs');
+
+my @keys = keys %$simple_inputs;
+is(scalar(@keys), 8, 'one key per simple input');
+
+for my $f (qw(in out)) {
+    isa_ok($simple_inputs->{$f}, 'HASH');
+    is($simple_inputs->{$f}{class}, 'File');
+}
+
+ok(!exists $simple_inputs->{silly_link_back_to_model}, 'excluded when not marked simple');
+is($input_processor->silly_link_back_to_model, $model, 'object input works');


### PR DESCRIPTION
This eliminates a lot of the copy+pasting between processing scripts.  For basic inputs, it eliminates most of the code from the script in favor of a class declaration.  Here's an example `process_inputs.pl` when no extra processing is required:

```perl
#!/usr/bin/env genome-perl

use strict;
use warnings;

use above 'Genome';
use YAML::XS;

my $build_id = $ARGV[0]
    or die 'no build id';

my $build = Genome::Model::Build->get($build_id)
    or die 'no build for id';

{
    package InputProcessor;
    class InputProcessor {
        is => 'Genome::Model::Build::CwlPipeline::InputProcessor',
        has_simple_input => [
            alpha => { input_type => 'Text' },
            bravo => { input_type => 'Text' },
            charlie => { input_type => 'Text' },

            first => { input_type => 'Number' },
            second => { input_type => 'Number' },
            third => { input_type => 'Number' },

            in => { input_type => 'File' },
            out => { input_type => 'File' },
        ],
    };
}

my $input_processor = InputProcessor->get($build->id);
my $inputs = $input_processor->simple_inputs;
my $yaml = File::Spec->join($build->data_directory, 'inputs.yaml');
YAML::XS::DumpFile($yaml, $inputs);
```
