### PR TITLE
Don't use defined on an array.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Music/Survival.pm
+++ b/lib/perl/Genome/Model/Tools/Music/Survival.pm
@@ -412,7 +412,7 @@ sub create_sample_gene_matrix_variant {
         }
 
         #check to see if this gene is on the list (if there is a list at all)
-        if( defined @{$mutated_genes_to_include} ) {
+        if( defined($mutated_genes_to_include) and @{$mutated_genes_to_include} ) {
             next unless (scalar grep { m/^$gene$/ } @{$mutated_genes_to_include});
         }
 


### PR DESCRIPTION
It used to be a warning back when this was written. Now it's an error.  Either way, it doesn't make sense, so I borrowed the conditional from a different line of the file to replace this one.

I make no guarantees of the ongoing usefulness of this tool, but it compiles now 🙂 