### PR TITLE
adding tarball option to build export

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/Export.pm
+++ b/lib/perl/Genome/Model/Build/Command/Export.pm
@@ -117,7 +117,7 @@ sub execute {
 
     if($self->create_tarball){
         my $tarball = File::Spec->join($self->target_export_directory, "build" . $self->build->id . ".tar");   
-        my $rv = Genome::Sys->shellcmd(cmd => ["tar","-cf",$tarball,"-C",$tempdir,"build" . $self->build->id]);
+        my $rv = Genome::Sys->shellcmd(cmd => ["tar","-cf",$tarball,"-C",$tempdir,"build" . $self->build->id], output_files => [ $tarball ]);
         unless ($rv) {
             $self->fatal_message("Could not create tar file");
         }


### PR DESCRIPTION
Globus eats symlinks, so tarballs seem like a reasonable, if somewhat I/O inefficient way to transfer build directories.  It also simplifies verifying the transfer, since we can compare file sizes or md5s of the tarballs. (Globus does this internally as well, but "trust and verify"...)