### PR TITLE
I believe this should be kill-docker like it's submit-docker.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -307,7 +307,7 @@ EOCONFIG
         """
 
         kill = "bkill ${job_id}"
-        docker-kill = "bkill ${job_id}"
+        kill-docker = "bkill ${job_id}"
         check-alive = "bjobs -noheader -o stat ${job_id} | /bin/grep 'PEND\\|RUN'"
         job-id-regex = "Job <(\\d+)>.*"
 EOCONFIG


### PR DESCRIPTION
It only matters if you have certain other settings enabled that we weren't using before.  But now it does matter 😄 