### PR TITLE
Tool to abandon prior builds for a model.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/AbandonPriorBuildsWithStatus.pm
+++ b/lib/perl/Genome/Model/Build/Command/AbandonPriorBuildsWithStatus.pm
@@ -1,0 +1,105 @@
+package Genome::Model::Build::Command::AbandonPriorBuildsWithStatus;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::Build::Command::AbandonPriorBuildsWithStatus {
+    is => 'Command::V2',
+    has => [
+        status => {
+            is => 'Text',
+            doc => 'Status of builds to abandon prior builds',
+            valid_values => Genome::Model::Build->__meta__->property(property_name => 'status')->valid_values,
+        },
+        models => {
+            is => 'Genome::Model',
+            is_many => 1,
+            shell_args_position => 1,
+            doc => 'models whose prior builds to abandon',
+            require_user_verify => 1,
+        },
+    ],
+    doc => 'abandon prior builds for a model',
+};
+
+sub help_detail {
+    return <<EOHELP
+Abandon prior builds for a model with a matching status, leaving only the most recent build.
+
+Suppose a model has these builds (using the format from `genome model build status`):
+
+ Model: example-model.prod-cwl   Model ID: abcdef1234567890abcdef1234567890
+ BUILD_ID        STATUS
+ abcdef1234567890abcdef1234567891        Succeeded
+ abcdef1234567890abcdef123456789a        Succeeded
+ abcdef1234567890abcdef1234567899        Failed
+ abcdef1234567890abcdef1234567894        Failed
+ abcdef1234567890abcdef1234567898        Succeeded
+
+Running with the --status=Succeeded option would yield:
+
+ Model: example-model.prod-cwl   Model ID: abcdef1234567890abcdef1234567890
+ BUILD_ID        STATUS
+ abcdef1234567890abcdef1234567891        Succeeded
+ abcdef1234567890abcdef123456789a        Abandoned
+ abcdef1234567890abcdef1234567899        Failed
+ abcdef1234567890abcdef1234567894        Failed
+ abcdef1234567890abcdef1234567898        Abandoned
+
+Running instead with the --status=Failed option would yield:
+
+ Model: example-model.prod-cwl   Model ID: abcdef1234567890abcdef1234567890
+ BUILD_ID        STATUS
+ abcdef1234567890abcdef1234567891        Succeeded
+ abcdef1234567890abcdef1234567892        Succeeded
+ abcdef1234567890abcdef1234567893        Failed
+ abcdef1234567890abcdef1234567894        Abandoned
+ abcdef1234567890abcdef1234567895        Succeeded
+
+Running twice, once with each of the above, will leave only one build with each status:
+
+ Model: example-model.prod-cwl   Model ID: abcdef1234567890abcdef1234567890
+ BUILD_ID        STATUS
+ abcdef1234567890abcdef1234567891        Succeeded
+ abcdef1234567890abcdef123456789a        Abandoned
+ abcdef1234567890abcdef1234567899        Failed
+ abcdef1234567890abcdef1234567894        Abandoned
+ abcdef1234567890abcdef1234567898        Abandoned
+
+EOHELP
+}
+
+sub execute {
+    my $self = shift;
+
+    my @builds_to_abandon;
+
+    my $status = $self->status;
+
+    for my $m ($self->models) {
+        my @builds = $m->builds;
+
+        my $found = 0;
+        for my $build (@builds) {
+            next unless $build->status eq $status;
+
+            if ($found) {
+                push @builds_to_abandon, $build;
+            } else {
+                $found = 1;
+            }
+        }
+    }
+
+    my $abandon_cmd = Genome::Model::Build::Command::Abandon->create(
+        builds => \@builds_to_abandon,
+    );
+
+    $abandon_cmd->builds([ $abandon_cmd->_limit_results_for_builds(@builds_to_abandon) ]);
+
+    return $abandon_cmd->execute;
+}
+
+1;

--- a/lib/perl/Genome/Model/Build/Command/AbandonPriorBuildsWithStatus.t
+++ b/lib/perl/Genome/Model/Build/Command/AbandonPriorBuildsWithStatus.t
@@ -1,0 +1,46 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+
+use Genome::Test::Factory::Model::CwlPipeline;
+use Genome::Test::Factory::Build;
+
+use Test::More tests => 7;
+
+my $pkg = 'Genome::Model::Build::Command::AbandonPriorBuildsWithStatus';
+
+use_ok($pkg);
+
+my $model = Genome::Test::Factory::Model::CwlPipeline->setup_object;
+for (('Failed')x3, 'Succeeded', 'Failed', ('Succeeded')x2, 'Scheduled', ('Succeeded')x3) {
+    my $build = Genome::Test::Factory::Build->setup_object(
+        model_id => $model->id,
+        status => $_,
+    );
+}
+is(scalar(@{[$model->builds]}), 11, 'created 11 test builds');
+
+my $last_complete_build = $model->last_complete_build;
+
+my $cmd = $pkg->create(
+    models => [$model],
+    status => 'Succeeded'
+);
+isa_ok($cmd, $pkg, 'created command');
+ok($cmd->execute, 'executed command');
+
+my %statuses;
+for my $build ($model->builds) {
+    $statuses{$build->status}++;
+}
+
+is($statuses{Succeeded}, 1, 'left one Succeeded build');
+is($statuses{Abandoned}, 5, 'abandoned other Succeeded builds');
+is($last_complete_build->status, 'Succeeded', 'the remaining Succeeded build is the most recent one');


### PR DESCRIPTION
If a model has many builds, sometimes we only want to keep the recent ones.  This facilitates abandoning the others for a large project.

(This tool's creation was motivated by BGAS-657, wherein a project of 900 models had run out of disk space but had many prior successes and failures.)