### PR TITLE
Address errors with metric ghost class [to fix CWL requeueing].

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.t
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 
 use above 'Genome';
-use Test::More tests => 18;
+use Test::More tests => 20;
 
 use Genome::Test::Factory::Build;
 use Genome::Test::Factory::Model::CwlPipeline;
@@ -39,6 +39,10 @@ run_test($build, $reason, undef);
 is(scalar(@notes), 2, 'created a second note given the second request');
 my @with_reason = grep { $_->body_text eq $reason } @notes;
 is(scalar(@with_reason), 1, 'found note with supplied reason');
+
+ok(UR::Context->commit(), 'can sync rebuild request to db');
+$build->rebuild_requested(0);
+ok(UR::Context->commit(), 'can replace value later (such as when restarting build');
 
 run_test($user_build, $reason, 'wrong user');
 my @user_notes = $user_build->notes(header_text => 'Rebuild Requested');

--- a/lib/perl/Genome/Model/Metric.pm
+++ b/lib/perl/Genome/Model/Metric.pm
@@ -17,9 +17,9 @@ class Genome::Model::Metric {
         value => {
             is => 'Text',
             len => 1000,
-            column_name => 'METRIC_VALUE',
+            column_name => 'metric_value',
         },
-        name => { is => 'Text', len => 100, column_name => 'METRIC_NAME' },
+        name => { is => 'Text', len => 100, column_name => 'metric_name' },
     ],
     has => [
         model => { is => 'Genome::Model', via => 'build' },


### PR DESCRIPTION
When deleting metrics (to replace them), UR was complaining about the column names not matching the database.  The capitalized names were held over from before we switched to PostgreSQL, so let's just lowercase them now.