### PR TITLE
preserve "build" prefix on build directory name

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Export.pm
+++ b/lib/perl/Genome/Model/Build/Command/Export.pm
@@ -132,7 +132,7 @@ sub check_available_space {
 
 sub export_directory {
     my $self = shift;
-    return File::Spec->join($self->target_export_directory, $self->build->id);
+    return File::Spec->join($self->target_export_directory, "build" . $self->build->id);
 }
 
 1;


### PR DESCRIPTION
the rest of gms uses a "build" prefix, this should too, for consistency (especially during storage1 migration)