### PR TITLE
Support setting an LSF user_group.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -208,6 +208,7 @@ sub _generate_cromwell_config {
         Genome::Sys->username,
         'workers'
     );
+    my $user_group = Genome::Config::get('lsf_user_group');
 
     my $server = Genome::Config::get('cromwell_server');
     my $auth = Genome::Config::get('cromwell_auth');
@@ -255,6 +256,7 @@ EOCONFIG
         -a '$primary_docker_image' \\
         -q '$default_queue' \\
         -g '$job_group' \\
+        -G '$user_group' \\
 EOCONFIG
         ;
     $config .= <<'EOCONFIG'
@@ -288,6 +290,7 @@ EOCONFIG
         -e $log_dir/cromwell-%J.err \\
         -q '$default_queue' \\
         -g '$job_group' \\
+        -G '$user_group' \\
 EOCONFIG
         ;
     $config .= <<'EOCONFIG'

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -251,6 +251,7 @@ sub _dispatch_process {
         log_file => "${log_file_base}.out",
         project => $self->lsf_project_name,
         job_group => $job_group,
+        user_group => Genome::Config::get('lsf_user_group'),
         resource_string => Genome::Config::get('lsf_resource_cwl_runner'),
     );
 

--- a/lib/perl/Genome/Site/TGI/Command/ImportDataFromLims.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportDataFromLims.pm
@@ -133,6 +133,7 @@ sub _resolve_lims_path {
     Genome::Sys->bsub_and_wait(
         cmd => $cmd,
         queue => Genome::Config::get('lsf_queue_build_worker'),
+        user_group => Genome::Config::get('lsf_user_group'),
         log_file => $log_file,
     );
 

--- a/lib/perl/Genome/Sys/LSF/ResourceParser.pm
+++ b/lib/perl/Genome/Sys/LSF/ResourceParser.pm
@@ -7,7 +7,7 @@ require Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(parse_lsf_params parse_resource_requirements);
 
-use Getopt::Long qw(GetOptionsFromString);
+use Getopt::Long qw(GetOptionsFromString :config no_ignore_case);
 use IO::String;
 
 sub parse_resource_requirements {
@@ -137,6 +137,7 @@ my %formatters = (
     'b' => \&string_formatter,
     'e' => \&string_formatter,
     'g' => \&string_formatter,
+    'G' => \&string_formatter,
     'i' => \&string_formatter,
     'J' => \&string_formatter,
     'u' => \&string_formatter,
@@ -163,6 +164,7 @@ my %valid_options = (
     'b' => 'beginTime',
     'e' => 'errFile',
     'g' => 'jobGroup',
+    'G' => 'userGroup',
     'i' => 'inFile',
     'J' => 'jobName',
     'u' => 'mail_user',

--- a/lib/perl/Genome/Sys/LSF/ResourceParser.t
+++ b/lib/perl/Genome/Sys/LSF/ResourceParser.t
@@ -324,10 +324,12 @@ parse_ok("-q short -R 'rusage[tmp=100]'", {
         'rLimits' => {}
 
     });
-parse_ok("-q long -R 'rusage[tmp=100]'", {
+parse_ok("-g /genome/test -G compute-test -q long -R 'rusage[tmp=100]'", {
         'options' => {
             'queue' => 'long',
-            'resReq' => 'rusage[tmp=100]'
+            'resReq' => 'rusage[tmp=100]',
+            'jobGroup' => '/genome/test',
+            'userGroup' => 'compute-test',
         },
         'rLimits' => {}
     });

--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -146,6 +146,11 @@ sub _args_spec {
             option_flag => '-g',
             type => SCALAR,
         },
+        user_group => {
+            optional => 1,
+            option_flag => '-G',
+            type => SCALAR,
+        },
         job_name => {
             optional => 1,
             option_flag => '-J',

--- a/lib/perl/Genome/Sys/LSF/bsub.t
+++ b/lib/perl/Genome/Sys/LSF/bsub.t
@@ -6,7 +6,7 @@ use Test::Builder;
 use Test::Fatal qw(exception);
 use Genome::Sys::LSF::bsub qw();
 
-plan tests => 11;
+plan tests => 12;
 
 my $fake_queue = 'fake_queue';
 my @queues = (map { Genome::Config::get($_) } qw(lsf_queue_build_worker lsf_queue_short));
@@ -70,6 +70,13 @@ my @cases = (
             resource_string => '-R "select[mem>9876] rusage[mem=9753] span[hosts=1]" -M 10000000 -n 4',
             cmd => 'true',
         ], ['-R', 'select[mem>9876] rusage[mem=9753] span[hosts=1]','-n', 4,  '-M', '10000000', 'true'], 'parsed resource request',
+    ],
+    [
+        [
+            job_group => '/genome/test',
+            user_group => 'compute-test',
+            cmd => 'true',
+        ], [qw(-g /genome/test -G compute-test true)], 'job and user groups',
     ]
 );
 for my $case (@cases) {


### PR DESCRIPTION
* The new compute cluster we're using requires this.  (Since this PR requires setting a value: for the old cluster a group such as `research-hpc/` will suffice.)
* In the new cluster, the correct value should be added to the AnP config (e.g., `lsf_user_group: compute-awesome`).  This is the compute group that will be charged when builds are run.  For the old cluster an appropriate default will be set in the production configuration.