### PR TITLE
Make sure $self gets passed to _resolve_bam_path.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/IndexIllumina.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/IndexIllumina.pm
@@ -204,7 +204,7 @@ EOS
         rev_base_quality_sum             => { },
     ],
     has_calculated_constant => [
-        bam_path                         => { calculate => \&_resolve_bam_path },
+        bam_path                         => { calculate => q{ $self->_resolve_bam_path } },
     ],
     data_source => 'Genome::DataSource::Dwrac',
 };


### PR DESCRIPTION
This fixes the errors recently seen in the synch cron.