### PR TITLE
Command to clean up Scratch Directory for a Build

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/CleanupScratchAllocation.pm
+++ b/lib/perl/Genome/Model/Build/Command/CleanupScratchAllocation.pm
@@ -1,0 +1,32 @@
+package Genome::Model::Build::Command::CleanupScratchAllocation;
+
+use strict;
+use warnings;
+
+use Genome;
+use Try::Tiny qw(try catch);
+
+class Genome::Model::Build::Command::CleanupScratchAllocation {
+    is  => 'Genome::Model::Build::Command::Base',
+};
+
+sub help_brief {
+    return "Cleanup the scratch allocation for a build";
+}
+
+sub help_detail {
+    return "This command cleans up the scratch allocation ('tmp') directory for a build while otherwise leaving its data directory intact.  This can be useful if the logs for a failed build need to preserved for further inspection, but the working space needs to be freed."
+}
+
+sub execute {
+    my $self = shift;
+
+    my @builds = $self->builds;
+    for my $build (@builds) {
+         $build->cleanup_scratch_directory;
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/Build/Command/CleanupScratchAllocation.pm
+++ b/lib/perl/Genome/Model/Build/Command/CleanupScratchAllocation.pm
@@ -22,8 +22,13 @@ sub execute {
     my $self = shift;
 
     my @builds = $self->builds;
-    for my $build (@builds) {
-         $build->cleanup_scratch_directory;
+    BUILD: for my $build (@builds) {
+        if ($build->status eq 'Running') {
+            $self->warning_message('Skipping Running build: %s.  To clean it up, stop the build before running this command.', $build->__display_name__);
+            next BUILD;
+        }
+
+        $build->cleanup_scratch_directory;
     }
 
     return 1;


### PR DESCRIPTION
Some users have requested a way to clean up the scratch space without abandoning a build.  (In this case, so they could continue to use the build logs while otherwise reclaiming the disk space.)

This command could also possibly be automated to reclaim space after a certain amount of time without necessarily removing a Failed build from someone's radar.