### PR TITLE
Allow individual configs for a model type to mismatch.

### DIFF
--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -121,6 +121,9 @@ sub _prepare_configuration_hashes_for_instrument_data {
             $config_hash->{$model_type} = [$config_hash->{$model_type}];
         }
 
+        my $subject_mapping_attempts = 0;
+        my $subject_mapping_successes = 0;
+
         for my $model_instance (@{$config_hash->{$model_type}}) {
             my $instrument_data_properties = delete $model_instance->{instrument_data_properties};
             if($instrument_data_properties) {
@@ -137,9 +140,11 @@ sub _prepare_configuration_hashes_for_instrument_data {
 
             my $requires_subject_mapping = delete $model_instance->{input_data_requires_subject_mapping};
             if ($requires_subject_mapping) {
+                $subject_mapping_attempts++;
                 my (@processed) = @{ $self->_process_mapped_samples($instrument_data, [{config_profile_item => $model_instance->{config_profile_item} }]) };
                 unless (@processed) {
-                    $self->fatal_message('Failed to map subject into configuration.');
+                    #tags didn't match, etc.
+                    $self->debug_message('Failed to map subject into configuration.');
                 }
 
                 if (@processed > 1) {
@@ -147,6 +152,7 @@ sub _prepare_configuration_hashes_for_instrument_data {
                 }
 
                 my $processed = $processed[0];
+                $subject_mapping_successes++;
 
                 delete $processed->{config_profile_item};
 
@@ -154,6 +160,10 @@ sub _prepare_configuration_hashes_for_instrument_data {
                     $model_instance->{input_data}{$key} = $value;
                 }
             }
+        }
+
+        if ($subject_mapping_attempts and not $subject_mapping_successes) {
+            $self->fatal_message('Failed to map subject into any configurations for model type %s.', $model_type);
         }
 
         $config_hash->{$model_type} = $self->_process_mapped_samples($instrument_data, $config_hash->{$model_type}) if $model_type->requires_subject_mapping;


### PR DESCRIPTION
When using tags to distinguish between otherwise matching configurations to limit to certain subject mappings, this will occasionally return no result for a given config.  For now, let's optimsitically assume that we should always get at least one match for a model type, even though it's possible even this assumption is not valid either.