### PR TITLE
`test-tracker` in `--track` mode requires tests to return a true value in order to pass.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/ListDockerImages.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/ListDockerImages.t
@@ -41,3 +41,5 @@ SKIP: {
     ok(scalar(@image_lines) > 0, 'theoretically included some docker images');
 }
 
+#test-tracker wants all tests to return a true value, (but "skip" returns undef)
+1;


### PR DESCRIPTION
`skip` returns `undef`, so we'll add our own true value!

(This will pass the PR tests (as it did before), because they don't use `--track` mode.  The real proof will only come after it's merged.)