### PR TITLE
Use Local `disk.` Tables

### DIFF
--- a/lib/perl/Genome/Disk/Allocation-move.t
+++ b/lib/perl/Genome/Disk/Allocation-move.t
@@ -67,8 +67,8 @@ for (1..2) {
     push @volumes, $volume;
 
     my $assignment = Genome::Disk::Assignment->create(
-        dv_id => $volume->id,
-        dg_id => $group->id,
+        volume_id => $volume->id,
+        group_id => $group->id,
     );
     ok($assignment, 'made disk assignment') or die;
     Genome::Sys->create_directory(join('/', $volume->mount_path, $group->subdirectory));

--- a/lib/perl/Genome/Disk/Allocation-resolve_allocation_path.t
+++ b/lib/perl/Genome/Disk/Allocation-resolve_allocation_path.t
@@ -53,8 +53,8 @@ my $group = Genome::Disk::Group->create(
 ok($group, 'successfully made testing group') or die;
 
 my $assignment = Genome::Disk::Assignment->create(
-    dg_id => $group->id,
-    dv_id => $volume->id,
+    group_id => $group->id,
+    volume_id => $volume->id,
 );
 ok($assignment, 'assigned volume to testing group');
 

--- a/lib/perl/Genome/Disk/Allocation.t
+++ b/lib/perl/Genome/Disk/Allocation.t
@@ -68,8 +68,8 @@ for (1..5) {
     push @volumes, $volume;
 
     my $assignment = Genome::Disk::Assignment->create(
-        dv_id => $volume->id,
-        dg_id => $group->id,
+        volume_id => $volume->id,
+        group_id => $group->id,
     );
     ok($assignment, "made disk assignment $_") or die;
 }

--- a/lib/perl/Genome/Disk/Allocation/t-lib/GenomeDiskAllocationCommon.pm
+++ b/lib/perl/Genome/Disk/Allocation/t-lib/GenomeDiskAllocationCommon.pm
@@ -89,8 +89,8 @@ sub create_test_volumes {
                 );
                 my $group = Genome::Disk::Group->get(disk_group_name => $disk_group_name);
                 my $assignment = Genome::Disk::Assignment->create(
-                    dg_id => $group->id,
-                    dv_id => $volume->id,
+                    group_id => $group->id,
+                    volume_id => $volume->id,
                 );
                 $tb->ok($assignment, "assigned volume to group ($disk_group_name)");
                 system("mkdir -p " . join('/', $volume->mount_path, $volume->groups->subdirectory));

--- a/lib/perl/Genome/Disk/Allocation/t-lib/GenomeDiskAllocationTest.pm
+++ b/lib/perl/Genome/Disk/Allocation/t-lib/GenomeDiskAllocationTest.pm
@@ -120,8 +120,8 @@ sub create_tmpfs_volume {
     );
 
     my $assignment = Genome::Disk::Assignment->create(
-        dg_id => $group->id,
-        dv_id => $volume->id,
+        group_id => $group->id,
+        volume_id => $volume->id,
     );
 
     UR::Context->commit;

--- a/lib/perl/Genome/Disk/Assignment.pm
+++ b/lib/perl/Genome/Disk/Assignment.pm
@@ -4,13 +4,13 @@ use strict;
 use warnings;
 
 class Genome::Disk::Assignment {
-    table_name => 'DISK_VOLUME_GROUP',
+    table_name => 'disk.volume_group_bridge',
     id_by => [
-        dg_id => {
+        group_id => {
             is => 'Number',
             doc => 'disk group ID',
         },
-        dv_id => {
+        volume_id => {
             is => 'Number',
             doc => 'disk volume ID'
         },
@@ -18,7 +18,7 @@ class Genome::Disk::Assignment {
     has => [
         group => {
             is => 'Genome::Disk::Group',
-            id_by => 'dg_id',
+            id_by => 'group_id',
         },
         disk_group_name => { via => 'group' },
         user_name => { via => 'group' },
@@ -26,7 +26,7 @@ class Genome::Disk::Assignment {
         subdirectory => { via => 'group' },
         volume => {
             is => 'Genome::Disk::Volume',
-            id_by => 'dv_id',
+            id_by => 'volume_id',
         },
         mount_path => { via => 'volume' },
         total_kb   => { via => 'volume' },
@@ -39,7 +39,7 @@ class Genome::Disk::Assignment {
             calculate => q| return $mount_path .'/'. $subdirectory; |,
         },
     ],
-    data_source => 'Genome::DataSource::Oltp',
+    data_source => 'Genome::DataSource::GMSchema',
 };
 
 1;

--- a/lib/perl/Genome/Disk/Command/Allocation/Import.t
+++ b/lib/perl/Genome/Disk/Command/Allocation/Import.t
@@ -77,8 +77,8 @@ sub create_test_volume_with_group {
     my $volume = create_test_volume($mount_path);
     die "Could not create test volume with mount path $mount_path" unless $volume;
     my $assignment = Genome::Disk::Assignment->create(
-        dv_id => $volume->id,
-        dg_id => $group->id,
+        volume_id => $volume->id,
+        group_id => $group->id,
     );
     return $volume;
 }

--- a/lib/perl/Genome/Disk/Command/Group/List.pm
+++ b/lib/perl/Genome/Disk/Command/Group/List.pm
@@ -13,7 +13,7 @@ class Genome::Disk::Command::Group::List {
             value => 'Genome::Disk::Group',
         },
         show => { 
-            default_value => 'disk_group_name,dg_id,user_name,group_name,subdirectory' 
+            default_value => 'disk_group_name,id,user_name,group_name,subdirectory' 
         },
     ],
     doc => 'Lists Genome::Disk::Group objects',

--- a/lib/perl/Genome/Disk/Group.pm
+++ b/lib/perl/Genome/Disk/Group.pm
@@ -11,15 +11,15 @@ use Module::Find qw(findsubmod usesub);
 usesub Genome::Disk::Group::Validate;
 
 class Genome::Disk::Group {
-    table_name => 'DISK_GROUP',
+    table_name => 'disk.group',
     id_by => [
-        dg_id => { is => 'Number' },
+        id => { is => 'Number' },
     ],
     has => [
-        disk_group_name => { is => 'Text' },
-        name => { via => '__self__', to => 'disk_group_name' },
+        disk_group_name => { via => '__self__', to => 'name' },
+        name => { is => 'Text', },
         permissions => { is => 'Number' },
-        setgid => { is => 'Number', is_transient => 1, is_optional => 1 }, #transient during transition from "sticky" column
+        setgid => { is => 'Boolean', default => 0, column_name => 'sticky' },
         subdirectory => { is => 'Text' },
         unix_uid => { is => 'Number' },
         unix_gid => { is => 'Number' },
@@ -93,7 +93,7 @@ class Genome::Disk::Group {
             reverse_id_by => 'group',
         },
     ],
-    data_source => 'Genome::DataSource::Oltp',
+    data_source => 'Genome::DataSource::GMSchema',
     doc => "Represents a disk group (eg, " . Genome::Config::get('disk_group_dev') . "), which contains any number of disk volumes",
 };
 

--- a/lib/perl/Genome/Disk/Group/View/SearchResult/Xml.pm
+++ b/lib/perl/Genome/Disk/Group/View/SearchResult/Xml.pm
@@ -11,7 +11,7 @@ class Genome::Disk::Group::View::SearchResult::Xml {
         default_aspects => {
             is => 'ARRAY',
             default => [
-                'dg_id',
+                'id',
                 'disk_group_name',
                 'user_name',
                 'group_name',

--- a/lib/perl/Genome/Disk/Volume.pm
+++ b/lib/perl/Genome/Disk/Volume.pm
@@ -88,7 +88,7 @@ class Genome::Disk::Volume {
     has_many_optional => [
         disk_group_names => {
             via => 'groups',
-            to => 'disk_group_name',
+            to => 'name',
         },
         groups => {
             is => 'Genome::Disk::Group',

--- a/lib/perl/Genome/Disk/Volume.pm
+++ b/lib/perl/Genome/Disk/Volume.pm
@@ -12,9 +12,9 @@ use List::Util qw(max);
 use Scope::Guard;
 
 class Genome::Disk::Volume {
-    table_name => 'DISK_VOLUME',
+    table_name => 'disk.volume',
     id_by => [
-        dv_id => {is => 'Number'},
+        id => {is => 'Number'},
     ],
     has => [
         hostname => { is => 'Text' },
@@ -25,19 +25,8 @@ class Genome::Disk::Volume {
             valid_values => ['inactive', 'active'],
         },
         can_allocate => {
-            is => 'Number',
-            valid_values => [0, 1],
+            is => 'Boolean', default_value => 1,
         },
-
-        # TODO remove this field when we switch to postgres
-        _placeholder_creation_event_id => {
-            is => 'Number',
-            is_optional => 1,
-            default_value => '1',
-            column_name => 'creation_event_id',
-            doc => 'This is here because of RT #88076.  Remove when we switch to postgres',
-        },
-
         total_kb => { is => 'Number' },
         total_gb => {
             calculate_from => 'total_kb',
@@ -116,7 +105,7 @@ class Genome::Disk::Volume {
             calculate => q| return Genome::Disk::Allocation->get(mount_path => $mount_path); |,
         },
     ],
-    data_source => 'Genome::DataSource::Oltp',
+    data_source => 'Genome::DataSource::GMSchema',
     doc => 'Represents a particular disk volume (eg, sata483)',
 };
 

--- a/lib/perl/Genome/Disk/Volume/View/SearchResult/Xml.pm
+++ b/lib/perl/Genome/Disk/Volume/View/SearchResult/Xml.pm
@@ -11,7 +11,7 @@ class Genome::Disk::Volume::View::SearchResult::Xml {
         default_aspects => {
             is => 'ARRAY',
             default => [
-                'dv_id',
+                'id',
                 'mount_path',
                 'disk_group_names',
             ]

--- a/lib/perl/Genome/Disk/Volume/View/Status/Xml.pm
+++ b/lib/perl/Genome/Disk/Volume/View/Status/Xml.pm
@@ -11,7 +11,7 @@ class Genome::Disk::Volume::View::Status::Xml {
         default_aspects => {
             is => 'ARRAY',
             value => [
-                'dv_id',
+                'id',
                 'mount_path',
                 'disk_status',
                 'can_allocate',

--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.pm
@@ -19,6 +19,7 @@ our @lims_classes = (
         IndexIllumina
         LimsProject LimsProjectSample
         InstrumentDataAnalysisProjectBridge
+        DiskGroup DiskVolume DiskAssignment
     /)
 );
 

--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.t
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/Dictionary.t
@@ -13,7 +13,7 @@ my $class_mapping = Genome::Site::TGI::Synchronize::Classes::Dictionary->get;
 ok($class_mapping, 'get class mapping');
 
 my @entities_to_sync = $class_mapping->entity_names;
-is(@entities_to_sync, 9, 'entity names');
+is(@entities_to_sync, 12, 'entity names');
 
 ok(!eval{$class_mapping->lims_class_for_entity_name;}, 'failed to get lims class for undef entity');
 is($class_mapping->error_message, 'No entity name given to get LIMS class!', 'correct error');

--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/DiskAssignment.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/DiskAssignment.pm
@@ -1,0 +1,33 @@
+package Genome::Site::TGI::Synchronize::Classes::DiskAssignment;
+use Genome;
+use strict;
+use warnings;
+
+class Genome::Site::TGI::Synchronize::Classes::DiskAssignment {
+    is => 'Genome::Site::TGI::Synchronize::Classes::LimsBase',
+    table_name => 'DISK_VOLUME_GROUP',
+    id_by => [
+        group_id => {
+            is => 'Number',
+            column_name => 'DG_ID',
+        },
+        volume_id => {
+            is => 'Number',
+            column_name => 'DV_ID',
+        },
+    ],
+    data_source => 'Genome::DataSource::Oltp',
+};
+
+sub genome_class_for_create { return 'Genome::Disk::Assignment' }
+
+sub entity_name { return 'disk assignment'; }
+
+sub properties_to_copy {
+    return (qw(
+        group_id
+        volume_id
+    ));
+}
+
+1;

--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/DiskGroup.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/DiskGroup.pm
@@ -1,0 +1,46 @@
+package Genome::Site::TGI::Synchronize::Classes::DiskGroup;
+
+use strict;
+use warnings;
+
+use Genome;
+use Carp qw(confess);
+use Memoize qw(memoize);;
+use Module::Find qw(findsubmod usesub);
+
+usesub Genome::Disk::Group::Validate;
+
+class Genome::Site::TGI::Synchronize::Classes::DiskGroup {
+    is => 'Genome::Site::TGI::Synchronize::Classes::LimsBase',
+    table_name => 'DISK_GROUP',
+    id_by => [
+        id => { is => 'Number', column_name => 'DG_ID' },
+    ],
+    has => [
+        name => { is => 'Text', column_name => 'DISK_GROUP_NAME' },
+        permissions => { is => 'Number' },
+        setgid => { is => 'Number', is_transient => 1, is_optional => 1 },
+        subdirectory => { is => 'Text' },
+        unix_uid => { is => 'Number' },
+        unix_gid => { is => 'Number' },
+    ],
+    data_source => 'Genome::DataSource::Oltp',
+};
+
+sub genome_class_for_create { return 'Genome::Disk::Group' } 
+
+sub entity_name { return 'disk group'; }
+
+sub properties_to_copy {
+    return (qw(
+        id
+        name
+        permissions
+        setgid
+        subdirectory
+        unix_uid
+        unix_gid
+    ));
+}
+
+1;

--- a/lib/perl/Genome/Site/TGI/Synchronize/Classes/DiskVolume.pm
+++ b/lib/perl/Genome/Site/TGI/Synchronize/Classes/DiskVolume.pm
@@ -1,0 +1,57 @@
+package Genome::Site::TGI::Synchronize::Classes::DiskVolume;
+
+use strict;
+use warnings;
+
+use Genome;
+use Carp;
+
+use Data::Dumper;
+use Filesys::Df qw();
+use List::Util qw(max);
+use Scope::Guard;
+
+class Genome::Site::TGI::Synchronize::Classes::DiskVolume {
+    is => 'Genome::Site::TGI::Synchronize::Classes::LimsBase',
+    table_name => 'DISK_VOLUME',
+    id_by => [
+        id => {is => 'Number', column_name => 'DV_ID'},
+    ],
+    has => [
+        hostname => { is => 'Text' },
+        physical_path => { is => 'Text' },
+        mount_path => { is => 'Text' },
+        disk_status => {
+            is => 'Text',
+        },
+        can_allocate => {
+            is => 'Number',
+        },
+        total_kb => { is => 'Number' },
+    ],
+    data_source => 'Genome::DataSource::Oltp',
+};
+
+sub genome_class_for_create { return 'Genome::Disk::Volume' }
+
+sub entity_name { return 'disk volume'; }
+
+sub properties_to_copy {
+    return (qw(
+        id
+        hostname
+        physical_path
+        mount_path
+        disk_status
+        can_allocate
+        total_kb
+    ));
+}
+
+sub properties_to_keep_updated {
+    return (qw(
+        total_kb
+    ));
+}
+
+1;

--- a/lib/perl/Genome/xsl/html/search-result/genome_disk_volume.xsl
+++ b/lib/perl/Genome/xsl/html/search-result/genome_disk_volume.xsl
@@ -4,7 +4,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:template name="genome_disk_volume" match="object[./types[./isa[@type='Genome::Disk::Volume']]]">
     <xsl:variable name="href">
-        <xsl:text>/disk/allocationmonitor/listallocations?dv_id=</xsl:text><xsl:value-of select='@id'/>
+        <xsl:text>/disk/allocationmonitor/listallocations?id=</xsl:text><xsl:value-of select='@id'/>
     </xsl:variable>
 
     <div class="search_result">


### PR DESCRIPTION
In preparation for the LIMS changing how they manage disk space, use our own copies of the tables so we can manage this independently. The DB already had tables created long ago, but we had never populated them until now.