### PR TITLE
Add option to trusted-data importer to delete the source files.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/TrustedData.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/TrustedData.pm
@@ -44,6 +44,11 @@ class Genome::InstrumentData::Command::Import::TrustedData {
             is_many => 1,
             doc => 'Name and value pairs to add to the instrument data. Separate name and value with an equals (=) and name/value pairs with a comma (,).',
         },
+        remove_source_files => {
+            is => 'Boolean',
+            default => 0,
+            doc => 'By default this tool makes a copy of the instrument data files in an allocation.  This option will delete the original source files leaving only the allocated copy.',
+        },
     ],
     has_optional_transient => [
         _new_instrument_data => {
@@ -118,6 +123,7 @@ sub execute {
         target_directory => $allocation->absolute_path,
         chmod => 'Dug=rx,Fug=r',
         chown => ':' . Genome::Config::get('sys_group'),
+        remove_source_files => $self->remove_source_files,
     );
 
     Genome::Config::AnalysisProject::InstrumentDataBridge->create(

--- a/lib/perl/Genome/InstrumentData/Command/Import/TrustedData.t
+++ b/lib/perl/Genome/InstrumentData/Command/Import/TrustedData.t
@@ -11,7 +11,7 @@ use warnings;
 
 use File::Spec;
 use Sub::Install qw(reinstall_sub);
-use Test::More tests => 10;
+use Test::More tests => 11;
 
 use above "Genome";
 use Genome::Test::Factory::AnalysisProject;
@@ -78,4 +78,5 @@ for my $key (sort keys %extra_properties) {
     is ($result->$key, $extra_properties{$key}, "assigned $key");
 }
 
-
+my @glob = glob(File::Spec->join($test_dir, '*'));
+is(scalar(@glob), 5, 'original source files were not deleted by default');

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -840,6 +840,8 @@ sub rsync_directory {
     my $chmod = delete $params{chmod};
     my $chown = delete $params{chown};
 
+    my $remove_source_files = delete $params{remove_source_files};
+
     unless ($source_dir) {
         Carp::confess "Not given directory to copy from!";
     }
@@ -864,6 +866,10 @@ sub rsync_directory {
     }
     if ($chown) {
         push @long_opts, '--chown=' . $chown;
+    }
+
+    if($remove_source_files) {
+        push @long_opts, '--remove-source-files';
     }
 
     $source_dir .= '/' unless substr($source_dir,-1) eq '/';


### PR DESCRIPTION
To avoid duplicate copies of data when importing from local disk, some users have requested the ability to have the importer not retain the original files.  This uses the `rsync` option that removes files on transfer.  It won't remove directories--only the files inside of them.