### PR TITLE
Site Feature: Import instrument data from LIMS in CQID.

### DIFF
--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -65,6 +65,7 @@ sub execute {
             next;
         }
         eval {
+            $self->_verify_or_import_instrument_data($current_pair);
             $analysis_project->get_configuration_profile->process_models_for_instrument_data($current_inst_data);
         };
 
@@ -229,6 +230,24 @@ sub _lock {
             }
         );
     }
+}
+
+sub _verify_or_import_instrument_data {
+    my $self = shift;
+    my $current_pair = shift;
+
+    my $instrument_data = $current_pair->instrument_data;
+    return 1 if @{[$instrument_data->disk_allocations]};
+
+    $self->_import_instrument_data($current_pair);
+}
+
+sub _import_instrument_data {
+    my $self = shift;
+    my $current_pair = shift;
+
+    #site-specific override required
+    $self->fatal_message(q{I don't know how to import %s for analysis.}, $current_pair->instrument_data->id);
 }
 
 1;

--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.t
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.t
@@ -9,6 +9,7 @@ use above "Genome";
 use Carp::Always;
 
 use Genome::Test::Factory::Config::Profile::Item;
+use Genome::Test::Factory::DiskAllocation;
 use Genome::Test::Factory::InstrumentData::Solexa;
 use Genome::Test::Factory::InstrumentData::Imported;
 use Genome::Test::Factory::AnalysisProject;
@@ -295,6 +296,7 @@ sub generate_rna_seq_instrument_data {
         target_region_set_name => 'turkey',
         run_type => 'Paired',
     );
+    my $da = Genome::Test::Factory::DiskAllocation->setup_object(owner => $inst_data);
 
     my $ap = Genome::Test::Factory::AnalysisProject->setup_object(
         config_hash => {
@@ -358,6 +360,7 @@ sub _generate_som_val_instrument_data {
         rev_clusters => 10,
         run_type => 'Paired',
     );
+    my $da_1 = Genome::Test::Factory::DiskAllocation->setup_object(owner => $inst_data_1);
 
     my $inst_data_2 = Genome::Test::Factory::InstrumentData::Solexa->setup_object(
         library_id => $library_2->id,
@@ -367,6 +370,7 @@ sub _generate_som_val_instrument_data {
         rev_clusters => 10,
         run_type => 'Paired',
     );
+    my $da_2 = Genome::Test::Factory::DiskAllocation->setup_object(owner => $inst_data_2);
 
     map $som_val_project->add_part(role => 'instrument_data', entity => $_), ($inst_data_1, $inst_data_2);
 
@@ -423,6 +427,7 @@ sub _generate_lane_qc_instrument_data {
         run_name => 'sans',
         subset_name => 3,
     );
+    my $sans_da = Genome::Test::Factory::DiskAllocation->setup_object(owner => $sans_data);
 
     #Lane QC stuff plus genotype data
     my $plus_sample = Genome::Test::Factory::Sample->setup_object(
@@ -439,6 +444,7 @@ sub _generate_lane_qc_instrument_data {
         run_name => 'plus',
         subset_name => 2,
     );
+    my $plus_da = Genome::Test::Factory::DiskAllocation->setup_object(owner => $plus_data);
 
     my $genotype_microarray_model = Genome::Model::GenotypeMicroarray->create(
         processing_profile_id => '2166945',

--- a/lib/perl/Genome/Site/TGI/Extension/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Site/TGI/Extension/ConfigureQueuedInstrumentData.pm
@@ -1,0 +1,29 @@
+package Genome::Config::Command::ConfigureQueuedInstrumentData;
+
+use strict;
+use warnings;
+
+use Genome;
+use Genome::Config::Command::ConfigureQueuedInstrumentData; #load real module first
+
+use Sub::Install;
+
+Sub::Install::reinstall_sub ({
+    as => '_import_instrument_data',
+    code => \&_import_lims_data,
+
+});
+
+sub _import_lims_data {
+    my $self = shift;
+    my $current_pair = shift;
+
+    my $importer = Genome::Site::TGI::Command::ImportDataFromLims->create(
+        instrument_data => $current_pair->instrument_data,
+        analysis_project => $current_pair->analysis_project,
+    );
+
+    unless($importer->execute) {
+        $self->fatal_message('Failed to import data from LIMS.');
+    }
+}

--- a/lib/perl/Genome/Site/TGI/Observers.pm
+++ b/lib/perl/Genome/Site/TGI/Observers.pm
@@ -34,5 +34,19 @@ $unarchive_observer = UR::Observer->register_callback(
     },
 );
 
+my $cqid_observer;
+$cqid_observer = UR::Observer->register_callback(
+    subject_class_name => 'UR::Object::Type',
+    aspect => 'load',
+    callback => sub {
+        my $meta = shift;
+        my $class_name = $meta->class_name;
+        if ($class_name eq 'Genome::Config::Command::ConfigureQueuedInstrumentData') {
+            require Genome::Site::TGI::Extension::ConfigureQueuedInstrumentData;
+            UR::Observer->unregister_callback(id => $cqid_observer);
+        }
+    },
+);
+
 1;
 


### PR DESCRIPTION
This will cause CQID failures when the data could not be imported.  But that's probably fine, since the builds would themselves fail later!

There is an additional complication in that this would need to be run as a user with access to import the data.