### PR TITLE
Now that multiple CWL Runners are implemented, give the workflow step a generic name.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -110,7 +110,7 @@ sub _resolve_workflow_for_build {
     );
 
     my $cmd = Genome::WorkflowBuilder::Command->create(
-        name => 'Toil Runner',
+        name => 'CWL Runner',
         command => 'Genome::Model::CwlPipeline::Command::Run',
     );
     $wf->add_operation($cmd);


### PR DESCRIPTION
This change will be most visible in the name of the log file generated for the run step.