### PR TITLE
Use lower-level `move` for staging results.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -331,7 +331,7 @@ sub _stage_cromwell_outputs {
                     $self->fatal_message('Cannot stage results. Multiple outputs with identical names: %s', $file);
                 }
 
-                Genome::Sys->move_file($source, $destination);
+                Genome::Sys->move($source, $destination);
             }
         }
     }


### PR DESCRIPTION
When moving symlinks, their targets may or may not exist depending if
what they point to already got moved. We need to faithfully relocate
them in either circumstance, so verifying readability is bad.