### PR TITLE
Cromwell Call Caching support

### DIFF
--- a/etc/genome/spec/cromwell_call_caching.yaml
+++ b/etc/genome/spec/cromwell_call_caching.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_CROMWELL_CALL_CACHING
+default_value: 0

--- a/lib/perl/Genome/Model/Build/Command/View.pm
+++ b/lib/perl/Genome/Model/Build/Command/View.pm
@@ -116,8 +116,11 @@ sub write_report {
         }
 
 
-        if (my $cromwell_wf = $self->_cromwell_workflow_id_for_build) {
-            $self->_display_cromwell_workflow($handle, $cromwell_wf);
+        my @cromwell_wf = $self->_cromwell_workflow_id_for_build;
+        if (@cromwell_wf) {
+            for my $wf (@cromwell_wf) {
+                $self->_display_cromwell_workflow($handle, $wf);
+            }
         } else {
             my @process = $self->build->process;
 
@@ -138,12 +141,12 @@ sub _cromwell_workflow_id_for_build {
     my $self = shift;
 
     my $results = Genome::Cromwell->query( [{ label => 'build:' . $self->build->id }] );
-    if ($results->{totalResultsCount} != 1) {
+    if ($results->{totalResultsCount} < 1) {
         $self->debug_message('Did not find cromwell workflow.');
         return;
     }
 
-    return $results->{results}->[0]->{id};
+    return map { $_->{id} } @{ $results->{results} };
 }
 
 sub _display_build {

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -314,6 +314,27 @@ EOCONFIG
 ;
     $config .= <<EOCONFIG
         root = "$tmp_dir/cromwell-executions"
+EOCONFIG
+;
+    if(Genome::Config::get('cromwell_call_caching')) {
+        $config .= <<'EOCONFIG'
+        filesysytems {
+          local {
+            caching {
+              duplication-strategy: [
+                "hard-link", "soft-link", "copy"
+              ]
+              hashing-strategy: "fingerprint"
+              fingerprint-size: 10485760
+              check-sibling-md5: false
+            }
+          }
+        }
+EOCONFIG
+;
+    }
+
+    $config .= <<EOCONFIG
       }
     }
   }
@@ -386,6 +407,16 @@ EOCONFIG
 ;
     } else {
         $self->fatal_message('Expected mysql or hsqldb cromwell server url but got: %s', $server);
+    }
+
+    if (Genome::Config::get('cromwell_call_caching')) {
+        $config .= <<EOCONFIG
+call-caching {
+  enabled = true
+  invalidate-bad-cache-results = true
+}
+EOCONFIG
+;
     }
 
     Genome::Sys->write_file($config_file, $config);

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -324,7 +324,7 @@ EOCONFIG
               duplication-strategy: [
                 "hard-link", "soft-link", "copy"
               ]
-              hashing-strategy: "fingerprint"
+              hashing-strategy: "xxh64"
               fingerprint-size: 10485760
               check-sibling-md5: false
             }

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -191,8 +191,12 @@ sub _determine_workflow_type {
 sub _generate_cromwell_config {
     my $self = shift;
     my $tmp_dir = shift;
-
     my $build = $self->build;
+
+    my $data_dir = $build->data_directory;
+    my $config_file = File::Spec->join($data_dir,'cromwell.config');
+    return $config_file if -e $config_file;
+
     my $log_dir = $build->log_directory;
 
     my $primary_docker_image = $build->model->primary_docker_image;
@@ -218,10 +222,6 @@ sub _generate_cromwell_config {
             $docker_volumes = $ENV{LSF_DOCKER_VOLUMES};
         }
     }
-
-
-    my $data_dir = $build->data_directory;
-    my $config_file = File::Spec->join($data_dir,'cromwell.config');
 
     my $config = <<'EOCONFIG'
 include required(classpath("application"))
@@ -428,6 +428,8 @@ sub _generate_cromwell_labels {
     my $build = $self->build;
 
     my $labels_file = File::Spec->join($build->data_directory, 'cromwell.labels');
+
+    return $labels_file if -e $labels_file;
 
     my $data = {
         build => $build->id,

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -447,9 +447,9 @@ sub _stage_cromwell_outputs {
 
     my $build = $self->build;
 
-    my $results = Genome::Cromwell->query( [{ label => 'build:' . $build->id }] );
+    my $results = Genome::Cromwell->query( [{ label => 'build:' . $build->id, status => 'Succeeded' }] );
     if ($results->{totalResultsCount} != 1) {
-        $self->fatal_message('Failed to find workflow.  Got: %s', scalar(Data::Dumper::dumper($results)));
+        $self->fatal_message('Failed to find workflow.  Got: %s', scalar(Data::Dumper::Dumper($results)));
     }
 
     my $workflow_id = $results->{results}->[0]->{id};


### PR DESCRIPTION
Add an option to enable call caching and take some steps to make the `restart` command work with Cromwell-based CwlPipeline builds.

There are some potential issues with display of and/or output retrieval under this scheme explained in the commit text for 009bddcc18c296f10f8aba75123644b3fffe6079.