### PR TITLE
Remove modifications of pre-provided LSF temp directory.

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -618,14 +618,6 @@ sub base_temp_directory {
         my $lsf_possible_tempdir = sprintf("%s/%s.tmpdir", $tmp_location, $ENV{'LSB_JOBID'});
         if (-d $lsf_possible_tempdir) {
             $tmp_location = $lsf_possible_tempdir;
-
-            #open up the temporary directory to those with data access for easier debugging
-            my $gid = gidgrnam(Genome::Config::get('sys_group'));
-            set_gid($gid, $tmp_location);
-            my $mode = mode($tmp_location);
-            $mode->add_group_readable;
-            $mode->add_group_executable;
-            $mode->rm_other_rwx;
         }
     }
     # tempdir() thows its own exception if there's a problem


### PR DESCRIPTION
On the new cluster this directory is locked down so we lack permissions to change it.