### PR TITLE
Better symlink handling in CWL output staging.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -10,6 +10,7 @@ use Genome::Utility::Text qw();
 use YAML;
 use JSON qw(to_json);
 use File::Compare qw();
+use File::Copy::Recursive qw();
 
 class Genome::Model::CwlPipeline::Command::Run {
     is => 'Command::V2',
@@ -375,7 +376,16 @@ sub _stage_cromwell_output {
             }
         }
 
-        Genome::Sys->move($source, $destination);
+        if (-l $source) {
+            if ($prefix) {
+                my $target = readlink $source;
+                symlink(join('-', $prefix, $target), $destination);
+            } else {
+                File::Copy::Recursive::fmove($source, $destination);
+            }
+        } else {
+            Genome::Sys->move($source, $destination);
+        }
     }
 
     return 1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -383,6 +383,8 @@ sub _stage_cromwell_output {
             } else {
                 File::Copy::Recursive::fmove($source, $destination);
             }
+        } elsif (-d $source) {
+            File::Copy::Recursive::dirmove($source, $destination);
         } else {
             Genome::Sys->move($source, $destination);
         }

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.t
@@ -10,7 +10,7 @@ BEGIN {
 };
 
 use File::Spec;
-use Test::More tests => 23;
+use Test::More tests => 25;
 
 my $class = 'Genome::Model::CwlPipeline::Command::Run';
 
@@ -38,6 +38,15 @@ for my $dir ('first', 'second', 'third') {
     }
 }
 
+my $symlink_path = $paths[6] . '.2';
+my $symlink_file = $files[6] . '.2';
+
+symlink($files[6], $symlink_path);
+
+push @files, $symlink_file;
+push @paths, $symlink_path;
+
+
 my @test_structures = (
     [
         [
@@ -49,7 +58,7 @@ my @test_structures = (
         ],
     ],
     [
-        { location => $paths[6], secondaryFiles => [] },
+        { location => $paths[6], secondaryFiles => [ { location => $symlink_path } ] },
     ],
     { location => $paths[7], secondaryFiles => [ { location => $paths[8] } ] },
 );


### PR DESCRIPTION
Perl's `File::Copy::move` doesn't work to move symlinks between mounts.  `File::Copy::Recursive` handles this, but makes a copy even when moving on the same mount, so isn't ideal for regular files.  Thus we'll use one for symlinks and one for everything else.

Additionally, fix symlink support in our prefix adding.  (Absolute symlinks will get broken, but those don't make much sense in the context of a Cromwell workflow... so hopefully none exist!)  This shortcoming was uncovered when adding a test for symlinks :smile: