### PR TITLE
Set default memory request of 4096MB.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -205,8 +205,8 @@ backend {
       config {
         runtime-attributes = """
         Int cpu = 1
-        Int? memory_kb
-        Int? memory_mb
+        Int memory_kb = 4096000
+        Int memory_mb = 4096
         String? docker
         """
 


### PR DESCRIPTION
This is the companion to genome/analysis-workflows#589.  It sets a default for any CWL steps that don't have a defined memory request.