### PR TITLE
Call gsutil with python3 in Ubuntu 20.04 focal based images

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/AddEnvironmentFile.pm
@@ -72,6 +72,7 @@ sub execute {
         my $env_filename = 'env.' . $analysis_project->id . '.yaml';
         Genome::Sys->shellcmd(
             cmd => [
+                '/usr/bin/python3',
                 '/usr/bin/gsutil/gsutil',
                 'cp',
                 $self->environment_file,

--- a/lib/perl/Genome/Config/AnalysisProject/Command/UpdateEnvironmentFile.pm
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/UpdateEnvironmentFile.pm
@@ -61,6 +61,7 @@ sub execute {
         my $env_filename = 'env.' . $analysis_project->id . '.yaml';
         Genome::Sys->shellcmd(
             cmd => [
+                '/usr/bin/python3',
                 '/usr/bin/gsutil/gsutil',
                 'cp',
                 $self->environment_file,

--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -163,6 +163,7 @@ sub _copy_file_to_allocation {
         my $config_file = join('.', 'model', $self->id, $file_name, 'yaml');
         Genome::Sys->shellcmd(
             cmd => [
+                '/usr/bin/python3',
                 '/usr/bin/gsutil/gsutil',
                 'cp',
                 $original_file_path,


### PR DESCRIPTION
Calls to gsutil default to using python (2.7), which is no longer installed in the updated images based on Ubuntu 20.04 Focal Fossa. Updating the command to explicitly call gsutil using python3 fixes the issue.