### PR TITLE
Use a hardcoded lims docker image.

### DIFF
--- a/lib/perl/Genome/Site/TGI/Command/ImportDataFromLims.pm
+++ b/lib/perl/Genome/Site/TGI/Command/ImportDataFromLims.pm
@@ -177,7 +177,7 @@ sub _resolve_lims_path {
 
     my $id = $data->id;
 
-    my $docker_image = `lims-config docker_images.lims_perl_environment`;
+    my $docker_image = 'registry.gsc.wustl.edu/genome/lims_perl_xenial_environment:latest';
     chomp $docker_image;
 
     my $guard = Genome::Config::set_env('lsb_sub_additional', "docker($docker_image)");


### PR DESCRIPTION
This purports to look it up in config, but the config is a lie.  The latest version of the config is itself stored inside the docker image, so it's not possible to look it up from the outside.  Rather than rely on an old version of the config, just put in the current latest value.