### PR TITLE
Basic config file changes

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
@@ -54,17 +54,18 @@ sub execute {
         );
     }
 
-    my $config_subpath = Genome::Config::config_subpath;
-    my $filename = $config_subpath->basename;
+    my $env_filename = 'env.' . $analysis_project->id . '.yaml';
+    Genome::Sys->shellcmd(
+        cmd => [
+            '/usr/bin/gsutil/gsutil',
+            'cp',
+            $self->environment_file,
+            'gs://gms_environment_config/' . $env_filename,
+        ],
+        input_files => [$self->environment_file],
+    );
 
-    my $dir = File::Spec->join($allocation->absolute_path, $config_subpath->dir->stringify);
-    Genome::Sys->create_directory($dir);
-
-    my $installed_path = File::Spec->join($dir, $filename);
-    Genome::Sys->copy_file($self->environment_file, $installed_path);
-    $allocation->reallocate();
-
-    $self->status_message('Environment file installed to %s', $installed_path);
+    $self->status_message('Environment file queued for installation');
 
     return 1;
 }

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -155,7 +155,7 @@ sub _copy_file_to_allocation {
         $allocation->reallocate();
     }
     else {
-        my $model_config = 'model.' . $self->id . '.yaml';
+        my $model_config = 'model.' . $self->id . $filename . '.yaml';
         Genome::Sys->shellcmd(
             cmd => [
                 '/usr/bin/gsutil/gsutil',

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -165,6 +165,7 @@ sub _copy_file_to_allocation {
             ],
             input_files => [$original_file_path],
         );
+        $self->status_message('Model config file queued for installation')
     }
     $allocation->archivable(0);
     return $destination_file_path;

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -155,17 +155,17 @@ sub _copy_file_to_allocation {
         $allocation->reallocate();
     }
     else {
-        my $model_config = 'model.' . $self->id . $filename . '.yaml';
+        my $config_file = 'model.' . $self->id . $filename . '.yaml';
         Genome::Sys->shellcmd(
             cmd => [
                 '/usr/bin/gsutil/gsutil',
                 'cp',
                 $original_file_path,
-                'gs://gms_environment_config/' . $model_config,
+                'gs://gms_environment_config/' . $config_file,
             ],
             input_files => [$original_file_path],
         );
-        $self->status_message('Model config file queued for installation')
+        $self->status_message('Config file queued for installation')
     }
     $allocation->archivable(0);
     return $destination_file_path;


### PR DESCRIPTION
Minimal changes to support adding environmental and model config files to AnPs. Instead of copying new files to the appropriate local directory, as compute1 permissions prevent this when run by regular users, the file is instead copied to a GCP bucket. Jenkins then periodically checks the bucket for new files, pushes them to the appropriate github repo, and uses git to sync storage0 and storage1.