### PR TITLE
Support deleting a config profile item with linked tags.

### DIFF
--- a/lib/perl/Genome/Config/Profile/Item.pm
+++ b/lib/perl/Genome/Config/Profile/Item.pm
@@ -74,6 +74,11 @@ UR::Observer->register_callback(subject_class_name => __PACKAGE__, aspect => 'cr
 
 sub delete {
     my $self = shift;
+
+    for my $bridge ($self->tag_bridges) {
+        $bridge->delete();
+    }
+
     eval {
         if ($self->allocation) {
             $self->allocation->delete();


### PR DESCRIPTION
This will still fail if the config was ever used for models (which prevents crazy cascading deletes!), but an unused config that happened to have a tag can now be cleaned up.