### PR TITLE
Limit threads instead of connections.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -271,7 +271,7 @@ database {
     user = "$user"
     password = "$auth"
     connectionTimeout = 5000
-    maxConnections = 10
+    numThreads = 5
   }
 }
 EOCONFIG


### PR DESCRIPTION
Slick will automatically limit connections based on the thread count but not vice versa.  Therefore to get sane numbers let's set the thread count instead.