### PR TITLE
We know that `when` is experimental, and we're okay with that.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use feature qw(switch);
+no if $] >= 5.018, warnings => qw( experimental::smartmatch );
 
 use Genome;
 

--- a/lib/perl/Genome/Config/Profile.pm
+++ b/lib/perl/Genome/Config/Profile.pm
@@ -9,6 +9,7 @@ use Genome;
 use UR::Util;
 
 use feature qw(switch);
+no if $] >= 5.018, warnings => qw( experimental::smartmatch );
 
 class Genome::Config::Profile {
     is => 'UR::Object',

--- a/lib/perl/Genome/Model/Build/CwlPipeline/InputProcessor.pm
+++ b/lib/perl/Genome/Model/Build/CwlPipeline/InputProcessor.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use feature qw(switch);
+no if $] >= 5.018, warnings => qw( experimental::smartmatch );
 
 use Genome;
 

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use feature qw(switch);
+no if $] >= 5.018, warnings => qw( experimental::smartmatch );
 use Genome;
 
 use Set::Scalar;

--- a/lib/perl/Genome/ProcessingProfile/Command/View.pm
+++ b/lib/perl/Genome/ProcessingProfile/Command/View.pm
@@ -3,6 +3,7 @@ package Genome::ProcessingProfile::Command::View;
 use strict;
 use warnings;
 use feature 'switch';
+no if $] >= 5.018, warnings => qw( experimental::smartmatch );
 
 use Genome;
 use List::MoreUtils "uniq";


### PR DESCRIPTION
This quiets the warnings from newer Perls like:
```when is experimental at lib/perl/Genome/Model/CwlPipeline.pm line 197.```