### PR TITLE
Adding is_10x_barcoded

### DIFF
--- a/lib/perl/Genome/Library.pm
+++ b/lib/perl/Genome/Library.pm
@@ -166,6 +166,14 @@ sub is_10x_atac {
     return 0;
 }
 
+sub is_10x_barcoded {
+    my $self = shift;
+
+    return 1 if $self->protocol =~ /^10x.*featurebarcod/i;
+
+    return 0;
+}
+
 sub is_10x_gex {
     my $self = shift;
 

--- a/lib/perl/Genome/Library.t
+++ b/lib/perl/Genome/Library.t
@@ -61,7 +61,7 @@ subtest 'is_rna' => sub{
 };
 
 subtest 'is_10x' => sub{
-    plan tests => 4;
+    plan tests => 7;
 
     $library->protocol('karate chop');
     is($library->is_10x_gex, 0, 'is NOT 10x_gex when protocol is karate chop');
@@ -75,6 +75,12 @@ subtest 'is_10x' => sub{
     $library->protocol("10x_SC_ATAC_SEQ");
     is($library->is_10x_atac, 1, "is 10x_atac when protocol is 10x_SC_ATAC_SEQ");
 
+    $library->protocol("10x_3'_FeatureBarcoding");
+    is($library->is_10x_barcoded, 1, "is 10x_barcoded when protocol is 10x_3'_FeatureBarcoding");
+
+    $library->protocol("10x_SC-3'GEX V3_FeatureBarcoded");
+    is($library->is_10x_barcoded, 1, "is 10x_barcoded when protocol is 10x_SC-3'GEX V3_FeatureBarcoded");
+    is($library->is_10x_gex, 1, "is 10x_gex when protocol is 10x_SC-3'GEX V3_FeatureBarcoded");
 };
 
 done_testing();


### PR DESCRIPTION
For analyzing feature barcoded single cell samples you need 2 libraries. first is the feature barcoded library, second is the feature barcoded gene expression library.

Previous analysis configuration files used `is_10x_gex -> 0` to get the feature barcoded gene expression instrument data and the feature barcoded instrument data in a single genome model. This was possible because the protocol for the feature barcoded gene expression instrument data added `FeatureBarcoded` to the end of the normal `10x_SC-5'GEX` or 3' gene expression protocol name.

The new 10x_gex regexes are now matching the feature barcoding gene expression instrument data. This is fine for the gene expression only analysis but causing issues for the feature barcoding analysis. The feature barcoding models are created with only the feature barcoded libraries and no gene expression libraries. These models cannot get a successful build.

This PR is adding `is_10x_barcoded` to help solve this problem. I should have created this earlier but the previous method was working fine. 

Currently these are the feature barcoded gene expression libraies:
```
10x_SC-3'GEX V3_FeatureBarcoded
10x_SC-5'GEX_FeatureBarcoded
```
These are the feature barocded libraries:
```
10x_3'_FeatureBarcoding
10x_5'_FeatureBarcoding
```
I've tested that these protocol names match the regex in this PR.

Once this is merged the 10x gex menu items should be updated to include `is_10x_barcoded -> 0` in the rules. 
