### PR TITLE
Skip running the abandon command when no builds match.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/AbandonPriorBuildsWithStatus.pm
+++ b/lib/perl/Genome/Model/Build/Command/AbandonPriorBuildsWithStatus.pm
@@ -93,6 +93,11 @@ sub execute {
         }
     }
 
+    unless (@builds_to_abandon) {
+        $self->status_message("Found no matching builds to abandon.");
+        return 1;
+    }
+
     my $abandon_cmd = Genome::Model::Build::Command::Abandon->create(
         builds => \@builds_to_abandon,
     );


### PR DESCRIPTION
Running `genome model build abandon` with no builds specified generates an error in commit, even though there's nothing to commit.