### PR TITLE
Some fixes for staging the final outputs from Cromwell.

### DIFF
--- a/lib/perl/Genome/Cromwell.pm
+++ b/lib/perl/Genome/Cromwell.pm
@@ -6,6 +6,7 @@ use warnings;
 use JSON qw(to_json from_json);
 use HTTP::Request;
 use LWP::UserAgent;
+use IO::Socket::SSL qw();
 
 use Genome;
 
@@ -25,7 +26,11 @@ class Genome::Cromwell {
         user_agent => {
             is => 'LWP::UserAgent',
             is_constant => 1,
-            calculate => q{ LWP::UserAgent->new(); },
+            calculate => q{
+                my $ua = LWP::UserAgent->new();
+                $ua->ssl_opts( verify_hostname => 0,  SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE );
+                return $ua;
+            },
         },
     ],
 };

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -302,7 +302,7 @@ sub _stage_cromwell_outputs {
 
     my $build = $self->build;
 
-    my $results = Genome::Cromwell->query({ label => $build->id });
+    my $results = Genome::Cromwell->query( [{ label => 'build:' . $build->id }] );
     if ($results->{totalResultsCount} != 1) {
         $self->fatal_message('Failed to find workflow.  Got: %s', $results);
     }


### PR DESCRIPTION
This disables SSL certificate validation when connecting to the Cromwell server!  One alternative solution would be to add a CA next to the keystore file we're pointing Java to, but this is expedient and should be fine on a trusted network...