### PR TITLE
Allow imported BAMs with arbitrary filenames

### DIFF
--- a/lib/perl/Genome/InstrumentData/Imported.pm
+++ b/lib/perl/Genome/InstrumentData/Imported.pm
@@ -422,9 +422,16 @@ sub bam_path {
 
     my $bam_file = $allocation->absolute_path . "/all_sequences.bam";
 
-    return if not -e $bam_file;
+    return $bam_file if -e $bam_file;
 
-    return $bam_file;
+    my @possible_bams = glob($allocation->absolute_path . "/*.bam");
+    if (@possible_bams == 1) {
+        return $possible_bams[0];
+    } elsif (@possible_bams > 1) {
+        $self->fatal_message('Multiple BAMs found in allocation for imported instrument data: %s.  Name one "all_sequences.bam" to have it used here.', $self->__display_name__);
+    }
+
+    return; #some other format besides BAM (e.g., FASTQs)
 }
 
 sub get_read_groups_set {

--- a/lib/perl/Genome/InstrumentData/Imported.pm
+++ b/lib/perl/Genome/InstrumentData/Imported.pm
@@ -417,8 +417,7 @@ sub bam_path {
 
     my ($allocation) = $self->disk_allocation;
     unless ($allocation) {
-        $self->error_message("Found no disk allocation for imported instrument data " . $self->id, ", so cannot find bam!");
-        die $self->error_message;
+        $self->fatal_message("Found no disk allocation for imported instrument data %s, so cannot find bam!", $self->__display_name__);
     }
 
     my $bam_file = $allocation->absolute_path . "/all_sequences.bam";


### PR DESCRIPTION
We heretofore have expected `all_sequences.bam` to be the name for all imported BAMs.  The new `trusted-data` importer makes it easier to not follow this convention.  As long as there's only one BAM in the directory, we should be fine to move along using it.

(Plus a bonus bugfix in an existing error message!)