### PR TITLE
Use AnP config for build creation/running in refseqs.

### DIFF
--- a/lib/perl/Genome/Model/Command/Define/ImportedReferenceSequence.pm
+++ b/lib/perl/Genome/Model/Command/Define/ImportedReferenceSequence.pm
@@ -366,6 +366,10 @@ sub _create_build {
         }
     }
 
+    my $anp = $model->analysis_project;
+    my $guard;
+    $guard = $anp->set_env if $anp;
+
     my $build = Genome::Model::Build->create(@build_parameters);
     if($build) {
         $self->status_message('Created build of id ' . $build->build_id);

--- a/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.t
+++ b/lib/perl/Genome/Model/SomaticValidation/Command/ValidateSvs/CreateAssembledContigReference.t
@@ -23,6 +23,11 @@ use_ok($pkg) or die();
 my $test_dir = Genome::Utility::Test->data_dir_ok($pkg);
 
 my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+
+my $env_file = Genome::Sys->create_temp_file_path;
+Genome::Sys->write_file($env_file, 'not_a_real_config_file: 1');
+Genome::Config::AnalysisProject::Command::AddEnvironmentFile->execute(environment_file => $env_file, analysis_project => $anp);
+
 my $model = Genome::Test::Factory::Model::SomaticValidation->setup_object();
 $anp->add_model_bridge(model_id => $model->id);
 my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id, status => 'Running');

--- a/lib/perl/Genome/Test/Factory/AnalysisProject.pm
+++ b/lib/perl/Genome/Test/Factory/AnalysisProject.pm
@@ -46,6 +46,10 @@ sub setup_system_analysis_project {
     my $class = shift;
     my $anp = $class->setup_object();
 
+    my $env_file = Genome::Sys->create_temp_file_path;
+    Genome::Sys->write_file($env_file, 'not_a_real_config_file: 1');
+    Genome::Config::AnalysisProject::Command::AddEnvironmentFile->execute(environment_file => $env_file, analysis_project => $anp);
+
     Genome::Config::set_env('system_analysis_project_name', $anp->name);
 
     return $anp;


### PR DESCRIPTION
This should make defining references within someone's non-core AnP go a little more smoothly!