### PR TITLE
Use more UR-centric approach to test for owner class existence.

### DIFF
--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -646,10 +646,10 @@ sub _log_change_for_rollback {
 sub _update_owner_for_move {
     my $self = shift;
     my $owner_class = $self->owner_class_name;
-    eval "require $owner_class";
+    eval "$owner_class->class";
     my $error = $@;
     if ($error) {
-        if ($error =~ /Can't locate [\w|\/|\.]+ in \@INC/) {
+        if ($error =~ /Can't locate object method "class" via package/) {
             # Some allocations are owned by classes that no longer exist. In this case,
             # we just return successfully, as there's no owner to update.
             return 1;


### PR DESCRIPTION
UR classes don't necessarily have defined perl module files, and we don't support auto-updating any non-UR classes, so this should be good enough!