### PR TITLE
New command to help identify which volumes to mount.

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/PossibleVolumes.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/PossibleVolumes.pm
@@ -1,0 +1,41 @@
+package Genome::Config::AnalysisProject::Command::PossibleVolumes;
+
+use strict;
+use warnings;
+
+use feature qw(say);
+
+use Genome;
+
+class Genome::Config::AnalysisProject::Command::PossibleVolumes {
+    is => 'Genome::Config::AnalysisProject::Command::Base',
+};
+
+sub help_brief {
+    return 'output the possible mount paths for the disk groups in the environment config';
+}
+
+sub help_detail {
+    return <<EOS
+This command is used to list all the possible volume mount paths that might be used for an analysis-project based on its environment configuration.  This forms the set of volumes that should be mounted inside any containers that need to do work for the analysis-project.
+EOS
+}
+
+sub valid_statuses {
+    return ('Pending', 'In Progress', 'Hold');
+}
+
+sub execute {
+    my $self = shift;
+
+    my $guard = $self->analysis_project->set_env;
+
+    my @group_names = map { Genome::Config::get($_) } (qw(disk_group_models disk_group_alignments disk_group_scratch));
+    my @volumes = Genome::Disk::Volume->get(disk_group_names => \@group_names);
+
+    for my $v (sort { $a->mount_path cmp $b->mount_path } @volumes) {
+        say $v->mount_path;
+    }
+
+    return 1;
+}

--- a/lib/perl/Genome/Config/AnalysisProject/Command/PossibleVolumes.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/PossibleVolumes.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use Test::More tests => 2;
+
+use above 'Genome';
+
+use Genome::Test::Factory::AnalysisProject;
+
+my $class = 'Genome::Config::AnalysisProject::Command::PossibleVolumes';
+
+use_ok($class);
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object;
+
+my $cmd = $class->create(analysis_project => $anp);
+
+isa_ok($cmd, $class, 'created command');
+
+


### PR DESCRIPTION
This command lists the possible volumes configured for an AnP.  This could be used for a safe list of volumes to mount when launching a container to work with the AnP.

After this and #1988 we'll have the building blocks to possibly support BQM launching remote builds.