### PR TITLE
A queue for requesting stop/abandon for production builds.

### DIFF
--- a/lib/perl/Genome/Model/Command/Admin/CleanupSucceeded.pm
+++ b/lib/perl/Genome/Model/Command/Admin/CleanupSucceeded.pm
@@ -2,6 +2,7 @@ package Genome::Model::Command::Admin::CleanupSucceeded;
 
 class Genome::Model::Command::Admin::CleanupSucceeded {
     is => 'Command::V2',
+    roles => ['Genome::Model::Command::Submittable'],
     doc => 'Abandon unsuccessful builds that have been superceded.',
     has => [
         models => {
@@ -22,8 +23,6 @@ class Genome::Model::Command::Admin::CleanupSucceeded {
 use strict;
 use warnings;
 use Genome;
-
-use Genome::Sys::LSF::bsub qw();
 
 sub help_detail {
     'Abandon unsuccessful builds that have been superceded.'
@@ -93,21 +92,9 @@ sub _submit_abandon_jobs {
     for my $anp_id (keys %builds_by_anp) {
         my $anp = Genome::Config::AnalysisProject->get($anp_id);
 
-        my @vol = $anp->possible_volumes;
-
-        my $anp_guard = $anp->set_env;
-        my $volume_guard = Genome::Config::set_env('docker_volumes', join(' ', map { "$_:$_" } @vol));
-        my $image_guard = Genome::Config::set_env('lsb_sub_additional', sprintf('docker0(%s)', $ENV{LSB_DOCKER_IMAGE})); #use the current image regardless of the AnP config
-        unless($ENV{LSF_DOCKER_NETWORK} eq 'host') {
-            $self->fatal_message('Parent container must have LSF_DOCKER_NETWORK=host set.');
-        }
-
-        local $ENV{UR_NO_REQUIRE_USER_VERIFY} = 1;
-
-        Genome::Sys::LSF::bsub::bsub(
-            cmd => [qw(genome model build abandon), map $_->id, @{$builds_by_anp{$anp_id}}],
-            user_group => Genome::Config::get('lsf_user_group'),
-            interactive => 1,
+        $self->_submit_jobs (
+            $anp,
+            [qw(genome model build abandon), map $_->id, @{$builds_by_anp{$anp_id}}],
         );
     }
 

--- a/lib/perl/Genome/Model/Command/Submittable.pm
+++ b/lib/perl/Genome/Model/Command/Submittable.pm
@@ -1,0 +1,38 @@
+package Genome::Model::Command::Submittable;
+
+use strict;
+use warnings;
+
+use Genome;
+
+use Genome::Sys::LSF::bsub qw();
+
+role Genome::Model::Command::Submittable {
+};
+
+sub _submit_jobs {
+    my $self = shift;
+    my $anp = shift;
+    my $cmd = shift;
+
+    my @vol = $anp->possible_volumes;
+
+    my $anp_guard = $anp->set_env;
+    my $volume_guard = Genome::Config::set_env('docker_volumes', join(' ', map { "$_:$_" } @vol));
+    my $image_guard = Genome::Config::set_env('lsb_sub_additional', sprintf('docker0(%s)', $ENV{LSB_DOCKER_IMAGE})); #use the current image regardless of the AnP config
+    unless($ENV{LSF_DOCKER_NETWORK} eq 'host') {
+        $self->fatal_message('Parent container must have LSF_DOCKER_NETWORK=host set.');
+    }
+
+    local $ENV{UR_NO_REQUIRE_USER_VERIFY} = 1;
+
+    Genome::Sys::LSF::bsub::bsub(
+        cmd => $cmd,
+        user_group => Genome::Config::get('lsf_user_group'),
+        interactive => 1,
+    );
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline.pm
+++ b/lib/perl/Genome/Model/CwlPipeline.pm
@@ -27,10 +27,11 @@ class Genome::Model::CwlPipeline {
         },
     },
     has_metric => {
-        rebuild_requested => {
+        action_requested => {
             is => 'Text',
             is_optional => 1,
-            doc => 'flag for a build to indicate that it should be rebuilt',
+            doc => 'flag for a build to indicate that it should be acted upon--for use with production user',
+            valid_values => ['restart', 'stop', 'abandon', '0'],
         },
     },
 };

--- a/lib/perl/Genome/Model/CwlPipeline/Command/ProcessActionQueue.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/ProcessActionQueue.pm
@@ -7,6 +7,7 @@ use Genome;
 
 class Genome::Model::CwlPipeline::Command::ProcessActionQueue {
     is => 'Command::V2',
+    roles => ['Genome::Model::Command::Submittable'],
     has => [
         max_count => {
             is => 'Number',

--- a/lib/perl/Genome/Model/CwlPipeline/Command/ProcessActionQueue.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/ProcessActionQueue.pm
@@ -1,0 +1,74 @@
+package Genome::Model::CwlPipeline::Command::ProcessActionQueue;
+
+use strict;
+use warnings;
+
+use Genome;
+
+class Genome::Model::CwlPipeline::Command::ProcessActionQueue {
+    is => 'Command::V2',
+    has => [
+        max_count => {
+            is => 'Number',
+            doc => 'Process at most this many queued builds',
+            default => 10,
+        },
+        submit_jobs => {
+            is => 'Boolean',
+            default => 0,
+            doc => 'if set, will use `genome analysis-project possible-volumes` to submit jobs for the actions',
+        },
+    ],
+};
+
+sub help_detail {
+    return <<EOHELP
+Takes the actions requested for CWLPipeline builds.
+EOHELP
+}
+
+sub execute {
+    my $self = shift;
+
+    my @to_process = Genome::Model::Build::CwlPipeline->get(
+        action_requested => ['stop', 'abandon'],
+        -limit => $self->max_count,
+    );
+
+    my %builds_by_anp;
+
+    for my $build (@to_process) {
+        my $anp = $build->model->analysis_project;
+        my $action = $build->action_requested;
+
+        $builds_by_anp{$anp->id}{$action} //= [];
+        push @{ $builds_by_anp{$anp->id}{$action} }, $build;
+    }
+
+    for my $anp_id (keys %builds_by_anp) {
+        my $anp = Genome::Config::AnalysisProject->get($anp_id);
+
+        for my $action (keys %{ $builds_by_anp{$anp_id} }) {
+            my $builds = $builds_by_anp{$anp_id}{$action};
+
+            if ($self->submit_jobs) {
+                $self->_submit_jobs(
+                    $anp,
+                    [qw(genome model build), $action, map $_->id, @$builds],
+                );
+            } else {
+                for my $build (@$builds) {
+                    $build->$action;
+                }
+            }
+
+            for my $build (@$builds) {
+                $build->action_requested(0);
+            }
+        }
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/ProcessActionQueue.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/ProcessActionQueue.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env genome-perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 6;
+
+BEGIN {
+    $ENV{UR_DBI_NO_COMMIT} = 1;
+};
+
+use above 'Genome';
+use Genome::Test::Factory::AnalysisProject;
+use Genome::Test::Factory::Build;
+use Genome::Test::Factory::Model::CwlPipeline;
+
+
+my $class = 'Genome::Model::CwlPipeline::Command::ProcessActionQueue';
+use_ok($class);
+
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+
+my $model = Genome::Test::Factory::Model::CwlPipeline->setup_object();
+my $bridge = Genome::Config::AnalysisProject::ModelBridge->create(
+    model_id => $model->id,
+    analysis_project_id => $anp->id,
+);
+
+my $build = Genome::Test::Factory::Build->setup_object( model_id => $model->id, status => 'Failed');
+
+$build->action_requested('abandon');
+is($build->action_requested, 'abandon', 'set up build to abandon');
+
+my $cmd = $class->create(
+    submit_jobs => 0,
+    max_count => 5,
+);
+isa_ok($cmd, $class, 'created command');
+
+#avoid finding production objects
+my $original_quc = UR::Context->query_underlying_context();
+UR::Context->query_underlying_context(0);
+
+ok($cmd->execute, 'executed command');
+
+is($build->action_requested, 0, 'action requested cleared');
+is($build->status, 'Abandoned', 'build was abandoned');
+
+done_testing();

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.pm
@@ -61,7 +61,6 @@ sub execute {
                 next BUILD;
             }
 
-            $DB::single = 1;
             unless($build->model->analysis_project->created_by eq Genome::Sys->username or Genome::Sys->current_user_is_admin) {
                 $self->error_message('Cannot %s builds for an analysis project owned by %s. (If this is your AnP, see `genome-analysis-project take-ownership`.', $action, $build->model->analysis_project->created_by);
                 next BUILD;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.pm
@@ -15,6 +15,12 @@ class Genome::Model::CwlPipeline::Command::Requeue {
             doc => 'The build(s) to queue for restart',
             shell_args_position => 1,
         },
+        action => {
+            is => 'Text',
+            doc => 'what action to request for the build',
+            valid_values => Genome::Model::Build::CwlPipeline->__meta__->property(property_name => 'action_requested')->valid_values,
+            default => 'restart',
+        },
     ],
     has_optional => [
         reason => {
@@ -34,23 +40,38 @@ EOHELP
 sub execute {
     my $self = shift;
 
+    my $action = $self->action;
+
     my $count = 0;
     BUILD: for my $build ($self->builds) {
 
-        unless ($build->status eq 'Failed') {
-            $self->error_message('Cannot restart build %s with status %s. Only Failed builds may be restarted.', $build->__display_name__, $build->status);
-            next BUILD;
+        if ($action eq 'restart') {
+            if ($build->status ne 'Failed') {
+                $self->error_message('Cannot restart build %s with status %s. Only Failed builds may be restarted.', $build->__display_name__, $build->status);
+                next BUILD;
+            }
+
+            unless($build->run_by eq Genome::Config::get('builder_run_as_user')) {
+                $self->error_message('Can only requeue builds for the configured builder user (%s). Restart your own builds directly with `genome model cwl-pipeline restart`.', Genome::Config::get('builder_run_as_user'));
+                next BUILD;
+            }
+        } else {
+            unless($build->run_by eq Genome::Config::get('builder_run_as_user')) {
+                $self->error_message('Can only %s builds for the configured builder user (%s). For your own builds, use `genome model build %s` directly.', $action, Genome::Config::get('builder_run_as_user'), $action);
+                next BUILD;
+            }
+
+            $DB::single = 1;
+            unless($build->model->analysis_project->created_by eq Genome::Sys->username or Genome::Sys->current_user_is_admin) {
+                $self->error_message('Cannot %s builds for an analysis project owned by %s. (If this is your AnP, see `genome-analysis-project take-ownership`.', $action, $build->model->analysis_project->created_by);
+                next BUILD;
+            }
         }
 
-        unless($build->run_by eq Genome::Config::get('builder_run_as_user')) {
-            $self->error_message('Can only requeue builds for the configured builder user (%s). Restart your own builds directly with `genome model cwl-pipeline restart`.', Genome::Config::get('builder_run_as_user'));
-            next BUILD;
-        }
-
-        $build->rebuild_requested(1);
+        $build->action_requested($action);
 
         my @note_params = (
-            header_text => 'Rebuild Requested',
+            header_text => 'Action Requested: ' . $action,
         );
         if ($self->reason) {
             push @note_params,
@@ -61,7 +82,7 @@ sub execute {
         $count++;
     }
 
-    $self->status_message('Requeued %s failed build(s).', $count);
+    $self->status_message('Requested %s for %s build(s).', $action, $count);
 
     return 1;
 }

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Requeue.t
@@ -7,16 +7,23 @@ BEGIN {
 use strict;
 use warnings;
 
-use above 'Genome';
-use Test::More tests => 20;
+use Sub::Override;
 
+use above 'Genome';
+use Test::More tests => 36;
+
+use Genome::Test::Factory::AnalysisProject;
 use Genome::Test::Factory::Build;
 use Genome::Test::Factory::Model::CwlPipeline;
 
 my $class = 'Genome::Model::CwlPipeline::Command::Requeue';
 use_ok($class) or die;
 
+my $anp = Genome::Test::Factory::AnalysisProject->setup_object();
+$anp->created_by('-nonexistent-user-');
 my $model = Genome::Test::Factory::Model::CwlPipeline->setup_object();
+
+Genome::Config::AnalysisProject::ModelBridge->create(analysis_project_id => $anp->id, model_id => $model->id);
 
 my $build = Genome::Test::Factory::Build->setup_object(model_id => $model->id, status => 'Running');
 $build->run_by( Genome::Config::get('builder_run_as_user') );
@@ -25,37 +32,63 @@ my $user_build = Genome::Test::Factory::Build->setup_object(model_id => $model->
 $user_build->run_by( 'not-' . Genome::Config::get('builder_run_as_user') );
 
 run_test($build, undef, 'wrong status');
-my @notes = $build->notes(header_text => 'Rebuild Requested');
+my @notes = $build->notes(header_text => 'Action Requested: restart');
 is(scalar(@notes), 0, 'no note created');
 
 $build->status('Failed');
 run_test($build, undef, undef);
-@notes = $build->notes(header_text => 'Rebuild Requested');
+@notes = $build->notes(header_text => 'Action Requested: restart');
 is(scalar(@notes), 1, 'created a note for the request');
 
 my $reason = 'testing the requeue command';
 run_test($build, $reason, undef);
-@notes = $build->notes(header_text => 'Rebuild Requested');
+@notes = $build->notes(header_text => 'Action Requested: restart');
 is(scalar(@notes), 2, 'created a second note given the second request');
 my @with_reason = grep { $_->body_text eq $reason } @notes;
 is(scalar(@with_reason), 1, 'found note with supplied reason');
 
 ok(UR::Context->commit(), 'can sync rebuild request to db');
-$build->rebuild_requested(0);
+$build->action_requested(0);
 ok(UR::Context->commit(), 'can replace value later (such as when restarting build');
 
 run_test($user_build, $reason, 'wrong user');
-my @user_notes = $user_build->notes(header_text => 'Rebuild Requested');
+my @user_notes = $user_build->notes(header_text => 'Action Requested: restart');
 is(scalar(@user_notes), 0, 'no note created');
+
+run_test($user_build, $reason, 'wrong user', 'stop');
+@user_notes = $user_build->notes(header_text => 'Action Requested: stop');
+is(scalar(@user_notes), 0, 'no note created');
+
+use Genome::Sys;
+my $guard = Sub::Override->new('Genome::Sys::current_user_is_admin', sub { return 0; });
+
+run_test($build, undef, 'wrong AnP owner', 'stop');
+@notes = $build->notes(header_text => 'Action Requested: stop');
+is(scalar(@notes), 0, 'no note created');
+
+$anp->created_by(Genome::Sys->username);
+
+run_test($build, undef, undef, 'stop');
+@notes = $build->notes(header_text => 'Action Requested: stop');
+is(scalar(@notes), 1, 'created a note for the request');
+
+run_test($build, undef, undef, '0');
+@notes = $build->notes(header_text => 'Action Requested: 0');
+is(scalar(@notes), 1, 'created a note for cancelling the request');
+
+undef $guard;
 
 done_testing();
 
 sub run_test {
-    my ($build, $reason, $failure_reason) = @_;
+    my ($build, $reason, $failure_reason, $action) = @_;
 
     my @params = ( builds => [$build] );
-    if ($reason) {
+    if (defined $reason) {
         push @params, reason => $reason;
+    }
+    if (defined $action) {
+        push @params, action => $action;
     }
 
     my $cmd = $class->create(@params);
@@ -63,9 +96,9 @@ sub run_test {
     ok($cmd->execute, 'executed command');
 
     if ($failure_reason) {
-        ok(!$build->rebuild_requested, 'rebuild was not requested -- ' . $failure_reason);
+        ok(!$build->action_requested, 'rebuild was not requested -- ' . $failure_reason);
     } else {
-        ok($build->rebuild_requested, 'rebuild was requested');
+        is($build->action_requested, ($action // 'restart'), 'action was requested');
     }
 
     Genome::Sys::Lock->release_all(); #setting metrics creates a lock; normally the command would commit but not here in testing

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.pm
@@ -82,7 +82,7 @@ sub _restart_build {
 
     my $rv = $build->_launch(\%params, $xml);
     if ($rv) {
-        $build->rebuild_requested(0);
+        $build->action_requested(0);
     }
 
     return $rv;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Restart.t
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Restart.t
@@ -48,10 +48,10 @@ $build->status('Failed'); #inline test ends up unstartable, but this is atypical
 
 Genome::Model::Metric->create(
     build_id => $build->id,
-    name => 'rebuild requested',
-    value => 1,
+    name => 'action requested',
+    value => 'restart',
 );
-ok($build->rebuild_requested, 'rebuild initially requested for test');
+is($build->action_requested, 'restart', 'rebuild initially requested for test');
 
 undef $override;
 $override = Sub::Install::reinstall_sub({
@@ -64,5 +64,5 @@ my $cmd = $class->create(
 );
 isa_ok($cmd, $class, 'created command');
 ok($cmd->execute, 'executed command, and it succeeded');
-ok(!$build->rebuild_requested, 'rebuild is not requested after build restarted');
+ok(!$build->action_requested, 'rebuild is not requested after build restarted');
 is($build->status, 'Succeeded', 'build succeeded on second attempt');


### PR DESCRIPTION
For CwlPipeline builds, now they can be requested to be stopped or abandoned in addition to being restarted.  Since stop and abandon are destructive, only the AnP owner (or an admin) can make these requests.