### PR TITLE
 Add support for multiple matching subject mappings for a sample.

### DIFF
--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -150,21 +150,25 @@ sub _prepare_configuration_hashes_for_instrument_data {
                     next MODEL_INSTANCE;
                 }
 
-                if (@processed > 1) {
-                    $self->fatal_message('Sorry, we do not currently support making multiple models for config-declared subject mappings.');
-                }
-
-                my $processed = $processed[0];
                 $subject_mapping_successes++;
 
-                delete $processed->{config_profile_item};
+                for my $processed (@processed) {
 
-                while (my ($key, $value) = each %$processed) {
-                    $model_instance->{input_data}{$key} = $value;
+                    #we need a copy of the instance and input_data to fill in, but a deep copy would copy objects (which is bad)
+                    my $per_mapping_instance = {%$model_instance};
+                    $per_mapping_instance->{input_data} = {%{$per_mapping_instance->{input_data}}};
+
+                    delete $processed->{config_profile_item};
+
+                    while (my ($key, $value) = each %$processed) {
+                        $per_mapping_instance->{input_data}{$key} = $value;
+                    }
+
+                    push @processed_model_instances, $per_mapping_instance;
                 }
+            } else {
+                push @processed_model_instances, $model_instance;
             }
-
-            push @processed_model_instances, $model_instance;
         }
 
         if ($subject_mapping_attempts and not $subject_mapping_successes) {

--- a/lib/perl/Genome/Config/Profile_input_data.t
+++ b/lib/perl/Genome/Config/Profile_input_data.t
@@ -68,7 +68,6 @@ for my $m (values %models) {
     ok(exists $inputs{this_uses_mappings}, 'test mapping indicator set');
 
     if ($inputs{this_uses_mappings}) {
-        $DB::single = 1;
         is($inputs{best_sample}, $sample->id, 'sample attached');
         is($inputs{some_key}, 'some_value', 'extra key attached');
     } else {


### PR DESCRIPTION
The trick here is to carefully duplicate the model instance hash for each matching subject mapping.

(Though not required, these changes might make more intuitive sense with `?w=1` applied.)