### PR TITLE
New WorkflowBuilder Backend: `simple`

### DIFF
--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -231,7 +231,7 @@ sub _dispatch_process {
     unless ($transaction->commit()) {
         $transaction->rollback();
         $self->fatal_message(
-            "Failed to submit process (%s): %s",
+            "Failed to dispatch process (%s): %s",
             $self->id, $transaction->error_message || 'Reason Unknown'
         );
     }
@@ -254,6 +254,9 @@ sub _dispatch_process {
         resource_string => Genome::Config::get('lsf_resource_cwl_runner'),
     );
 
+    unless ($job_id) {
+        $self->fatal_message('Failed to dispatch process (%s): bsub did not succeed.', $self->id);
+    }
     $self->lsf_job_id($job_id);
     Genome::Sys::CommitAction->create(
         on_commit => sub {

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -297,14 +297,27 @@ sub update_status {
     return $self->status;
 }
 
+sub lsf_job_id_header {
+    return 'workflow lsf job_id';
+}
+
 sub lsf_job_id {
     my $self = shift;
 
-    my $id_note = $self->notes(header_text => 'workflow lsf job_id');
-    if ($id_note) {
-        return $id_note->body_text;
+    my $new_value = shift;
+    if ($new_value) {
+        my $existing = $self->notes(header_text => $self->lsf_job_id_header);
+        if ($existing) {
+            $existing->delete;
+        }
+        $self->add_note(header_text => $self->lsf_job_id_header, body_text => $new_value);
     } else {
-        return;
+        my $id_note = $self->notes(header_text => $self->lsf_job_id_header);
+        if ($id_note) {
+            return $id_note->body_text;
+        } else {
+            return;
+        }
     }
 }
 

--- a/lib/perl/Genome/Sys/LSF/bsub.t
+++ b/lib/perl/Genome/Sys/LSF/bsub.t
@@ -6,7 +6,7 @@ use Test::Builder;
 use Test::Fatal qw(exception);
 use Genome::Sys::LSF::bsub qw();
 
-plan tests => 10;
+plan tests => 11;
 
 my $fake_queue = 'fake_queue';
 my @queues = (map { Genome::Config::get($_) } qw(lsf_queue_build_worker lsf_queue_short));
@@ -65,6 +65,12 @@ my @cases = (
             cmd => 'true',
         ], [qw(-H true)], 'enabled flag',
     ],
+    [
+        [
+            resource_string => '-R "select[mem>9876] rusage[mem=9753] span[hosts=1]" -M 10000000 -n 4',
+            cmd => 'true',
+        ], ['-R', 'select[mem>9876] rusage[mem=9753] span[hosts=1]','-n', 4,  '-M', '10000000', 'true'], 'parsed resource request',
+    ]
 );
 for my $case (@cases) {
     my @input = @{$case->[0]};


### PR DESCRIPTION
Everything old is new again! The `simple` backend `bsub`s a single job that then runs the entire workflow inline.  (For CWL pipelines "the entire workflow" is a single job that runs `toil` or `cromwell` for the *real* workflow :smile:)