### PR TITLE
Use job group for Cromwell workers.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -188,6 +188,12 @@ sub _generate_cromwell_config {
 
     my $default_queue = Genome::Config::get('lsf_queue_build_worker_alt');
 
+    my $job_group = join('/',
+        Genome::Config::get('lsf_job_group'),
+        Genome::Sys->username,
+        'workers'
+    );
+
     my $server = Genome::Config::get('cromwell_server');
     my $auth = Genome::Config::get('cromwell_auth');
     my $user = Genome::Config::get('cromwell_user');
@@ -222,6 +228,7 @@ EOCONFIG
         -e $log_dir/cromwell-%J.err \\
         -a '$primary_docker_image' \\
         -q '$default_queue' \\
+        -g '$job_group' \\
 EOCONFIG
         ;
     $config .= <<'EOCONFIG'
@@ -243,6 +250,7 @@ EOCONFIG
         -o /dev/null \\
         -e $log_dir/cromwell-%J.err \\
         -q '$default_queue' \\
+        -g '$job_group' \\
 EOCONFIG
         ;
     $config .= <<'EOCONFIG'

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -239,6 +239,7 @@ sub _dispatch_process {
     my $job_group = join('/',
         Genome::Config::get('lsf_job_group'),
         Genome::Sys->username,
+        'process',
     );
 
     my $log_file_base = File::Spec->join($self->log_directory, 'process-%J');

--- a/lib/perl/Genome/WorkflowBuilder/Command.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Command.pm
@@ -163,6 +163,7 @@ sub _get_ptero_lsf_parameters {
     my $default_job_group = join('/',
         Genome::Config::get('lsf_job_group'),
         Genome::Sys->username,
+        'ptero-workers',
     );
     $set_lsf_option->('jobGroup', $default_job_group);
 


### PR DESCRIPTION
For systems that require a job group for all job submissions, this might come in handy!