### PR TITLE
CWLPipeline: Accept WDL and custom mount paths

### DIFF
--- a/etc/genome/spec/docker_volumes.yaml
+++ b/etc/genome/spec/docker_volumes.yaml
@@ -1,0 +1,4 @@
+# Specify addtional volumes to mount when running docker
+---
+env: XGENOME_DOCKER_VOLUMES
+default_value: ''

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -344,7 +344,7 @@ sub _stage_cromwell_outputs {
     my $prefix = $self->_determine_output_prefix;
     for my $output_name (keys %$outputs) {
         my $info = $outputs->{$output_name};
-        
+
         $self->_stage_cromwell_output($results_dir, $info, $prefix);
     }
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -24,7 +24,7 @@ class Genome::Model::CwlPipeline::Command::Run {
             value => Genome::Config::get('lsf_resource_cwl_runner'),
         },
     ],
-    doc => 'wrapper command to run "cwltoil"'
+    doc => 'wrapper command to run the workflow for a build'
 };
 
 sub sub_command_category { 'pipeline steps' }

--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -21,6 +21,7 @@ sub run {
     }
 
     local $ENV{LSB_SUB_ADDITIONAL} = Genome::Config::get('lsb_sub_additional') || $ENV{LSB_SUB_ADDITIONAL};
+    local $ENV{LSF_DOCKER_VOLUMES} = Genome::Config::get('docker_volumes') || $ENV{LSF_DOCKER_VOLUMES};
 
     my @output = Genome::Sys->capture(@$executable, @args);
 


### PR DESCRIPTION
* Cromwell can run WDLs, so if someone tries to give us one, try to run it.
* In the "string" version of pipelines, we don't localize references and instead assume they're mounted in a standard location.  Now there's a config variable to help mount that standard location.  (This isn't strictly required for the File version of workflows to work, but we like avoiding copies!)