### PR TITLE
Enable ACL support for filetests.

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -17,6 +17,7 @@ use File::Copy qw();
 use File::Path;
 use File::Spec;
 use File::stat qw(stat lstat);
+use filetest qw(access);
 use IO::File;
 use JSON;
 use List::MoreUtils "each_array";


### PR DESCRIPTION
Less performant, sure, but actually works with a lovely non-posix-compliant filesystem, too!

See also: https://perldoc.perl.org/filetest