### PR TITLE
Pass the inputs along to the outputs in Block operation.

### DIFF
--- a/lib/perl/Genome/WorkflowBuilder/Block.pm
+++ b/lib/perl/Genome/WorkflowBuilder/Block.pm
@@ -61,7 +61,9 @@ sub _add_property_xml_elements {
 sub _execute_inline {
     my ($self, $inputs) = @_;
 
-    return {result => 1};
+    my $outputs = { result => 1, %$inputs };
+
+    return $outputs;
 }
 
 1;


### PR DESCRIPTION
Someone is running `ReferenceAlignment` builds even though we shut down PTero.  The inline `WorkflowBuilder` logic almost worked, but the final step failed because the preceding block operation didn't pass along some required information.  This fills in the implementation of blocks to pass along their inputs.