### PR TITLE
Remove hardcoded references to `gc4096`.

### DIFF
--- a/lib/perl/Genome/Model/ImportedReferenceSequence.t
+++ b/lib/perl/Genome/Model/ImportedReferenceSequence.t
@@ -16,14 +16,14 @@ my $model = Genome::Model::ImportedReferenceSequence->get(name => 'NCBI-human');
 isa_ok( $model, 'Genome::Model::ImportedReferenceSequence' );
 
 my $build = $model->build_by_version("36-lite");
-my $expected_dir = '/gscmnt/gc4096/info/model_data/2741951221/build101947881';
+my $expected_dir = qr'model_data/2741951221/build101947881$';
 
-is( $build->data_directory(), $expected_dir, 'got the right data directory' );
+like( $build->data_directory(), $expected_dir, 'got the right data directory' );
 
 my $bases_file = $build->get_bases_file(1);
 my $expected_bases_file
-    = '/gscmnt/gc4096/info/model_data/2741951221/build101947881/1.bases';
-is( $bases_file, $expected_bases_file, 'bases file correct' );
+    = qr'model_data/2741951221/build101947881/1.bases$';
+like( $bases_file, $expected_bases_file, 'bases file correct' );
 
 my $test_seq0 = $build->sequence( 1, 1, 10 );
 my $expected_seq0 = 'TAACCCTAAC';

--- a/lib/perl/Genome/Model/Tools/RefCov/ExomeCapture.t
+++ b/lib/perl/Genome/Model/Tools/RefCov/ExomeCapture.t
@@ -22,13 +22,16 @@ my $expected_data_dir = $data_dir;
 my $alignment_file_path = $data_dir .'/test.bam';
 my $regions_file = $data_dir .'/test.bed';
 
+my $ref_build = Genome::Model::Build->get('101947881');
+my $fasta = $ref_build->full_consensus_path('fa');
+
 my $expected_stats_file = $expected_data_dir .'/PDL_test_STATS.tsv';
 my $ref_cov = Genome::Model::Tools::RefCov::ExomeCapture->create(
     output_directory => $tmp_dir,
     alignment_file_path => $alignment_file_path,
     roi_file_path => $regions_file,
     evaluate_gc_content => 1,
-    reference_fasta => '/gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa',
+    reference_fasta => $fasta,
 );
 isa_ok($ref_cov,'Genome::Model::Tools::RefCov::ExomeCapture');
 ok($ref_cov->execute,'execute Standard command '. $ref_cov->command_name);
@@ -42,7 +45,7 @@ my $q20_ref_cov = Genome::Model::Tools::RefCov::ExomeCapture->create(
     alignment_file_path => $alignment_file_path,
     roi_file_path => $regions_file,
     min_base_quality => 20,
-    reference_fasta => '/gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa',
+    reference_fasta => $fasta,
 );
 isa_ok($q20_ref_cov,'Genome::Model::Tools::RefCov::ExomeCapture');
 ok($q20_ref_cov->execute,'execute Standard command '. $q20_ref_cov->command_name);
@@ -56,7 +59,7 @@ my $q20_q1_ref_cov = Genome::Model::Tools::RefCov::ExomeCapture->create(
     roi_file_path => $regions_file,
     min_base_quality => 20,
     min_mapping_quality => 1,
-    reference_fasta => '/gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa',
+    reference_fasta => $fasta,
 );
 isa_ok($q20_q1_ref_cov,'Genome::Model::Tools::RefCov::ExomeCapture');
 ok($q20_q1_ref_cov->execute,'execute Standard command '. $q20_q1_ref_cov->command_name);

--- a/lib/perl/Genome/Model/Tools/RefCov/WholeGenome.t
+++ b/lib/perl/Genome/Model/Tools/RefCov/WholeGenome.t
@@ -31,6 +31,9 @@ my $expected_merged_stats_file = $expected_data_dir .'/PDL_NOTCH1_merged_stats_e
 my $merged_stats_file = $tmp_dir .'/NOTCH1_merged_stats.tsv';
 my $stats_file = $tmp_dir .'/NOTCH1_1k_NOTCH1_STATS.tsv';
 
+my $ref_build = Genome::Model::Build->get('101947881');
+my $fasta = $ref_build->full_consensus_path('fa');
+
 my $ref_cov = Genome::Model::Tools::RefCov::WholeGenome->create(
     stats_file => $stats_file,
     merged_stats_file => $merged_stats_file,
@@ -40,7 +43,7 @@ my $ref_cov = Genome::Model::Tools::RefCov::WholeGenome->create(
     #THIS TAKES TOO LONG FOR THIS TEST
     genome_normalized_coverage => 0,
     min_depth_filter => 1,
-    reference_fasta => '/gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa',
+    reference_fasta => $fasta,
 );
 isa_ok($ref_cov,'Genome::Model::Tools::RefCov::WholeGenome');
 ok($ref_cov->execute,'execute WholeGenome command '. $ref_cov->command_name);


### PR DESCRIPTION
More bad paths left hanging out in tests!