### PR TITLE
Some fixes to a log message.

### DIFF
--- a/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
+++ b/lib/perl/Genome/Model/Command/Services/ListBuildQueue.pm
@@ -122,10 +122,11 @@ sub execute {
 
                 my $per_anp_scheduled = builds_for($run_as, 'Scheduled', $anp_id);
                 if ($per_anp_scheduled >= $self->per_analysis_project_max) {
-                    Genome::Logger::infof(
+                    Genome::Logger->infof(
                         "%s's scheduled count for AnP %s (%d) meets or exceeds maximum (%d)\n",
                         $run_as,
                         $anp_id,
+                        $per_anp_scheduled,
                         $self->per_analysis_project_max,
                     );
                     $full_anps{$anp_id} = 1;


### PR DESCRIPTION
The `::` in place of `->` was preventing this from proceeding if any
given AnP was at its cap.