### PR TITLE
Add batch mode to search indexer.

### DIFF
--- a/lib/perl/Genome/Sys/Command/Search/Index.pm
+++ b/lib/perl/Genome/Sys/Command/Search/Index.pm
@@ -64,6 +64,9 @@ sub execute {
     elsif ($self->subject_text eq 'queued') {
         $self->index_queued;
     }
+    elsif ($self->subject_text eq 'batch') {
+        $self->index_queued($self->max_changes_per_commit);
+    }
     elsif ($self->subject_text eq 'daemon') {
         $self->daemon;
     }


### PR DESCRIPTION
Adds items from the queue up to the specified maximum.  (Contrast with the "queued" option that processes everything.)

There are issues with using the daemon in our current setup, so this allows a processing batch to be scheduled regularly instead.