### PR TITLE
Make `docker_volumes` config additive to the existing environment.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -211,6 +211,14 @@ sub _generate_cromwell_config {
     my $user = Genome::Config::get('cromwell_user');
 
     my $docker_volumes = Genome::Config::get('docker_volumes');
+    if ($ENV{LSF_DOCKER_VOLUMES}) {
+        if ($docker_volumes) {
+            $docker_volumes .= $ENV{LSF_DOCKER_VOLUMES} . ' ' . $docker_volumes;
+        } else {
+            $docker_volumes = $ENV{LSF_DOCKER_VOLUMES};
+        }
+    }
+
 
     my $data_dir = $build->data_directory;
     my $config_file = File::Spec->join($data_dir,'cromwell.config');

--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -21,7 +21,16 @@ sub run {
     }
 
     local $ENV{LSB_SUB_ADDITIONAL} = Genome::Config::get('lsb_sub_additional') || $ENV{LSB_SUB_ADDITIONAL};
-    local $ENV{LSF_DOCKER_VOLUMES} = Genome::Config::get('docker_volumes') || $ENV{LSF_DOCKER_VOLUMES};
+
+    my $docker_volumes = $ENV{LSF_DOCKER_VOLUMES};
+    if (my $config_docker_volumes = Genome::Config::get('docker_volumes')) {
+        if ($docker_volumes) {
+            $docker_volumes .= ' ' . $config_docker_volumes;
+        } else {
+            $docker_volumes = $config_docker_volumes;
+        }
+    }
+    local $ENV{LSF_DOCKER_VOLUMES} = $docker_volumes;
 
     my @output = Genome::Sys->capture(@$executable, @args);
 


### PR DESCRIPTION
The environment will have been set up with necessary mounts to get things started (e.g., via `gsub` or the BQM cron).  We'll need to keep those along in addition to whatever project-specific mounts someone chooses to add.