### PR TITLE
Create a separate allocation for scratch space for CWL builds.

### DIFF
--- a/etc/genome/spec/disk_group_scratch.yaml
+++ b/etc/genome/spec/disk_group_scratch.yaml
@@ -1,0 +1,2 @@
+---
+env: XGENOME_DISK_GROUP_SCRATCH

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -87,12 +87,10 @@ sub prepare_directories {
     my $self = shift;
     my $build = $self->build;
 
+    my $tmp_dir = $build->get_or_create_scratch_directory;
+
     my $data_directory = $build->data_directory;
-
-    my $tmp_dir = File::Spec->join($data_directory, 'tmp');
     my $results_dir = File::Spec->join($data_directory, 'results');
-
-    Genome::Sys->create_directory($tmp_dir);
     Genome::Sys->create_directory($results_dir);
 
     return ($tmp_dir, $results_dir);
@@ -400,7 +398,8 @@ sub cleanup {
     my $tmp_dir = shift;
     my $results_dir = shift;
 
-    Genome::Sys->remove_directory_tree($tmp_dir);
+    my $build = $self->build;
+    $build->cleanup_scratch_directory;
 
     if ($results_dir) {
         for my $dir (glob("$results_dir/tmp*")) {


### PR DESCRIPTION
This way we can have a pool of scratch space and final project disk groups can be sized to only hold the final data products.

If this is deployed, a value for `disk_group_scratch` will need to be defined in configuration for builds to not fail!