### PR TITLE
Handle not having automatic mounts in Cleanup Succeeded

### DIFF
--- a/lib/perl/Genome/Config/AnalysisProject.pm
+++ b/lib/perl/Genome/Config/AnalysisProject.pm
@@ -200,4 +200,15 @@ sub system_analysis_project {
     return $anp;
 }
 
+sub possible_volumes {
+    my $self = shift;
+
+    my $guard = $self->set_env;
+
+    my @group_names = map { Genome::Config::get($_) } (qw(disk_group_models disk_group_alignments disk_group_scratch));
+    my @volumes = Genome::Disk::Volume->get(disk_group_names => \@group_names);
+
+    return sort map { $_->mount_path } @volumes;
+}
+
 1;

--- a/lib/perl/Genome/Config/AnalysisProject/Command/PossibleVolumes.t
+++ b/lib/perl/Genome/Config/AnalysisProject/Command/PossibleVolumes.t
@@ -7,7 +7,7 @@ BEGIN {
     $ENV{UR_DBI_NO_COMMIT} = 1;
 };
 
-use Test::More tests => 2;
+use Test::More tests => 4;
 
 use above 'Genome';
 
@@ -17,10 +17,63 @@ my $class = 'Genome::Config::AnalysisProject::Command::PossibleVolumes';
 
 use_ok($class);
 
+my $dg = Genome::Disk::Group->__define__(
+    name => 'testing_possible_volumes',
+);
+my $dv1 = Genome::Disk::Volume->__define__(
+    mount_path => '/tmp/testing_possible_volumes',
+    can_allocate => 1,
+);
+
+my $da1 = Genome::Disk::Assignment->__define__(
+    group_id => $dg->id,
+    volume_id => $dv1->id,
+);
+
+my $dv2 = Genome::Disk::Volume->__define__(
+    mount_path => '/tmp/testing_possible_volumes2',
+    can_allocate => 1,
+);
+
+my $da2 = Genome::Disk::Assignment->__define__(
+    group_id => $dg->id,
+    volume_id => $dv2->id,
+);
 my $anp = Genome::Test::Factory::AnalysisProject->setup_object;
 
 my $cmd = $class->create(analysis_project => $anp);
 
+my $env_file = Genome::Sys->create_temp_file_path;
+Genome::Sys->write_file($env_file, <<EOENV
+disk_group_alignments: testing_possible_volumes
+disk_group_models: testing_possible_volumes
+disk_group_scratch: testing_possible_volumes
+EOENV
+);
+
+Genome::Config::AnalysisProject::Command::AddEnvironmentFile->execute(
+    environment_file => $env_file,
+    analysis_project => $anp
+);
+
+
+
 isa_ok($cmd, $class, 'created command');
 
+my ($fh, $file) = Genome::Sys->create_temp_file();
+my $rv;
+{
+    local *STDOUT = $fh;
+    $rv = $cmd->execute;
+    close *STDOUT;
+}
 
+ok($rv, "executed command");
+my $expected = <<EOEXPECTED
+/tmp/testing_possible_volumes
+/tmp/testing_possible_volumes2
+EOEXPECTED
+;
+
+my $diff = Genome::Sys->diff_file_vs_text($file, $expected);
+ok(!$diff, 'output matched expected');

--- a/lib/perl/Genome/Model/Command/Admin/CleanupSucceeded.pm
+++ b/lib/perl/Genome/Model/Command/Admin/CleanupSucceeded.pm
@@ -11,12 +11,19 @@ class Genome::Model::Command::Admin::CleanupSucceeded {
             shell_args_position => 1,
             doc => 'Models to check',
         },
+        submit_abandon_jobs => {
+            is => 'Boolean',
+            default => 0,
+            doc => 'if set, will use `genome analysis-project possible-volumes` to submit jobs for abandoning',
+        },
     ],
 };
 
 use strict;
 use warnings;
 use Genome;
