### PR TITLE
Add option to preserve region names to the IntervalList dumper.

### DIFF
--- a/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
+++ b/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
@@ -26,6 +26,11 @@ class Genome::FeatureList::Command::DumpIntervalList {
             doc => 'whether to merge adjacent regions of the BED file',
             default => 1,
         },
+        preserve_region_names => {
+            is => 'Boolean',
+            doc => 'whether to retain the region names from the feature-list (or replace them with "short" names)',
+            default => 0,
+        },
     },
     has_optional_output => {
         output_path => {
@@ -38,6 +43,10 @@ class Genome::FeatureList::Command::DumpIntervalList {
 sub execute {
     my $self = shift;
 
+    if ($self->preserve_region_names and $self->merge) {
+        $self->fatal_message('The --preserve-region-names option has no effect unless --nomerge is also specified.  Running the region merger reassigns the region names.');
+    }
+
     my $result_users = {
         sponsor => Genome::Config::AnalysisProject->system_analysis_project,
         requestor => $self->reference_build,
@@ -48,6 +57,7 @@ sub execute {
         reference_build => $self->reference_build,
         track_name => $self->track_name,
         merge => $self->merge,
+        preserve_region_names => $self->preserve_region_names,
         users => $result_users,
     );
 

--- a/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
+++ b/lib/perl/Genome/FeatureList/Command/DumpIntervalList.pm
@@ -43,10 +43,6 @@ class Genome::FeatureList::Command::DumpIntervalList {
 sub execute {
     my $self = shift;
 
-    if ($self->preserve_region_names and $self->merge) {
-        $self->fatal_message('The --preserve-region-names option has no effect unless --nomerge is also specified.  Running the region merger reassigns the region names.');
-    }
-
     my $result_users = {
         sponsor => Genome::Config::AnalysisProject->system_analysis_project,
         requestor => $self->reference_build,

--- a/lib/perl/Genome/FeatureList/Command/DumpIntervalList.t
+++ b/lib/perl/Genome/FeatureList/Command/DumpIntervalList.t
@@ -9,7 +9,7 @@ BEGIN {
 
 use above 'Genome';
 use Genome::Test::Factory::AnalysisProject;
-use Test::More tests => 6;
+use Test::More tests => 10;
 use Genome::Utility::Test qw(compare_ok);
 
 my $class = 'Genome::FeatureList::Command::DumpIntervalList';
@@ -61,4 +61,29 @@ compare_ok($interval_list_path, $expected_file,
     filters => [qr/\@SQ.*?$/],
 );
 
+my $interval_list_path2 = Genome::Sys->create_temp_file_path;
+my $dump_command_with_preserved_regions = $class->create(
+    feature_list => $test_fl,
+    reference_build => $reference,
+    track_name => 'target_region',
+    output_path => $interval_list_path2,
+    preserve_region_names => 1,
+    merge => 0,
+);
+isa_ok($dump_command_with_preserved_regions, $class, 'created second interval-list command');
+ok($dump_command_with_preserved_regions->execute, 'execute second interval-list command');
 
+ok(-e $interval_list_path2, 'created interval-list');
+
+my $expected_file2 = Genome::Sys->create_temp_file_path;
+Genome::Sys->write_file($expected_file2,
+"\@HD	VN:1.4	SO:unsorted\n",
+"\@SQ etc. etc.\n" x 84,
+"1	12	12	+	region1\n",
+"1	41	50	+	region2\n"
+);
+
+compare_ok($interval_list_path2, $expected_file2,
+    name => 'produced expected interval-list with region names',
+    filters => [qr/\@SQ.*?$/],
+);

--- a/lib/perl/Genome/FeatureList/Command/DumpIntervalList.t
+++ b/lib/perl/Genome/FeatureList/Command/DumpIntervalList.t
@@ -9,7 +9,7 @@ BEGIN {
 
 use above 'Genome';
 use Genome::Test::Factory::AnalysisProject;
-use Test::More tests => 10;
+use Test::More tests => 11;
 use Genome::Utility::Test qw(compare_ok);
 
 my $class = 'Genome::FeatureList::Command::DumpIntervalList';
@@ -61,14 +61,26 @@ compare_ok($interval_list_path, $expected_file,
     filters => [qr/\@SQ.*?$/],
 );
 
+my $fl_cmd2 = Genome::FeatureList::Command::Create->create(
+    name => 'another test feature list for dump-interval-list',
+    format => 'true-BED',
+    file_path => $bed_path,
+    content_type => 'targeted',
+    description => 'just a test',
+    source => 'GMS',
+    reference => $reference,
+);
+my $test_fl2 = $fl_cmd2->execute;
+isa_ok($test_fl2, 'Genome::FeatureList', 'setup second test feature-list');
+
 my $interval_list_path2 = Genome::Sys->create_temp_file_path;
 my $dump_command_with_preserved_regions = $class->create(
-    feature_list => $test_fl,
+    feature_list => $test_fl2,
     reference_build => $reference,
     track_name => 'target_region',
     output_path => $interval_list_path2,
     preserve_region_names => 1,
-    merge => 0,
+    merge => 1,
 );
 isa_ok($dump_command_with_preserved_regions, $class, 'created second interval-list command');
 ok($dump_command_with_preserved_regions->execute, 'execute second interval-list command');

--- a/lib/perl/Genome/FeatureList/Command/DumpMergedList.pm
+++ b/lib/perl/Genome/FeatureList/Command/DumpMergedList.pm
@@ -27,7 +27,7 @@ class Genome::FeatureList::Command::DumpMergedList {
         },
         merge => {
             is => 'Boolean',
-            doc => 'A command line option to merge or not merge the feature list',
+            doc => 'Whether to merge or not merge the feature list',
             default_value => 1,
             is_optional => 1,
         },
@@ -39,7 +39,7 @@ class Genome::FeatureList::Command::DumpMergedList {
         },
         short_name => {
             is => 'Boolean',
-            doc => 'A command line option to merge or not merge the feature list',
+            doc => 'Whether to replace the region names in the feature list with short names',
             default_value => 1,
             is_optional => 1,
         },

--- a/lib/perl/Genome/FeatureList/IntervalList.pm
+++ b/lib/perl/Genome/FeatureList/IntervalList.pm
@@ -35,6 +35,11 @@ class Genome::FeatureList::IntervalList {
             doc => 'whether to forcibly remove "chr" from the beginning of chromosome names (ignored if specified reference build is different from feature list reference)',
             default => 0,
         },
+        preserve_region_names => {
+            is => 'Boolean',
+            doc => 'whether to keep the "long" region names from the feature-list or replace them with the short names',
+            default => 0,
+        },
     ],
 };
 
@@ -68,6 +73,7 @@ sub _run {
         merge => $self->merge,
         strip_chr => $self->strip_chr,
         result_users => $self->_user_data_for_nested_results,
+        short_name => !$self->preserve_region_names,
         @alt_reference,
     );
     unless ($bed_dumper and $bed_dumper->execute) {


### PR DESCRIPTION
This will come in handy for the per-target metric reporting!