### PR TITLE
Fix uploaded file name

### DIFF
--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -156,7 +156,7 @@ sub _copy_file_to_allocation {
     }
     else {
         my ($file_name, $file_dirs, $file_suffix) = File::Basename::fileparse($config_path, qr/\.[^.]+/);
-        my $config_file = 'model.' . $self->id . '.' . $file_name . '.yaml';
+        my $config_file = join('.', 'model', $self->id, $file_name, 'yaml');
         Genome::Sys->shellcmd(
             cmd => [
                 '/usr/bin/gsutil/gsutil',

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -155,7 +155,8 @@ sub _copy_file_to_allocation {
         $allocation->reallocate();
     }
     else {
-        my $config_file = 'model.' . $self->id . $filename . '.yaml';
+        my ($file_name, $file_dirs, $file_suffix) = File::Basename::fileparse($config_path, qr/\.[^.]+/);
+        my $config_file = 'model.' . $self->id . '.' . $file_name . '.yaml';
         Genome::Sys->shellcmd(
             cmd => [
                 '/usr/bin/gsutil/gsutil',

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -155,7 +155,7 @@ sub _copy_file_to_allocation {
         $allocation->reallocate();
     }
     else {
-        my ($file_name, $file_dirs, $file_suffix) = File::Basename::fileparse($config_path, qr/\.[^.]+/);
+        my ($file_name) = File::Basename::fileparse($original_file_path, qr/\.[^.]+/);
         my $config_file = join('.', 'model', $self->id, $file_name, 'yaml');
         Genome::Sys->shellcmd(
             cmd => [


### PR DESCRIPTION
Add in a forgotten `.` to the constructed file name and make sure that it does not contain the original file name's suffix, following the naming convention expected by a downstream jenkins script used for syncing.