### PR TITLE
More Tolerant Staging and Handling of Strange Outputs

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -333,6 +333,7 @@ sub _stage_cromwell_output {
         return 1;
     }
 
+    return unless ref $item eq 'HASH';
     my $location = $item->{location};
     return unless $location;
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -8,6 +8,7 @@ use Genome;
 use Genome::Utility::File::Mode qw();
 use YAML;
 use JSON qw(to_json);
+use File::Compare qw();
 
 class Genome::Model::CwlPipeline::Command::Run {
     is => 'Command::V2',
@@ -342,7 +343,12 @@ sub _stage_cromwell_output {
 
         my $destination = File::Spec->join($results_dir, $file);
         if (-e $destination) {
-            $self->fatal_message('Cannot stage results. Multiple outputs with identical names: %s', $file);
+            if( File::Compare::compare($source, $destination) == 0 ) {
+                $self->warning_message('Skipping staging of %s--an identical file was already staged.', $source);
+                return 1;
+            } else {
+                $self->fatal_message('Cannot stage results. Multiple differing outputs with identical names: %s', $file);
+            }
         }
 
         Genome::Sys->move($source, $destination);

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -363,6 +363,7 @@ sub preserve_results {
     my $results_dir = shift;
 
     for my $file ($results_dir, glob("$results_dir/*")) {
+        next unless -e $file; #sometimes workflows produce dangling symlinks, yay!
         Genome::Utility::File::Mode::mode($file)->rm_all_writable;
     }
 


### PR DESCRIPTION
* I don't know why someone would want to make dangling symlinks as the output of their workflow, but we encountered this in the wild... so handle it!
* Sometimes there are arrays of things that aren't JSON objects.  For simple values (i.e. numbers and strings), go ahead and skip them.
* Allow for duplicate filenames as long as the contents of the files are the same.