### PR TITLE
When call-caching is enabled, check the health of jobs.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -318,6 +318,8 @@ EOCONFIG
 ;
     if(Genome::Config::get('cromwell_call_caching')) {
         $config .= <<'EOCONFIG'
+        exit-code-timeout-seconds = 600
+
         filesysytems {
           local {
             caching {


### PR DESCRIPTION
Before we were letting jobs fail and manually running `script.submit` for replacement jobs in the event of LSF failure due to the high cost of starting a workflow from the beginning over such a trivial failure. With call-caching that cost is reduced, so it's better to have quicker notification of issues.

(Ten minutes is an arbitrary choice on my part; I don't have any particular justification for it if someone has suggestions for alternate intervals.)