### PR TITLE
Don't assume mount_path structure.

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -966,8 +966,16 @@ END {
 sub get_allocation_for_path {
     my ($class, $path) = @_;
 
+    #If we found this assume we have an absolute path; if we don't, assume we got an allocation path.
+    my $mount_path = $class->_get_mount_path_from_full_path($path);
+    if ($mount_path) {
+        $path =~ s/^$mount_path//;
+    }
+
+    $path =~ s!^/!!; #either this is left over from the mount path, or it might be present on an allocation path passed directly. Either way, we don't want it!
     my @parts = split(/\//, $path);
-    @parts = @parts[4..$#parts]; # Remove mount path and group subdirectory
+
+    shift @parts if $mount_path; #remove group subdirectory from absolute path
 
     my $allocation;
     # Try finding allocation by allocation path, removing subdirectories from the end after each attempt

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -753,9 +753,7 @@ sub symlinked_allocations {
         my %allocations;
         for my $symlink ( keys %symlinks ) {
             my $target = $symlinks{$symlink};
-            my @tokens = split(m#/+#, $target);
-            my $allocation_path = join('/', @tokens[4..$#tokens]);
-            my @allocations = Genome::Disk::Allocation->get(allocation_path => $allocation_path);
+            my @allocations = Genome::Disk::Allocation->get_allocation_for_path($target);
             next if not @allocations or @allocations > 1;
             my $allocation = $allocations[0];
             next if $allocations{$allocation->id};

--- a/lib/perl/Genome/Model/Command/Admin/FixOrphanedAllocationsForDv2Results.pm
+++ b/lib/perl/Genome/Model/Command/Admin/FixOrphanedAllocationsForDv2Results.pm
@@ -47,9 +47,7 @@ sub execute {
 
         for my $s (@symlinks) {
             my $t = readlink $s;
-            my @d = File::Spec->splitdir($t);
-            my $p = File::Spec->catdir(@d[4..$#d]);
-            my $a = Genome::Disk::Allocation->get(allocation_path => $p);
+            my $a = Genome::Disk::Allocation->get_allocation_for_path($t);
 
             next unless $a && $a->owner_class_name->isa('Genome::Model::Tools::DetectVariants2::Result::Base');
 


### PR DESCRIPTION
There were a few places in the code base that made strong assumptions about how many `/`s appear in an allocation `mount_path`.  That's gotten us by in the past, but isn't really ideal.  Now that more volumes are going to violate this assumption, let's patch up the code to handle the variety of possibilities!

This patch disclaims responsibility for the choice of using `$a` as a variable in the orphaned allocation finder. :smile: 