### PR TITLE
Update lsf_log_dir for test-tracker configuration.

### DIFF
--- a/.test-tracker.conf
+++ b/.test-tracker.conf
@@ -6,7 +6,7 @@ db_dsn: 'dbi:Pg:dbname=test_tracker;host=gms-postgres'
 db_password: zIwWhT8qkzrhPm
 db_prefix: 'test_tracker.'
 db_user: test_tracker
-lsf_log_dir: /gscmnt/gc13001/info/model_data/apipe-ci/workspace
+lsf_log_dir: /gscmnt/gc2560/core/genome-ci/lsf_logs
 module_regex: '^lib/perl/Genome.*\.pm$'
 test_regex: '^lib/perl/Genome.*\.t$'
 prove: genome-prove


### PR DESCRIPTION
In order to launch the test-tracker in a world where interactive LSF jobs can't be nested, this will need to instead rely upon one of the versions that uses the log directory.