### PR TITLE
Handle builds with multiple allocations.

### DIFF
--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -637,7 +637,7 @@ sub disk_usage_allocations {
     my $self = shift;
 
     my @allocations;
-    push @allocations, $self->disk_allocation if $self->disk_allocation;
+    push @allocations, $self->disk_allocations if @{[$self->disk_allocations]};
 
     push @allocations, $self->user_allocations;
     push @allocations, $self->symlinked_allocations;


### PR DESCRIPTION
Thanks to scratch dirs, builds sometimes have multiple allocations.
* Use the plural accessor.
* Avoid triggering UR's "multiple results in scalar context" error.