### PR TITLE
Use the apparent size for allocations.

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -83,7 +83,7 @@ sub disk_usage_for_path {
     }
 
     return unless -d $path;
-    my $cmd = "du -sk $path 2>&1";
+    my $cmd = "du -sk --apparent-size $path 2>&1";
     my @du_output = split( /\n/, qx{$cmd} );
     my $last_line = pop @du_output;
     my $kb_used = ( split( ' ', $last_line, 2 ) )[0];


### PR DESCRIPTION
With the fancy fancy cache layer we're using these days, the actual size of files that haven't been pulled into the cache is not detemrined correctly by `du`.  But the apparent size is good enough!