### PR TITLE
Increase connection timeout in Cromwell config to 30s.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -283,7 +283,7 @@ database {
     url = "jdbc:$server"
     user = "$user"
     password = "$auth"
-    connectionTimeout = 5000
+    connectionTimeout = 30000
     numThreads = 5
   }
 }


### PR DESCRIPTION
We've been testing this configuration change in real pipeline runs for a few weeks now.  Seems to be fine :smile: