### PR TITLE
Find the reference FASTA via a database lookup instead of hardcoding.

### DIFF
--- a/lib/perl/Genome/Db/Ensembl/Command/Run/Vep.t
+++ b/lib/perl/Genome/Db/Ensembl/Command/Run/Vep.t
@@ -36,6 +36,9 @@ for my $file_type ('ensembl', 'vcf', 'vcf.gz') {
 
     my $result_users = Genome::Test::Factory::SoftwareResult::User->setup_user_hash();
 
+    my $ref = Genome::Model::Build::ImportedReferenceSequence->get(name => 'GRCh37-lite-build37');
+    my $fasta = $ref->full_consensus_path('fa');
+
     my %params = (
         input_file => $input_file,
         format => $format,
@@ -48,7 +51,7 @@ for my $file_type ('ensembl', 'vcf', 'vcf.gz') {
         hgnc => 1,
         hgvs => 1,
         reference_version => "GRCh37",
-        fasta => "/gscmnt/ams1102/info/model_data/2869585698/build106942997/all_sequences.fa",
+        fasta => $fasta,
     );
 
     if ($file_type eq 'vcf' || $file_type eq 'vcf.gz') {

--- a/lib/perl/Genome/Model/Tools/Gatk/IndelRealigner.t
+++ b/lib/perl/Genome/Model/Tools/Gatk/IndelRealigner.t
@@ -23,7 +23,8 @@ use_ok('Genome::Model::Tools::Gatk::IndelRealigner');
 my $test_data_dir = Genome::Config::get('test_inputs') . '/Genome-Model-Tools-Gatk-IndelRealigner';
 my $tumor_bam = "$test_data_dir/tumor.bam";
 my $normal_bam = "$test_data_dir/normal.bam";
-my $reference_fasta = "/gscmnt/ams1102/info/model_data/2869585698/build106942997/all_sequences.fa";
+my $ref_build = Genome::Model::Build::ImportedReferenceSequence->get(name => 'GRCh37-lite-build37');
+my $reference_fasta = $ref_build->full_consensus_path('fa');
 my $small_indel_list = "$test_data_dir/small_indels.padded1bp.bed";
 
 # Outputs

--- a/lib/perl/Genome/Model/Tools/Validation/LongIndelsGenerateMergedAssemblies.t
+++ b/lib/perl/Genome/Model/Tools/Validation/LongIndelsGenerateMergedAssemblies.t
@@ -25,6 +25,9 @@ my $temp_large_indels = $temp_dir."/large_indels.bed";
 copy($base_dir."/large_indels.bed", $temp_large_indels)
     or die "failed to copy large_indels.bed to temp_dir: $!";
 
+my $ref_build = Genome::Model::Build::ImportedReferenceSequence->get(name => 'GRCh37-lite-build37');
+my $fasta = $ref_build->full_consensus_path('fa');
+
 my $cmd = Genome::Model::Tools::Validation::LongIndelsGenerateMergedAssemblies->create(
     long_indel_bed_file => $temp_large_indels,
     output_dir => $temp_dir,
@@ -32,7 +35,7 @@ my $cmd = Genome::Model::Tools::Validation::LongIndelsGenerateMergedAssemblies->
     reference_transcripts => "NCBI-human.ensembl/67_37l_v2",
     tumor_bam => $base_dir."/tumor.bam",
     normal_bam => $base_dir."/normal.bam",
-    reference_fasta => "/gscmnt/ams1102/info/model_data/2869585698/build106942997/all_sequences.fa",
+    reference_fasta => $fasta,
 );
 
 ok($cmd, "Command created successfully");

--- a/lib/perl/Genome/Model/Tools/Varscan/PullOneTwoBpIndels.t
+++ b/lib/perl/Genome/Model/Tools/Varscan/PullOneTwoBpIndels.t
@@ -26,7 +26,8 @@ my $test_data_dir = Genome::Config::get('test_inputs') . '/Genome-Model-Tools-Va
 my $input_indels = indel_fof($test_data_dir);
 my $tumor_bam = "$test_data_dir/tumor.bam";
 my $normal_bam = "$test_data_dir/normal.bam";
-my $reference_fasta = "/gscmnt/ams1102/info/model_data/2869585698/build106942997/all_sequences.fa";
+my $reference_build = Genome::Model::Build::ImportedReferenceSequence->get(name => 'GRCh37-lite-build37');
+my $reference_fasta = $reference_build->full_consensus_path('fa');
 
 # Outputs
 my $output_dir = File::Temp::tempdir('VarscanValidationXXXXX', CLEANUP => 1, TMPDIR => 1);


### PR DESCRIPTION
Most of these paths were changed long ago, but we recently disabled the symlinks.  The database has the updated value, so look at it!