### PR TITLE
Set a default for disk volume hostname.

### DIFF
--- a/lib/perl/Genome/Disk/Volume.pm
+++ b/lib/perl/Genome/Disk/Volume.pm
@@ -17,7 +17,7 @@ class Genome::Disk::Volume {
         id => {is => 'Number'},
     ],
     has => [
-        hostname => { is => 'Text' },
+        hostname => { is => 'Text', default => 'unknown' },
         physical_path => { is => 'Text' },
         mount_path => { is => 'Text' },
         disk_status => {


### PR DESCRIPTION
New disk volumes are coming through LIMS Synchronization with this value undefined.  A better solution would probably be to make a sqitch migration to drop this column and then not worry about it.  This is an expedient solution instead.