### PR TITLE
Support using file-based database for Cromwell workflows

### DIFF
--- a/lib/perl/Genome/Cromwell.pm
+++ b/lib/perl/Genome/Cromwell.pm
@@ -22,8 +22,8 @@ class Genome::Cromwell {
         },
         server_url => {
             is => 'Text',
-            is_constant => 1,
-            value => Genome::Config::get('cromwell_api_server'),
+            is_calculated => 1,
+            calculate => q{ Genome::Config::get('cromwell_api_server') },
         },
         user_agent => {
             is => 'LWP::UserAgent',

--- a/lib/perl/Genome/Cromwell.pm
+++ b/lib/perl/Genome/Cromwell.pm
@@ -45,7 +45,7 @@ sub outputs {
     my $self = $class->_singleton_object;
     my $url = $self->_request_url($workflow_id, 'outputs');
 
-    return $self->_make_request('GET', $url);
+    return $self->_make_json_request('GET', $url);
 }
 
 sub metadata {
@@ -56,7 +56,7 @@ sub metadata {
     my $url = $self->_request_url($workflow_id, 'metadata');
     $url .= '?excludeKey=submittedFiles&excludeKey=inputs&excludeKey=outputs&expandSubWorkflows=false';
 
-    return $self->_make_request('GET', $url);
+    return $self->_make_json_request('GET', $url);
 }
 
 sub query {
@@ -66,7 +66,18 @@ sub query {
     my $self = $class->_singleton_object;
     my $url = $self->_request_url('query');
 
-    return $self->_make_request('POST', $url, $query_options);
+    return $self->_make_json_request('POST', $url, $query_options);
+}
+
+sub timing {
+    my $class = shift;
+    my $workflow_id = shift;
+
+    my $self = $class->_singleton_object;
+    my $url = $self->_request_url($workflow_id, 'timing');
+
+    my $content = $self->_make_request('GET', $url);
+    return $content;
 }
 
 sub _request_url {
@@ -79,6 +90,13 @@ sub _request_url {
     $url .= join('/', 'api', 'workflows', $self->api_version, @parts);
 
     return $url;
+}
+
+sub _make_json_request {
+    my $class = shift;
+
+    my $content = $class->_make_request(@_);
+    return from_json($content);
 }
 
 sub _make_request {
@@ -111,8 +129,7 @@ sub _make_request {
             next ATTEMPT;
         }
 
-        my $content = $response->decoded_content;
-        return from_json($content);
+        return $response->decoded_content;
     }
 
     $self->fatal_message('Failed to query server after serveral attempts.');

--- a/lib/perl/Genome/Model/Build/Command/View.pm
+++ b/lib/perl/Genome/Model/Build/Command/View.pm
@@ -105,6 +105,11 @@ sub write_report {
             return 1;
         }
 
+        if ($build->status eq 'Running') {
+            $handle->say("\nCromwell build used local database. It is locked while build is running.");
+            return 1;
+        }
+
         my $config_file = File::Spec->join($build->data_directory, 'cromwell.config');
         $cromwell_server_guard = Genome::Cromwell->spawn_local_server($config_file);
     }

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -418,6 +418,8 @@ sub _stage_cromwell_outputs {
         $self->_stage_cromwell_output($results_dir, $info, $prefix);
     }
 
+    $self->_generate_timing_report($workflow_id);
+
     return 1;
 }
 
@@ -485,6 +487,19 @@ sub _stage_cromwell_output {
     }
 
     return 1;
+}
+
+sub _generate_timing_report {
+    my $self = shift;
+    my $workflow_id = shift;
+
+    my $data_dir = $self->build->data_directory;
+    my $timing_file = File::Spec->join($data_dir, 'timing.html');
+
+    my $report = Genome::Cromwell->timing($workflow_id);
+    Genome::Sys->write_file($timing_file, $report);
+
+    return $timing_file;
 }
 
 sub preserve_results {

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -159,16 +159,11 @@ sub run_cromwell {
     my $config_file = $self->_generate_cromwell_config($tmp_dir, $results_dir);
     my $labels_file = $self->_generate_cromwell_labels;
 
-    my $truststore_file = Genome::Config::get('cromwell_truststore_file');
-    my $truststore_auth = Genome::Config::get('cromwell_truststore_auth');
+    my @jar_cmdline = Genome::Cromwell->cromwell_jar_cmdline($config_file);
 
     Genome::Sys->shellcmd(
         cmd => [
-            '/usr/bin/java',
-            sprintf('-Dconfig.file=%s', $config_file),
-            sprintf('-Djavax.net.ssl.trustStorePassword=%s', $truststore_auth),
-            sprintf('-Djavax.net.ssl.trustStore=%s', $truststore_file),
-            '-jar', '/opt/cromwell.jar',
+            @jar_cmdline,
             'run',
             '-t', $wf_type,
             '-l', $labels_file,

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -347,8 +347,10 @@ EOCONFIG
             $self->debug_message('Using supplied hsqldb location: %s', $dbfile_location);
         }
 
-        my $note = $build->add_note(header_text => 'hsqldb_server_file', body_text => $dbfile_location);
-        $note->body_text($dbfile_location); #ignore any system-generated sudo message for this note.
+        #shell out so this is saved immediately for the benefit of `genome model build view` while this build runs.
+        Genome::Sys->shellcmd(
+            cmd => [qw(genome model build add-note --header-text=hsqldb_server_file), "--body-text=$dbfile_location", $build->id],
+        );
 
         $config .= <<EOCONFIG
 database {

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -173,6 +173,7 @@ sub run_cromwell {
         input_files => [$main_workflow_file, $yaml],
     );
 
+    my $guard = Genome::Cromwell->spawn_local_server($config_file);
     $self->_stage_cromwell_outputs($results_dir);
 }
 


### PR DESCRIPTION
* Instead of using a MySQL database, can specify to use a local disk-backed database:
  * `hsqldb:tmp`: to use a database in the build's scratch directory that will be cleaned up.
  * `hsqldb:build`: to use a database retained in the build's data directory.
  * `hsqldb:file:/path/`: to use a database in a specified location.
* The timing report from Cromwell will now be saved after a workflow completes.  This is stored as `timing.html` in the build data directory.
* When using the local disk-backed database, the workflow view is often unavailable.  (It might be possible to write our own viewer that opens the database read-only, but Cromwell itself can't deal with a read-only database.)
* `Genome::Cromwell` now tries performing Cromwell API queries up to five times.  In practice I've never seen this come up, but it's more similar to how the PTero workflow viewer behaved.
* No call caching yet, but this PR lays the groundwork to implement build `restart` for Cromwell-backed builds.
