### PR TITLE
Skip allocation path creation for config files

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
@@ -51,6 +51,7 @@ sub execute {
             disk_group_name => Genome::Config::get('disk_group_references'),
             allocation_path => 'analysis_project/' . $analysis_project->id,
             kilobytes_requested => ((-s $self->environment_file)/1024 + 1),
+            create_remotely => 1,
         );
     }
 

--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
@@ -51,7 +51,7 @@ sub execute {
             disk_group_name => Genome::Config::get('disk_group_references'),
             allocation_path => 'analysis_project/' . $analysis_project->id,
             kilobytes_requested => ((-s $self->environment_file)/1024 + 1),
-            create_remotely => 1,
+            skip_allocation_path_creation => 1,
         );
     }
 

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -132,7 +132,7 @@ sub has_model_for {
 sub _create_allocation_for_file {
     my $self = shift;
     my $file_to_store = shift;
-    my $skip_allocation_path_creation = shift // 1;
+    my $skip_allocation_path_creation = (shift // 1) && !$ENV{UR_DBI_NO_COMMIT};
 
     my $allocation = Genome::Disk::Allocation->create(
         owner_id            => $self->id,

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -140,7 +140,7 @@ sub _create_allocation_for_file {
         allocation_path     => 'analysis_configuration/' . $self->id,
         owner_class_name    => $self->class,
         kilobytes_requested => $self->_get_size_in_kb($file_to_store),
-	skip_allocation_path_creation => $skip_allocation_path_creation,
+        skip_allocation_path_creation => $skip_allocation_path_creation,
     );
 
     return $self->_copy_file_to_allocation($file_to_store, $allocation, $skip_allocation_path_creation);

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -138,6 +138,7 @@ sub _create_allocation_for_file {
         allocation_path     => 'analysis_configuration/' . $self->id,
         owner_class_name    => $self->class,
         kilobytes_requested => $self->_get_size_in_kb($file_to_store),
+	skip_allocation_path_creation => 1,
     );
 
     return $self->_copy_file_to_allocation($file_to_store, $allocation);

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -101,7 +101,8 @@ sub concretize {
     return if $self->is_concrete();
 
     my $original_file_path = $self->file_path;
-    return $self->_create_allocation_for_file($original_file_path);
+    my $skip_allocation_path_creation = 0;
+    return $self->_create_allocation_for_file($original_file_path, $skip_allocation_path_creation);
 }
 
 sub create_from_file_path {
@@ -131,6 +132,7 @@ sub has_model_for {
 sub _create_allocation_for_file {
     my $self = shift;
     my $file_to_store = shift;
+    my $skip_allocation_path_creation = shift // 1;
 
     my $allocation = Genome::Disk::Allocation->create(
         owner_id            => $self->id,
@@ -138,20 +140,21 @@ sub _create_allocation_for_file {
         allocation_path     => 'analysis_configuration/' . $self->id,
         owner_class_name    => $self->class,
         kilobytes_requested => $self->_get_size_in_kb($file_to_store),
-	skip_allocation_path_creation => 1,
+	skip_allocation_path_creation => $skip_allocation_path_creation,
     );
 
-    return $self->_copy_file_to_allocation($file_to_store, $allocation);
+    return $self->_copy_file_to_allocation($file_to_store, $allocation, $skip_allocation_path_creation);
 }
 
 sub _copy_file_to_allocation {
     my $self = shift;
     my $original_file_path = shift;
     my $allocation = shift;
+    my $skip_allocation_path_creation = shift // 1;
 
     my $filename = File::Basename::basename($original_file_path);
     my $destination_file_path = File::Spec->catdir($allocation->absolute_path, $filename);
-    if ($ENV{UR_DBI_NO_COMMIT}) {
+    if ($ENV{UR_DBI_NO_COMMIT} or not $skip_allocation_path_creation) {
         Genome::Sys->copy_file($original_file_path, $destination_file_path);
         $allocation->reallocate();
     }

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -323,12 +323,14 @@ sub _create {
     my %parameters = @_;
     $parameters{allocation_id} = delete $parameters{id};
 
+    my $create_flag = delete $parameters{create_remotely} // 0;
+
     my $pars = Genome::Disk::Detail::Allocation::CreationParameters->create(
         %parameters);
 
     my $creator = Genome::Disk::Detail::Allocation::Creator->create(
         parameters => $pars);
-    return $creator->create_allocation();
+    return $creator->create_allocation( create_flag => $create_flag );
 }
 
 

--- a/lib/perl/Genome/Disk/Allocation.pm
+++ b/lib/perl/Genome/Disk/Allocation.pm
@@ -323,14 +323,14 @@ sub _create {
     my %parameters = @_;
     $parameters{allocation_id} = delete $parameters{id};
 
-    my $create_flag = delete $parameters{create_remotely} // 0;
+    my $skip_allocation_path_creation = delete $parameters{skip_allocation_path_creation} // 0;
 
     my $pars = Genome::Disk::Detail::Allocation::CreationParameters->create(
         %parameters);
 
     my $creator = Genome::Disk::Detail::Allocation::Creator->create(
         parameters => $pars);
-    return $creator->create_allocation( create_flag => $create_flag );
+    return $creator->create_allocation( skip_allocation_path_creation => $skip_allocation_path_creation );
 }
 
 

--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -22,7 +22,7 @@ sub create_allocation {
     my $self = shift;
 
     my %parameters = @_;
-    my $create_remotely = delete $parameters{create_flag} // 0;
+    my $skip_allocation_path_creation = delete $parameters{skip_allocation_path_creation} // 0;
 
     $self->verify_no_parent_allocation;
     $self->wait_for_database_pause;
@@ -32,7 +32,7 @@ sub create_allocation {
     my $allocation_object = $self->_get_allocation_without_lock(
         \@candidate_volumes);
 
-    unless ($create_remotely) {
+    unless ($skip_allocation_path_creation) {
         $self->create_directory_or_delete_allocation($allocation_object);
     }
 

--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -32,7 +32,7 @@ sub create_allocation {
     my $allocation_object = $self->_get_allocation_without_lock(
         \@candidate_volumes);
 
-    if ($ENV{UR_DBI_NO_COMMIT} or not $skip_allocation_path_creation) {
+    unless ($skip_allocation_path_creation) {
         $self->create_directory_or_delete_allocation($allocation_object);
     }
 

--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -21,6 +21,9 @@ class Genome::Disk::Detail::Allocation::Creator {
 sub create_allocation {
     my $self = shift;
 
+    my %parameters = @_;
+    my $create_remotely = delete $parameters{create_flag} // 0;
+
     $self->verify_no_parent_allocation;
     $self->wait_for_database_pause;
 
@@ -29,7 +32,9 @@ sub create_allocation {
     my $allocation_object = $self->_get_allocation_without_lock(
         \@candidate_volumes);
 
-    $self->create_directory_or_delete_allocation($allocation_object);
+    unless ($create_remotely) {
+        $self->create_directory_or_delete_allocation($allocation_object);
+    }
 
     Genome::Timeline::Event::Allocation->created('initial creation',
         $allocation_object);

--- a/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
+++ b/lib/perl/Genome/Disk/Detail/Allocation/Creator.pm
@@ -32,7 +32,7 @@ sub create_allocation {
     my $allocation_object = $self->_get_allocation_without_lock(
         \@candidate_volumes);
 
-    unless ($skip_allocation_path_creation) {
+    if ($ENV{UR_DBI_NO_COMMIT} or not $skip_allocation_path_creation) {
         $self->create_directory_or_delete_allocation($allocation_object);
     }
 


### PR DESCRIPTION
These changes retain the ability to write directly to the filesystem, for use in testing or by the service account running CQID, while otherwise skipping allocation path creation for new environment and config files. The paths are created by the jenkins task that syncs the new files.