### PR TITLE
Handle `000`-mode files for BAM imports.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/ImportBamFromLims.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportBamFromLims.pm
@@ -77,10 +77,8 @@ sub _process_instrument_data {
         Genome::Sys->rsync_directory(
             source_directory => $lims_source_dir,
             target_directory => $allocation->absolute_path,
-        );
-
-        Genome::Sys->shellcmd(
-            cmd => ['chgrp', '-R', $self->_user_group, $allocation->absolute_path],
+            chmod => 'Dug=rx,Fug=r',
+            chown => ':' . $self->_user_group,
         );
 
         my $new_path = File::Spec->join($allocation->absolute_path, $bam_file);

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -844,6 +844,8 @@ sub rsync_directory {
     my $target_dir = delete $params{target_directory};
     my $pattern = delete $params{file_pattern};
 
+    my $chmod = delete $params{chmod};
+
     unless ($source_dir) {
         Carp::confess "Not given directory to copy from!";
     }
@@ -857,16 +859,22 @@ sub rsync_directory {
         Genome::Sys->create_directory($target_dir);
     }
 
-    my @pattern_option = ();
+    my @long_opts = ();
     if ($pattern) {
-        push @pattern_option,
+        push @long_opts,
             '--include=' . $pattern,
             '--exclude=*';
     }
+    if ($chmod) {
+        push @long_opts, '--chmod=' . $chmod;
+    }
 
     $source_dir .= '/' unless substr($source_dir,-1) eq '/';
+
+    my $opts = $chmod? '-rlHpgt' : 'rlHgt';
+
     my $rv = Genome::Sys->shellcmd(
-        cmd => ['rsync', '-rlHpgt', @pattern_option, $source_dir, $target_dir],
+        cmd => ['rsync', $opts, @long_opts, $source_dir, $target_dir],
     );
     unless ($rv) {
         confess "Could not copy data from $source_dir to $target_dir";

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -845,6 +845,7 @@ sub rsync_directory {
     my $pattern = delete $params{file_pattern};
 
     my $chmod = delete $params{chmod};
+    my $chown = delete $params{chown};
 
     unless ($source_dir) {
         Carp::confess "Not given directory to copy from!";
@@ -868,10 +869,19 @@ sub rsync_directory {
     if ($chmod) {
         push @long_opts, '--chmod=' . $chmod;
     }
+    if ($chown) {
+        push @long_opts, '--chown=' . $chown;
+    }
 
     $source_dir .= '/' unless substr($source_dir,-1) eq '/';
 
-    my $opts = $chmod? '-rlHpgt' : 'rlHgt';
+    my $opts = '-rlHt';
+    unless ($chmod) {
+        $opts .= 'p';
+    }
+    unless ($chown) {
+        $opts .= 'g';
+    }
 
     my $rv = Genome::Sys->shellcmd(
         cmd => ['rsync', $opts, @long_opts, $source_dir, $target_dir],


### PR DESCRIPTION
The BAMs we're importing have ACLs but no POSIX-style permissions at all, so `rsync` is failing.  You might think the `-A` option would help, but that still fails. Here we take matters into our own hands and set up permissions just the way we want them.