### PR TITLE
Use explicit units for memory reservations (LSF10 feature).

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -234,7 +234,6 @@ backend {
       config {
         runtime-attributes = """
         Int cpu = 1
-        Int memory_kb = 4096000
         Int memory_mb = 4096
         String? docker
         """
@@ -265,9 +264,9 @@ EOCONFIG
 EOCONFIG
         ;
     $config .= <<'EOCONFIG'
-        -M ${memory_kb} \
+        -M ${memory_mb}M \
         -n ${cpu} \
-        -R "span[hosts=1] select[mem>${memory_mb}] rusage[mem=${memory_mb}]" \
+        -R "span[hosts=1] select[mem>${memory_mb}M] rusage[mem=${memory_mb}M]" \
         /bin/bash ${script}
         """
 
@@ -300,9 +299,9 @@ EOCONFIG
         ;
     $config .= <<'EOCONFIG'
         -a "docker(${docker})" \
-        -M ${memory_kb} \
+        -M ${memory_mb}M \
         -n ${cpu} \
-        -R "span[hosts=1] select[mem>${memory_mb}] rusage[mem=${memory_mb}]" \
+        -R "span[hosts=1] select[mem>${memory_mb}M] rusage[mem=${memory_mb}M]" \
         /bin/bash ${script}
         """
 


### PR DESCRIPTION
The historic default for units in LSF `bsub`s are confusing (and depending on cluster configuration may be differently inconsistent). Now it's possible to specify a unit suffix, so let's set it to the same precision as CWL affords.

[Marking this as a draft PR because we can't merge it so long as we need to support older clusters.  But it's a change we likely want to patch in on new enough versions.]