+
+use Genome::Sys::LSF::bsub qw();
 
 sub help_detail {
     'Abandon unsuccessful builds that have been superceded.'
@@ -56,13 +63,55 @@ sub execute {
     if (@builds_to_abandon) {
         $self->status_message(sprintf('Will abandon %d builds...',
             scalar(@builds_to_abandon)));
-        my $abandon_failed = Genome::Model::Build::Command::Abandon->create(
-            builds => \@builds_to_abandon,
-            show_display_command_summary_report => 0,
-        );
-        $abandon_failed->dump_status_messages(1);
-        return $abandon_failed->execute();
+
+        if ($self->submit_abandon_jobs) {
+            $self->_submit_abandon_jobs(@builds_to_abandon);
+        } else {
+            my $abandon_failed = Genome::Model::Build::Command::Abandon->create(
+                builds => \@builds_to_abandon,
+                show_display_command_summary_report => 0,
+            );
+            $abandon_failed->dump_status_messages(1);
+            return $abandon_failed->execute();
+        }
     }
 
     return 1;
 }
+
+sub _submit_abandon_jobs {
+    my $self = shift;
+    my @builds = @_;
+
+    my %builds_by_anp;
+    for my $build (@builds) {
+        my $anp = $build->model->analysis_project;
+        $builds_by_anp{$anp->id} //= [];
+        push @{ $builds_by_anp{$anp->id} }, $build;
+    }
+
+    for my $anp_id (keys %builds_by_anp) {
+        my $anp = Genome::Config::AnalysisProject->get($anp_id);
+
+        my @vol = $anp->possible_volumes;
+
+        my $anp_guard = $anp->set_env;
+        my $volume_guard = Genome::Config::set_env('docker_volumes', join(' ', map { "$_:$_" } @vol));
+        my $image_guard = Genome::Config::set_env('lsb_sub_additional', sprintf('docker0(%s)', $ENV{LSB_DOCKER_IMAGE})); #use the current image regardless of the AnP config
+        unless($ENV{LSF_DOCKER_NETWORK} = 'host') {
+            $self->fatal_message('Parent container must have LSF_DOCKER_NETWORK=host set.');
+        }
+
+        local $ENV{UR_NO_REQUIRE_USER_VERIFY} = 1;
+
+        Genome::Sys::LSF::bsub::bsub(
+            cmd => [qw(genome model build abandon), map $_->id, @{$builds_by_anp{$anp_id}}],
+            user_group => Genome::Config::get('lsf_user_group'),
+            interactive => 1,
+        );
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/Command/Admin/CleanupSucceeded.pm
+++ b/lib/perl/Genome/Model/Command/Admin/CleanupSucceeded.pm
@@ -98,7 +98,7 @@ sub _submit_abandon_jobs {
         my $anp_guard = $anp->set_env;
         my $volume_guard = Genome::Config::set_env('docker_volumes', join(' ', map { "$_:$_" } @vol));
         my $image_guard = Genome::Config::set_env('lsb_sub_additional', sprintf('docker0(%s)', $ENV{LSB_DOCKER_IMAGE})); #use the current image regardless of the AnP config
-        unless($ENV{LSF_DOCKER_NETWORK} = 'host') {
+        unless($ENV{LSF_DOCKER_NETWORK} eq 'host') {
             $self->fatal_message('Parent container must have LSF_DOCKER_NETWORK=host set.');
         }
 

--- a/lib/perl/Genome/Model/Command/Admin/PurgeDiskAllocationsForAbandonedBuilds.pm
+++ b/lib/perl/Genome/Model/Command/Admin/PurgeDiskAllocationsForAbandonedBuilds.pm
@@ -1,0 +1,95 @@
+package Genome::Model::Command::Admin::PurgeDiskAllocationsForAbandonedBuilds;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::Command::Admin::PurgeDiskAllocationsForAbandonedBuilds {
+    is => 'Command::V2',
+    doc => 'Purge remaining allocations for abandoned builds.',
+    has => [
+        submit_purge_jobs => {
+            is => 'Boolean',
+            default => 0,
+            doc => 'if set, will use `genome analysis-project possible-volumes` to submit jobs for purging',
+        },
+    ],
+    has_optional_transient => [
+        builds => {
+            is => 'Genome::Model::Build',
+            require_user_verify => 1,
+            is_many => 1,
+        },
+    ],
+};
+
+sub help_detail {
+    'Purge active disk allocaitons remaining for abandoned builds.';
+};
+
+sub execute {
+    my $self = shift;
+
+    my @builds = $self->resolve_param_value_from_cmdline_text(
+        {
+            name => 'builds',
+            class => 'Genome::Model::Build',
+            value => ['status=Abandoned,run_by=' . Genome::Sys->username . ',disk_allocations.status=active'],
+        }
+    );
+
+    if ($self->submit_purge_jobs) {
+        $self->_submit_purge_jobs(@builds);
+    } else {
+        for my $build (@builds) {
+            map $_->purge('purging leftover allocation for abandoned build'), $build->disk_allocations;
+        }
+    }
+}
+
+sub _submit_purge_jobs {
+    my $self = shift;
+    my @builds = @_;
+
+    my %builds_by_anp;
+    for my $build (@builds) {
+        my $anp = $build->model->analysis_project;
+        $builds_by_anp{$anp->id}{$build->class}{$build->id} = 1;
+    }
+
+    for my $anp_id (keys %builds_by_anp) {
+        my $anp = Genome::Config::AnalysisProject->get($anp_id);
+
+        my @vol = $anp->possible_volumes;
+
+        my $anp_guard = $anp->set_env;
+        my $volume_guard = Genome::Config::set_env('docker_volumes', join(' ', map { "$_:$_" } @vol));
+        my $image_guard = Genome::Config::set_env('lsb_sub_additional', sprintf('docker0(%s)', $ENV{LSB_DOCKER_IMAGE})); #use the current image regardless of the AnP config
+        unless($ENV{LSF_DOCKER_NETWORK} eq 'host') {
+            $self->fatal_message('Parent container must have LSF_DOCKER_NETWORK=host set.');
+        }
+
+        for my $build_class (keys %{$builds_by_anp{$anp_id}}) {
+
+            local $ENV{UR_NO_REQUIRE_USER_VERIFY} = 1; 
+
+            my @build_ids = keys %{ $builds_by_anp{$anp_id}{$build_class} };
+            my $connector = (scalar(@build_ids) == 1)? '=' : ':';
+
+            Genome::Sys::LSF::bsub::bsub(
+                cmd => [
+                    qw(genome disk allocation purge --reason),
+                    'purging leftover allocation for abandoned build',
+                    'status=active,owner_class_name=' . $build_class . ',owner_id' . $connector . join("/", @build_ids),
+                ],
+                user_group => Genome::Config::get('lsf_user_group'),
+                interactive => 1,
+            );
+        }
+    }
+
+    return 1;
+}
+
+1;


### PR DESCRIPTION
This creates an option to submit sub-jobs for the abandon process to give a chance to mount the requisite volumes for the abandonment process.

This also includes a cleanup command to look for allocations for abandoned builds (because sometimes disk is unreliable...).