### PR TITLE
Check that we got exactly one disk group and explicitly die if not.

### DIFF
--- a/lib/perl/Genome/Disk/Detail/Allocation/CreationParameters.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/CreationParameters.pm
@@ -96,7 +96,12 @@ sub sanitize_disk_group {
     if ($dgn =~ m!/!) { #maybe it's a mount path
         if (my $dv = Genome::Disk::Volume->get(mount_path => $dgn)) {
             $self->mount_path($dgn);
-            $self->disk_group_name($dv->disk_group_name);
+
+            my @disk_groups = $dv->disk_group_names;
+            $self->fatal_message('Failed to infer disk group for mount path %s', $dgn)
+                unless @disk_groups == 1;
+
+            $self->disk_group_name($disk_groups[0]);
         }
     }
 }


### PR DESCRIPTION
This should help make more plain errors if a volume belongs to multiple disk groups (or...none, if such a thing ever were to happen!).