### PR TITLE
Remove extra layer of method calls.

### DIFF
--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -165,13 +165,6 @@ sub get_candidate_volumes {
 
 sub _get_allocation_without_lock {
     my ($self, $candidate_volumes) = @_;
-
-    my $allocation_object = $self->_get_allocation_without_lock_impl($candidate_volumes);
-    return $allocation_object;
-}
-
-sub _get_allocation_without_lock_impl {
-    my ($self, $candidate_volumes) = @_;
     # We randomize to avoid the rare repeated contention case
     my @randomized_candidate_volumes = (@$candidate_volumes,
         shuffle(@$candidate_volumes));


### PR DESCRIPTION
In 461d694dae993e839e8fee2dd77c7eb6a3b2533a we removed instrumentation, which left the outer call here as a mostly pointless wrapper.  So now let's just consolidate them.