### PR TITLE
Only consider active allocations when deciding whether to import.

### DIFF
--- a/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
+++ b/lib/perl/Genome/Config/Command/ConfigureQueuedInstrumentData.pm
@@ -237,7 +237,7 @@ sub _verify_or_import_instrument_data {
     my $current_pair = shift;
 
     my $instrument_data = $current_pair->instrument_data;
-    return 1 if @{[$instrument_data->disk_allocations]};
+    return 1 if @{[$instrument_data->disk_allocations(status => 'active')]};
 
     $self->_import_instrument_data($current_pair);
 }


### PR DESCRIPTION
A previous import might have been purged, in which case new analysis would require reimporting the data. (Users can then also use `genome analysis-project reprocess` if they need to pull back the data to build again later.)