### PR TITLE
Add ability to queue rebuilds for CwlPipeline builds.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -26,6 +26,13 @@ class Genome::Model::CwlPipeline {
             doc => 'short name for pipeline to include in default model names',
         },
     },
+    has_metric => {
+        rebuild_requested => {
+            is => 'Text',
+            is_optional => 1,
+            doc => 'flag for a build to indicate that it should be rebuilt',
+        },
+    },
 };
 
 sub create {

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.pm
@@ -1,0 +1,69 @@
+package Genome::Model::CwlPipeline::Command::Requeue;
+
+use strict;
+use warnings;
+
+use File::Spec;
+use Genome;
+
+class Genome::Model::CwlPipeline::Command::Requeue {
+    is => 'Command::V2',
+    has => [
+        builds => {
+            is => 'Genome::Model::Build::CwlPipeline',
+            is_many => 1,
+            doc => 'The build(s) to queue for restart',
+            shell_args_position => 1,
+        },
+    ],
+    has_optional => [
+        reason => {
+            is => 'Text',
+            doc => 'a note on why the build(s) are being requeued, if desired',
+        },
+    ],
+    doc => 'queue a reattempt for a failed build',
+};
+
+sub help_detail {
+    return <<EOHELP
+Queues a build to be restarted.  This is only useful for "production" builds.  For user-launched builds, use the `restart` command instead.
+EOHELP
+}
+
+sub execute {
+    my $self = shift;
+
+    my $count = 0;
+    BUILD: for my $build ($self->builds) {
+
+        unless ($build->status eq 'Failed') {
+            $self->error_message('Cannot restart build %s with status %s. Only Failed builds may be restarted.', $build->__display_name__, $build->status);
+            next BUILD;
+        }
+
+        unless($build->run_by eq Genome::Config::get('builder_run_as_user')) {
+            $self->error_message('Can only requeue builds for the configured builder user (%s). Restart your own builds directly with `genome model cwl-pipeline restart`.', Genome::Config::get('builder_run_as_user'));
+            next BUILD;
+        }
+
+        $build->rebuild_requested(1);
+
+        my @note_params = (
+            header_text => 'Rebuild Requested',
+        );
+        if ($self->reason) {
+            push @note_params,
+                body_text => $self->reason;
+        }
+        $build->add_note(@note_params);
+
+        $count++;
+    }
+
+    $self->status_message('Requeued %s failed build(s).', $count);
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.t
@@ -1,0 +1,69 @@
+#!/usr/bin/env genome-perl
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use strict;
+use warnings;
+
+use above 'Genome';
+use Test::More tests => 18;
+
+use Genome::Test::Factory::Build;
+use Genome::Test::Factory::Model::CwlPipeline;
+
+my $class = 'Genome::Model::CwlPipeline::Command::Requeue';
+use_ok($class) or die;
+
+my $model = Genome::Test::Factory::Model::CwlPipeline->setup_object();
+
+my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id, status => 'Running');
+$build->run_by( Genome::Config::get('builder_run_as_user') );
+
+my $user_build = Genome::Test::Factory::Build->setup_object(model_id => $model->id, status => 'Failed');
+$user_build->run_by( 'not-' . Genome::Config::get('builder_run_as_user') );
+
+run_test($build, undef, 'wrong status');
+my @notes = $build->notes(header_text => 'Rebuild Requested');
+is(scalar(@notes), 0, 'no note created');
+
+$build->status('Failed');
+run_test($build, undef, undef);
+@notes = $build->notes(header_text => 'Rebuild Requested');
+is(scalar(@notes), 1, 'created a note for the request');
+
+my $reason = 'testing the requeue command';
+run_test($build, $reason, undef);
+@notes = $build->notes(header_text => 'Rebuild Requested');
+is(scalar(@notes), 2, 'created a second note given the second request');
+my @with_reason = grep { $_->body_text eq $reason } @notes;
+is(scalar(@with_reason), 1, 'found note with supplied reason');
+
+run_test($user_build, $reason, 'wrong user');
+my @user_notes = $user_build->notes(header_text => 'Rebuild Requested');
+is(scalar(@user_notes), 0, 'no note created');
+
+done_testing();
+
+sub run_test {
+    my ($build, $reason, $failure_reason) = @_;
+
+    my @params = ( builds => [$build] );
+    if ($reason) {
+        push @params, reason => $reason;
+    }
+
+    my $cmd = $class->create(@params);
+    isa_ok($cmd, $class, 'created command');
+    ok($cmd->execute, 'executed command');
+
+    if ($failure_reason) {
+        ok(!$build->rebuild_requested, 'rebuild was not requested -- ' . $failure_reason);
+    } else {
+        ok($build->rebuild_requested, 'rebuild was requested');
+    }
+
+    Genome::Sys::Lock->release_all(); #setting metrics creates a lock; normally the command would commit but not here in testing
+}
+

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
@@ -80,7 +80,12 @@ sub _restart_build {
         File::Spec->join($build->data_directory, 'build.xml')
     );
 
-    return $build->_launch(\%params, $xml);
+    my $rv = $build->_launch(\%params, $xml);
+    if ($rv) {
+        $build->rebuild_requested(0);
+    }
+
+    return $rv;
 }
 
 1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.t
@@ -14,7 +14,7 @@ use Genome::Test::Factory::AnalysisProject;
 use Genome::Test::Factory::Model::CwlPipeline;
 
 use Sub::Install;
-use Test::More tests => 4;
+use Test::More tests => 6;
 
 my $class = 'Genome::Model::CwlPipeline::Command::Restart';
 use_ok($class);
@@ -46,6 +46,13 @@ my $override = Sub::Install::reinstall_sub({
 $build->start;
 $build->status('Failed'); #inline test ends up unstartable, but this is atypical.
 
+Genome::Model::Metric->create(
+    build_id => $build->id,
+    name => 'rebuild requested',
+    value => 1,
+);
+ok($build->rebuild_requested, 'rebuild initially requested for test');
+
 undef $override;
 $override = Sub::Install::reinstall_sub({
     into => 'Genome::Model::CwlPipeline::Command::Run',
@@ -57,5 +64,5 @@ my $cmd = $class->create(
 );
 isa_ok($cmd, $class, 'created command');
 ok($cmd->execute, 'executed command, and it succeeded');
-
+ok(!$build->rebuild_requested, 'rebuild is not requested after build restarted');
 is($build->status, 'Succeeded', 'build succeeded on second attempt');


### PR DESCRIPTION
This functions like `genome model build queue` but for restarting builds rather than creating new ones.  Since we're moving away from supporting the queue for arbitrary users, this is set up to only allowing the queue of failed "production" builds.

To lend functionality to this, there'll need to be a task that runs to process the queue, such as via
```bash
ur list objects --subject Genome::Model::Build::CwlPipeline --filter rebuild_requested=1 --show id
```