### PR TITLE
Use the current interpreter rather than assuming genome-perl.

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -605,7 +605,7 @@ sub _execute_system_command {
         my $perl_program_string = join('; ', @statements);
 
         my @cmd = (
-            'genome-perl',
+            $^X,
             @includes,
             @_execute_system_command_perl5opt,
             '-e',


### PR DESCRIPTION
This usually doesn't matter at all, but if someone is trying to test different perl versions they'll be glad it's here :)