### PR TITLE
Make the "prod-builder" run_as configurable.

### DIFF
--- a/etc/genome/spec/builder_run_as_user.yaml
+++ b/etc/genome/spec/builder_run_as_user.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_BUILDER_RUN_AS_USER
+default_value: prod-builder

--- a/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/Create.pm
@@ -101,7 +101,7 @@ sub _resolve_properties_for_environment {
         }
         when ('prod-builder') {
             return (
-                run_as => 'prod-builder',
+                run_as => Genome::Config::get('builder_run_as_user'),
                 is_cle => 0,
             );
         }


### PR DESCRIPTION
Now that we're operating on multiple clusters we've run into a situation where it'd be nice to distinguish between then with different "run_as" indications.  This will let us change it when run on the new cluster while leaving it the same on the old.  (Or someone enterprising could set the appropriate environment variable to setup for the "other" cluster for the one they're on!)