### PR TITLE
Add is_10x_ support

### DIFF
--- a/lib/perl/Genome/Library.pm
+++ b/lib/perl/Genome/Library.pm
@@ -154,6 +154,45 @@ sub is_rna {
     return 0;
 }
 
+sub is_10x_atac {
+    my $self = shift;
+
+    return 1 if Genome::Utility::List::in(
+        $self->protocol, (
+            "10x_SC_ATAC_SEQ"
+        )
+    );
+
+    return 0;
+}
+
+sub is_10x_gex {
+    my $self = shift;
+
+    return 1 if Genome::Utility::List::in(
+        $self->protocol, (
+            "10x_SC-5'GEX",
+            "10x_SC-3'GEX V3",
+            "10x_SC-5'GEX"
+        )
+    );
+
+    return 0;
+}
+
+sub is_10x_vdj {
+    my $self = shift;
+
+    return 1 if Genome::Utility::List::in(
+        $self->protocol, (
+            "10x_SC-5'Enriched BCELL",
+            "10x_SC-5'Enriched TCELL"
+        )
+    );
+
+    return 0;
+}
+
 sub lock_id {
     my $class = shift;
     my %args = @_;

--- a/lib/perl/Genome/Library.t
+++ b/lib/perl/Genome/Library.t
@@ -60,4 +60,21 @@ subtest 'is_rna' => sub{
 
 };
 
+subtest 'is_10x' => sub{
+    plan tests => 4;
+
+    $library->protocol('karate chop');
+    is($library->is_10x_gex, 0, 'is NOT 10x_gex when protocol is karate chop');
+
+    $library->protocol("10x_SC-5'GEX");
+    is($library->is_10x_gex, 1, "is 10x_gex when protocol is 10x_SC-5'GEX");
+
+    $library->protocol("10x_SC-5'Enriched BCELL");
+    is($library->is_10x_vdj, 1, "is 10x_vdj when protocol is 10x_SC-5'Enriched BCELL");
+
+    $library->protocol("10x_SC_ATAC_SEQ");
+    is($library->is_10x_atac, 1, "is 10x_atac when protocol is 10x_SC_ATAC_SEQ");
+
+};
+
 done_testing();


### PR DESCRIPTION
This PR adds `is_10x_atac`, `is_10x_gex`, and `is_10x_vdj` support for libraries and tests to confirm they work. Having these will help simplify the configs necessary to run the 10x cellranger pipelines.

One thing I wasn't sure was okay was switching to double quotes `"` because the library protocol names we have contain a single quote `'`.