### PR TITLE
Support supplying input classes directly in CwlPipeline commands

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.pm
@@ -1,5 +1,10 @@
 package Genome::Model::CwlPipeline::Command::Input::Add;
 
+use strict;
+use warnings;
+
+use Genome;
+
 class Genome::Model::CwlPipeline::Command::Input::Add {
     is => 'Command::V2',
     has_input => [

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.pm
@@ -25,6 +25,11 @@ class Genome::Model::CwlPipeline::Command::Input::Add {
             doc => 'value(s) to set as input(s)',
             shell_args_position => 3,
         },
+        value_class_name => {
+            is => 'Text',
+            doc => 'If set, the "value(s)" will be treated as IDs for objects of this class--resolution will be skipped',
+            is_optional => 1,
+        },
     ],
     doc => 'add inputs to the model',
 };
@@ -41,9 +46,22 @@ sub execute {
     my $self = shift;
 
     for my $m ($self->model) {
-        $m->process_input_data(
-            $self->name, [$self->value]
-        );
+        if (my $value_class_name = $self->value_class_name) {
+
+            my @values = $value_class_name->get([$self->value]);
+            for my $value (@values) {
+                Genome::Model::Input->create(
+                    model_id => $m->id,
+                    name => $self->name,
+                    value_id => $value->id,
+                    value_class_name => $value->class,
+                );
+            }
+        } else {
+            $m->process_input_data(
+                $self->name, [$self->value]
+            );
+        }
     }
 
     return 1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Add.t
@@ -10,7 +10,7 @@ BEGIN {
 use above 'Genome';
 use Genome::Test::Factory::InstrumentData::Solexa;
 
-use Test::More tests => 5;
+use Test::More tests => 9;
 
 my $class = 'Genome::Model::CwlPipeline::Command::Input::Add';
 use_ok($class);
@@ -34,3 +34,20 @@ ok($add_cmd->execute, 'executed command');
 my @inputs = $m->inputs;
 is(scalar(@inputs), 1, 'added an input');
 is($inputs[0]->value, $value, 'input has correct value');
+
+my $sample_value = $value->sample;
+
+my $add_cmd_manual = $class->create(
+    model => $m,
+    name => 'sample',
+    value => $sample_value->id,
+    value_class_name => $sample_value->class,
+);
+isa_ok($add_cmd_manual, $class, 'created manual command');
+
+ok($add_cmd_manual->execute, 'executed command');
+
+@inputs = $m->inputs;
+is(scalar(@inputs), 2, 'added second input');
+my ($s) = grep { $_->name eq 'sample' } @inputs;
+is($s->value, $sample_value, 'new input has correct value');

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.pm
@@ -1,5 +1,10 @@
 package Genome::Model::CwlPipeline::Command::Input::Remove;
 
+use strict;
+use warnings;
+
+use Genome;
+
 class Genome::Model::CwlPipeline::Command::Input::Remove {
     is => 'Command::V2',
     has_input => [

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Input/Remove.t
@@ -10,7 +10,7 @@ BEGIN {
 use above 'Genome';
 use Genome::Test::Factory::InstrumentData::Solexa;
 
-use Test::More tests => 6;
+use Test::More tests => 9;
 
 my $class = 'Genome::Model::CwlPipeline::Command::Input::Remove';
 use_ok($class);
@@ -46,3 +46,16 @@ ok($remove_cmd->execute, 'executed command');
 my @inputs = $m->inputs;
 is(scalar(@inputs), 1, 'removed one input');
 is($inputs[0]->value, $other_value, 'other input remains');
+
+my $remove_cmd_manual = $class->create(
+    model => $m,
+    name => 'instrument_data',
+    value => $other_value->id,
+    value_class_name => $other_value->class,
+);
+isa_ok($remove_cmd_manual, $class, 'created manual command');
+
+ok($remove_cmd_manual->execute, 'executed manual command');
+
+@inputs = $m->inputs;
+is(scalar(@inputs), 0, 'removed other input');


### PR DESCRIPTION
Sometimes someone might want to add a custom object input that isn't automatically resolved by the class.  Now there's a way to do so (as long as the object exists, anyway!)