### PR TITLE
Use UUID generator for creating disk groups.

### DIFF
--- a/lib/perl/Genome/Disk/Assignment.pm
+++ b/lib/perl/Genome/Disk/Assignment.pm
@@ -7,11 +7,11 @@ class Genome::Disk::Assignment {
     table_name => 'disk.volume_group_bridge',
     id_by => [
         group_id => {
-            is => 'Number',
+            is => 'Text',
             doc => 'disk group ID',
         },
         volume_id => {
-            is => 'Number',
+            is => 'Text',
             doc => 'disk volume ID'
         },
     ],

--- a/lib/perl/Genome/Disk/Group.pm
+++ b/lib/perl/Genome/Disk/Group.pm
@@ -12,8 +12,9 @@ usesub Genome::Disk::Group::Validate;
 
 class Genome::Disk::Group {
     table_name => 'disk.group',
+    id_generator => '-uuid',
     id_by => [
-        id => { is => 'Number' },
+        id => { is => 'Text', len => 32 },
     ],
     has => [
         disk_group_name => { via => '__self__', to => 'name' },


### PR DESCRIPTION
We've heretofore been importing them from an external canonical source that determines their IDs, but now we need to be able to make them directly.