### PR TITLE
Have ris.wustl.edu domains use the "TGI" site, too.

### DIFF
--- a/lib/perl/Genome/Site/edu/wustl/ris.pm
+++ b/lib/perl/Genome/Site/edu/wustl/ris.pm
@@ -1,0 +1,16 @@
+package Genome::Site::edu::wustl::ris;
+use Genome::Site::TGI;
+1;
+
+=pod
+
+=head1 NAME
+
+Genome::Config::edu::wustl::ris - WU TGI host configuration
+
+=head1 SYNOPSIS
+
+Ensures that Genome::Site::TGI is used by all *.ris.wustl.edu hosts
+
+=cut
+


### PR DESCRIPTION
Maybe at some point we'll split these up since they represent two different clusters.  It might even be a good opportunity to pull things from TGI that really belong in the main classes!  But for now, the two clusters are similar enough...

(See also, the existing `Genome::Site::edu::wustl::gsc` module.)