### PR TITLE
Don't match on the absolute path to the reference.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Sam/Pileup.t
+++ b/lib/perl/Genome/Model/Tools/Sam/Pileup.t
@@ -29,7 +29,8 @@ my $bam_file = $data_dir .'/test.bam';
 my $example_output_file = $data_dir .'/expected/test.pileup.gz';
 
 my $output_file = $tmp_dir."/test.pileup.gz";
-my $refseq_path = "/gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa";
+my $refseq_build = Genome::Model::Build->get('101947881');
+my $refseq_path = $refseq_build->full_consensus_path('fa');
 my $region_file = $data_dir."/test.region.gz";
 
 

--- a/lib/perl/Genome/Model/Tools/Sam/Readcount.t
+++ b/lib/perl/Genome/Model/Tools/Sam/Readcount.t
@@ -55,15 +55,15 @@ subtest 'testing command strings' => sub {
     plan tests => 5;
 
     my %expected_command = (
-        0.3 => "/usr/bin/bam-readcount0.3 $test_data_dir/tiny.bam -f /gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa -l $test_data_dir/regions 2> /dev/null",
-        0.4 => "/usr/bin/bam-readcount0.4 $test_data_dir/tiny.bam -f /gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa -l $test_data_dir/regions 2> /dev/null",
-        0.5 => "/usr/bin/bam-readcount0.5 $test_data_dir/tiny.bam -f /gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa -l $test_data_dir/regions -w 1",
-        0.6 => "/usr/bin/bam-readcount0.6 $test_data_dir/tiny.bam -f /gscmnt/gc4096/info/model_data/2741951221/build101947881/all_sequences.fa -l $test_data_dir/regions -w 1",
+        0.3 => qr"/usr/bin/bam-readcount0.3 $test_data_dir/tiny.bam -f .+/model_data/2741951221/build101947881/all_sequences.fa -l $test_data_dir/regions 2> /dev/null",
+        0.4 => qr"/usr/bin/bam-readcount0.4 $test_data_dir/tiny.bam -f .+/model_data/2741951221/build101947881/all_sequences.fa -l $test_data_dir/regions 2> /dev/null",
+        0.5 => qr"/usr/bin/bam-readcount0.5 $test_data_dir/tiny.bam -f .+/model_data/2741951221/build101947881/all_sequences.fa -l $test_data_dir/regions -w 1",
+        0.6 => qr"/usr/bin/bam-readcount0.6 $test_data_dir/tiny.bam -f .+/model_data/2741951221/build101947881/all_sequences.fa -l $test_data_dir/regions -w 1",
     );
 
     for my $version (keys %expected_command) {
         $cmd->use_version($version);
-        is($cmd->command, $expected_command{$version}, "The command string looks as expected for version $version");
+        like($cmd->command, $expected_command{$version}, "The command string looks as expected for version $version");
     }
 
     $cmd->use_version('0.4');


### PR DESCRIPTION
It's a little bit silly to even worry about a real path here at all... maybe these tests should use a dummy path under the test's control.