### PR TITLE
Stop hardcoding "apipe-builder" when determining applicable models

### DIFF
--- a/lib/perl/Genome/Project/Command/Update/Models.pm
+++ b/lib/perl/Genome/Project/Command/Update/Models.pm
@@ -22,13 +22,6 @@ class Genome::Project::Command::Update::Models {
             doc => 'match models to the project based on these values',
         },
     ],
-    has_constant => {
-        model_user => {
-            is => 'Text',
-            doc => 'user whose models to add to the project',
-            value => 'apipe-builder',
-        },
-    },
     doc => 'add models to a project that have matching instrument data or samples',
 };
 
@@ -46,7 +39,7 @@ sub execute {
 
         my $model_getter = '_models_for_' . $self->match_type;
         my @models =
-            grep { $_->created_by eq $self->model_user or $_->run_as eq $self->model_user }
+            grep { Genome::Sys->user_has_role($_->created_by, 'production') or Genome::Sys->user_has_role($_->run_as, 'production') }
             $self->$model_getter(@parts);
 
         my @new_parts =

--- a/lib/perl/Genome/Project/Command/Update/Models.t
+++ b/lib/perl/Genome/Project/Command/Update/Models.t
@@ -20,11 +20,19 @@ use_ok('Genome::Project::Command::Update::Models') or die;
 my $project = Genome::Project->create(name => 'test project for ' . __FILE__);
 isa_ok($project, 'Genome::Project', 'created test project');
 
+my $user = Genome::Sys::User->__define__(email => 'testingaccount@example.com', username => ('testing' . time));
+my $role = Genome::Sys::User::Role->get(name => 'production') || Genome::Sys::User::Role->__define__(name => 'production');
+
+Genome::Sys::User::RoleMember->__define__(
+    user_email => $user->email,
+    role_id  => $role->id,
+);
+
 my @models;
 my @instrument_data;
 for(1..3) {
     my $m = Genome::Test::Factory::Model::ReferenceAlignment->setup_object(
-        created_by => 'apipe-builder', # matches default in Genome::Project::Command::Update::Models::model_user
+        created_by => $user->username,
     );
     my $i = Genome::Test::Factory::InstrumentData::Solexa->setup_object();
     $m->add_instrument_data($i);


### PR DESCRIPTION
We've locally been using a different production user for many years, so it'd be nice if this worked again!