### PR TITLE
Don't use hardcoded queue names in LSF bsub test.

### DIFF
--- a/lib/perl/Genome/Sys/LSF/bsub.t
+++ b/lib/perl/Genome/Sys/LSF/bsub.t
@@ -8,13 +8,8 @@ use Genome::Sys::LSF::bsub qw();
 
 plan tests => 10;
 
-do {
-    no warnings 'redefine';
-    *Genome::Sys::LSF::bsub::_queues = sub { qw(long short) };
-};
-
 my $fake_queue = 'fake_queue';
-my @queues = Genome::Sys::LSF::bsub::_queues();
+my @queues = (map { Genome::Config::get($_) } qw(lsf_queue_build_worker lsf_queue_short));
 
 ok( !Genome::Sys::LSF::bsub::_valid_lsf_queue($fake_queue),
     qq('$fake_queue' is not a valid queue));


### PR DESCRIPTION
Use the config!  Also... don't inject a method into our module that only gets used in this test... just use an array directly.