### PR TITLE
Ensure only the LSF Job ID gets into the process note.

### DIFF
--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -355,7 +355,8 @@ sub lsf_job_id {
         if ($existing) {
             $existing->delete;
         }
-        $self->add_note(header_text => $self->lsf_job_id_header, body_text => $new_value);
+        my $n = $self->add_note(header_text => $self->lsf_job_id_header, body_text => $new_value);
+        $n->body_text($new_value); #ignore any system-generated sudo message for this note.
     } else {
         my $id_note = $self->notes(header_text => $self->lsf_job_id_header);
         if ($id_note) {


### PR DESCRIPTION
There's logic to prepend any notes with a sudo message when running as another user, but that's not helpful here. (Really, storing this as a note is not great--it should just be a column on the table.)