### PR TITLE
Restrict the number of DB connections for a single Cromwell run.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -271,6 +271,7 @@ database {
     user = "$user"
     password = "$auth"
     connectionTimeout = 5000
+    maxConnections = 10
   }
 }
 EOCONFIG


### PR DESCRIPTION
This was the advice provided in:
https://gatkforums.broadinstitute.org/gatk/discussion/12330/call-catching-cromwell-exhausts-all-connection-to-mysqld