### PR TITLE
Make LSF Resource for CWL Runner job configurable.

### DIFF
--- a/etc/genome/spec/lsf_resource_cwl_runner.yaml
+++ b/etc/genome/spec/lsf_resource_cwl_runner.yaml
@@ -1,0 +1,3 @@
+---
+default_value: "-R 'select[mem>8000] rusage[mem=8000]' -M 8000000"
+env: XGENOME_LSF_RESOURCE_CWL_RUNNER

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -17,7 +17,7 @@ class Genome::Model::CwlPipeline::Command::Run {
         },
         lsf_resource => {
             is_param => 1,
-            value => '-R "select[mem>8000] rusage[mem=8000]" -M 8000000',
+            value => Genome::Config::get('lsf_resource_cwl_runner'),
         },
     ],
     doc => 'wrapper command to run "cwltoil"'


### PR DESCRIPTION
We've encountered some workflows where Cromwell needs more than the default amount to survive pre-processing, but it's probably better to only request more memory if we really need it.  (This lets us configure it on a per-project basis.)