### PR TITLE
Create commands for disk groups and volumes

### DIFF
--- a/lib/perl/Genome/Disk/Command/Group/Create.pm
+++ b/lib/perl/Genome/Disk/Command/Group/Create.pm
@@ -12,7 +12,7 @@ class Genome::Disk::Command::Group::Create {
     has_input => [
         name => {
             is => 'Text',
-            doc => 'name of the new disk group',
+            doc => 'unqiue name for the new disk group',
         },
         subdirectory => {
             is => 'Text',
@@ -24,6 +24,20 @@ class Genome::Disk::Command::Group::Create {
         },
     ],
 };
+
+sub _is_hidden_in_docs { !Genome::Sys->current_user_is_admin }
+
+sub help_brief {
+    return 'create a new disk group';
+}
+
+sub help_synopsis {
+    return 'genome disk group create --name newdiskgroup --subdirectory gmsroot --unix-group root';
+}
+
+sub help_detail {
+    return 'Creates a new disk group to which volumes can be assigned.  The name should be unique.';
+}
 
 sub execute {
     my $self = shift;

--- a/lib/perl/Genome/Disk/Command/Group/Create.pm
+++ b/lib/perl/Genome/Disk/Command/Group/Create.pm
@@ -1,0 +1,64 @@
+package Genome::Disk::Command::Group::Create;
+
+use strict;
+use warnings;
+
+use Genome;
+use Genome::Utility::Text qw();
+
+class Genome::Disk::Command::Group::Create {
+    is => 'Command::V2',
+    doc => 'Create a new disk group',
+    has_input => [
+        name => {
+            is => 'Text',
+            doc => 'name of the new disk group',
+        },
+        subdirectory => {
+            is => 'Text',
+            doc => 'the directory within a volume under which all allocations will be created',
+        },
+        unix_group => {
+            is => 'Text',
+            doc => 'the group who owns this disk group',
+        },
+    ],
+};
+
+sub execute {
+    my $self = shift;
+
+    my $name = $self->name;
+    my $subdirectory = $self->subdirectory;
+    my $unix_group = $self->unix_group;
+
+    my $existing = Genome::Disk::Group->get(name => $name);
+    if ($existing) {
+        $self->fatal_message('A group named %s already exists.', $name);
+    }
+
+    my $gid = Genome::Sys::gidgrnam($unix_group);
+
+    my $sanitized_subdirectory = Genome::Utility::Text::sanitize_string_for_filesystem($subdirectory);
+    unless ($sanitized_subdirectory eq $subdirectory) {
+        $self->fatal_message('Proposed subdirectory %s contains invalid characters.', $subdirectory);
+    }
+
+    my $new_group = Genome::Disk::Group->create(
+        name => $name,
+        subdirectory => $subdirectory,
+        setgid => 0,
+        unix_uid => 0,
+        unix_gid => $gid,
+        permissions => 770,
+    );
+
+    unless ($new_group) {
+        $self->fatal_message('Failed to create group.');
+    }
+    $self->status_message('New group %s created with ID %s.', $name, $new_group->id);
+
+    return $new_group->id;
+}
+
+1;

--- a/lib/perl/Genome/Disk/Command/Group/Create.t
+++ b/lib/perl/Genome/Disk/Command/Group/Create.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+
+use Test::More tests => 9;
+use Test::Exception;
+
+my $class = 'Genome::Disk::Command::Group::Create';
+
+use_ok($class);
+
+my $test_name = 'disk_command_group_t_test_group' . time;
+
+my $bad_subdir = 'dir1/dir2';
+my $good_subdir = 'dir12';
+
+my $unix_group = Genome::Config::get('sys_group');
+
+my $cmd1 = $class->create(
+    name => $test_name,
+    subdirectory => $bad_subdir,
+    unix_group => $unix_group,
+);
+isa_ok($cmd1, $class, 'created first command');
+throws_ok(sub { $cmd1->execute }, qr/contains invalid characters/, 'fails with bad subdirectory');
+
+my $cmd2 = $class->create(
+    name => $test_name,
+    subdirectory => $good_subdir,
+    unix_group => $unix_group,
+);
+isa_ok($cmd2, $class, 'created second command');
+my $disk_group_id = $cmd2->execute;
+ok($disk_group_id, 'command executed successfully');
+
+my $disk_group = Genome::Disk::Group->get(name => $test_name);
+isa_ok($disk_group, 'Genome::Disk::Group', 'created disk group');
+is($disk_group->id, $disk_group_id, 'command returned id of new group');
+
+my $cmd3 = $class->create(
+    name => $test_name,
+    subdirectory => $good_subdir,
+    unix_group => $unix_group,
+);
+isa_ok($cmd3, $class, 'created third command');
+throws_ok(sub {$cmd3->execute }, qr/already exists/, 'fails to create new group with same name');
+
+

--- a/lib/perl/Genome/Disk/Command/Volume/Create.pm
+++ b/lib/perl/Genome/Disk/Command/Volume/Create.pm
@@ -1,0 +1,67 @@
+package Genome::Disk::Command::Volume::Create;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Disk::Command::Volume::Create {
+    is => 'Command::V2',
+    doc => 'Create a new disk volume within a group',
+    has_input => [
+        mount_path => {
+            is => 'DirectoryPath',
+            doc => 'location where the volume is mounted on the filesystem',
+        },
+        total_kb => {
+            is => 'Number',
+            doc => 'Total size of the disk in kilobytes (or total size to make allocatable)',
+        },
+        hostname => {
+            is => 'Text',
+            doc => 'host of the storage volume being mounted',
+        },
+        physical_path => {
+            is => 'Text',
+            doc => 'path to the physical mount (in case the mount path is a logical volume thereunder)'
+        },
+        disk_group => {
+            is => 'Genome::Disk::Group',
+            doc => 'the group to which to initially assign the new volume',
+        },
+    ],
+};
+
+sub execute {
+    my $self = shift;
+
+    my $mount_path = $self->mount_path;
+    Genome::Sys->validate_existing_directory($mount_path);
+
+    my $total_kb = int($self->total_kb);
+    unless ($total_kb > 0) {
+        $self->fatal_message('total_kb must be a positive integer');
+    }
+
+    my $hostname = $self->hostname;
+    my $physical_path = $self->physical_path;
+    my $disk_group = $self->disk_group;
+
+    my $new_volume = Genome::Disk::Volume->create(
+        mount_path => $mount_path,
+        total_kb => $total_kb,
+        hostname => $hostname,
+        physical_path => $physical_path,
+        disk_status => 'active',
+        can_allocate => 1,
+    );
+
+    my $assignment = Genome::Disk::Assignment->create(
+        volume_id => $new_volume->id,
+        group_id => $disk_group->id,
+    );
+
+    return $new_volume->id;
+}
+
+1;

--- a/lib/perl/Genome/Disk/Command/Volume/Create.pm
+++ b/lib/perl/Genome/Disk/Command/Volume/Create.pm
@@ -32,6 +32,20 @@ class Genome::Disk::Command::Volume::Create {
     ],
 };
 
+sub _is_hidden_in_docs { !Genome::Sys->current_user_is_admin }
+
+sub help_brief {
+    return 'create a new disk volume';
+}
+
+sub help_synopsis {
+    return 'genome disk volume create --mount-path /path/to/mount --total-kb 1024 --hostname fileserver.example.com --phsyical-path /vol/to/mount --disk-group some_existing_group';
+}
+
+sub help_detail {
+    return 'Creates a new disk volume within a group.  The volume needs to be currently mounted.';
+}
+
 sub execute {
     my $self = shift;
 

--- a/lib/perl/Genome/Disk/Command/Volume/Create.t
+++ b/lib/perl/Genome/Disk/Command/Volume/Create.t
@@ -1,0 +1,67 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+
+use Test::More tests => 10;
+use Test::Exception;
+
+my $class = 'Genome::Disk::Command::Volume::Create';
+
+use_ok($class);
+
+my $mount_path = Genome::Sys->create_temp_directory();
+my $total_kb = 1024;
+my $hostname = Genome::Sys->hostname();
+my $physical_path = $mount_path;
+
+my $disk_group = Genome::Disk::Group->__define__(
+    name => 'disk_command_volume_t_test_group' . time(),
+    id => (0 - time()),
+);
+
+my $bad_mount_path = '/dev/null/bonus/path';
+
+my $cmd1 = $class->create(
+    mount_path => $bad_mount_path,
+    total_kb => $total_kb,
+    hostname => $hostname,
+    physical_path => $physical_path,
+    disk_group => $disk_group,
+);
+isa_ok($cmd1, $class, 'created first command');
+throws_ok(sub { $cmd1->execute }, qr/directory/, 'fails with bad directory');
+
+my $cmd2 = $class->create(
+    mount_path => $mount_path,
+    total_kb => 0,
+    hostname => $hostname,
+    physical_path => $physical_path,
+    disk_group => $disk_group,
+);
+isa_ok($cmd2, $class, 'created second command');
+throws_ok(sub { $cmd2->execute }, qr/must be a positive integer/, 'fails with bad total_kb');
+
+my $cmd3 = $class->create(
+    mount_path => $mount_path,
+    total_kb => $total_kb,
+    hostname => $hostname,
+    physical_path => $physical_path,
+    disk_group => $disk_group,
+);
+isa_ok($cmd3, $class, 'created third command');
+my $volume_id = $cmd3->execute;
+ok($volume_id, 'command executes');
+
+my $volume = Genome::Disk::Volume->get(mount_path => $mount_path);
+isa_ok($volume, 'Genome::Disk::Volume', 'got new volume');
+is($volume->id, $volume_id, 'command returned new volume id');
+
+is($volume->disk_group_names, $disk_group->name, 'volume is assigned to group');
+


### PR DESCRIPTION
Now that we're mostly managing volumes manually, here are two new commands: `genome disk group create` and `genome disk volume create`.  This should help make the process easier!