### PR TITLE
Make sure we're in the AnP environment when looking up the disk group.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/ImportDataFromLims.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportDataFromLims.pm
@@ -156,7 +156,7 @@ sub _create_allocation {
     my $data = shift;
 
     my %params = (
-        disk_group_name => Genome::Config::get('disk_group_alignments'),
+        disk_group_name => $self->_disk_group,
         allocation_path => File::Spec->join('instrument_data',$data->id),
         kilobytes_requested => $data->calculate_alignment_estimated_kb_usage,
         owner_class_name => $data->class,
@@ -191,6 +191,27 @@ sub _resolve_user_group {
     my $group = Genome::Config::get('sys_group');
 
     return $group;
+}
+
+sub _disk_group {
+    my $self = shift;
+
+    unless (exists $self->{_disk_group}) {
+        $self->{_disk_group} = $self->_resolve_disk_group;
+    }
+
+    return $self->{_disk_group};
+}
+
+sub _resolve_disk_group {
+    my $self = shift;
+
+    my $anp = $self->analysis_project;
+    my $guard = $anp->set_env;
+
+    my $dg = Genome::Config::get('disk_group_alignments');
+
+    return $dg;
 }
 
 1;


### PR DESCRIPTION
Otherwise we're in the default environment, which never has a configured disk group.