### PR TITLE
Include certs in test-tracker server config.

### DIFF
--- a/.test-tracker.conf
+++ b/.test-tracker.conf
@@ -2,7 +2,7 @@
 db_host: gms-postgres
 db_name: test_tracker
 db_schema: test_tracker
-db_dsn: 'dbi:Pg:dbname=test_tracker;host=gms-postgres'
+db_dsn: 'dbi:Pg:dbname=test_tracker;host=gms-postgres;sslcert=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.crt;sslkey=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.pem;sslrootcert=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.server.crt'
 db_password: zIwWhT8qkzrhPm
 db_prefix: 'test_tracker.'
 db_user: test_tracker


### PR DESCRIPTION
Once again not a useful file for the world at large, but helpful for us!