### PR TITLE
For now, don't try to `df` remote volumes.

### DIFF
--- a/lib/perl/Genome/Disk/Command/Volume/List.pm
+++ b/lib/perl/Genome/Disk/Command/Volume/List.pm
@@ -61,16 +61,16 @@ sub is_volume_mounted {
         _populate_cached_is_mounted();
     }
 
-    my $mount_path = $volume->mount_path;
+    my $path = $volume->is_remote_volume ? $volume->physical_path : $volume->mount_path;
 
-    if (! exists($cached_is_mounted{$mount_path}) && $self->accurate_size) {
-        my $dir = IO::Dir->new($mount_path);
+    if (! exists($cached_is_mounted{$path}) && $self->accurate_size) {
+        my $dir = IO::Dir->new($path);
         $dir->read if $dir;
         _populate_cached_is_mounted();
-        $cached_is_mounted{$mount_path} //= 0;
+        $cached_is_mounted{$path} //= 0;
     }
 
-    return $cached_is_mounted{$volume->mount_path}
+    return $cached_is_mounted{$path}
 }
 
 sub _populate_cached_is_mounted {


### PR DESCRIPTION
For volumes that are mounted via a cache layer, df doesn't work properly (among other non-compliant aspects of the filesystem).  In our case we could possibly use SMB to connect to the remote server and find out the canonical used and total KB, but for now let's trust our database to be accurate.

Some notes: 
* The `hostname` should be properly filled out for these remote volumes--right now we're only checking for the hostname to have a `.` in it to decide it's from a remote server.
* For volumes that point to directories within remote volumes, the physical path must be set to the actual volume. (e.g., for a `mount_path` of `/storage/fs/foobar/VOLUME/subpath/for/genome` the `physical_path` is still `/storage/fs/foobar/VOLUME`)
* This does mean that a user can set a separate soft quota for GMS data.  As an advisory system, it's of course possible to exceed this quota... but new allocations would not be created upon reaching the limit.