### PR TITLE
Enable GCP workflows via environment configuration options

### DIFF
--- a/etc/genome/spec/cromwell_gcp_bucket.yaml
+++ b/etc/genome/spec/cromwell_gcp_bucket.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_CROMWELL_GCP_BUCKET
+default_value: ""

--- a/etc/genome/spec/cromwell_workflow_options.yaml
+++ b/etc/genome/spec/cromwell_workflow_options.yaml
@@ -1,0 +1,8 @@
+# The `cromwell_workflow_options` configuration variable is the path
+# to a json file containing the configuration for an individal
+# workflow run in Cromwell.
+#
+# This is required only when cwl_runner=cromwell_gcp
+---
+env: XGENOME_CROMWELL_WORKFLOW_OPTIONS
+default: ""

--- a/etc/genome/spec/workflow_deps_zip.yaml
+++ b/etc/genome/spec/workflow_deps_zip.yaml
@@ -1,8 +1,0 @@
-# The `workflow_deps_zip` configuration variable is the path to a zip
-# file containing the dependencies of the submitted workflow. This
-# should typically be $ANALYSIS_WDLS/workflows.zip. This is only used
-# when cwl_runner=cromwell_gcp
-#
----
-env: XGENOME_WORKFLOW_DEPS_ZIP
-default: ""

--- a/etc/genome/spec/workflow_deps_zip.yaml
+++ b/etc/genome/spec/workflow_deps_zip.yaml
@@ -1,0 +1,8 @@
+# The `workflow_deps_zip` configuration variable is the path to a zip
+# file containing the dependencies of the submitted workflow. This
+# should typically be $ANALYSIS_WDLS/workflows.zip. This is only used
+# when cwl_runner=cromwell_gcp
+#
+---
+env: XGENOME_WORKFLOW_DEPS_ZIP
+default: ""

--- a/lib/perl/Genome/Cromwell.pm
+++ b/lib/perl/Genome/Cromwell.pm
@@ -132,17 +132,17 @@ sub _send_request {
     my $req = shift;
 
     my $self = $class->_singleton_object;
-  ATTEMPT: for (1..5) {
-      my $response = $self->user_agent->request($req);
+    ATTEMPT: for (1..5) {
+        my $response = $self->user_agent->request($req);
 
-      unless ($response->is_success) {
-          $self->fatal_message('Error querying server: %s', $response->status_line);
-          sleep 5;
-          next ATTEMPT;
-      }
+        unless ($response->is_success) {
+            $self->fatal_message('Error querying server: %s', $response->status_line);
+            sleep 5;
+            next ATTEMPT;
+        }
 
-      return $response->decoded_content;
-  }
+        return $response->decoded_content;
+    }
 
     $self->fatal_message('Failed to query server after serveral attempts.');
 }

--- a/lib/perl/Genome/Cromwell.pm
+++ b/lib/perl/Genome/Cromwell.pm
@@ -35,7 +35,7 @@ class Genome::Cromwell {
                 return $ua;
             },
         },
-        ],
+    ],
 };
 
 sub status {

--- a/lib/perl/Genome/Cromwell.pm
+++ b/lib/perl/Genome/Cromwell.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use JSON qw(to_json from_json);
 use HTTP::Request;
+use HTTP::Request::Common qw(POST);
 use LWP::UserAgent;
 use IO::Socket::SSL qw();
 use IPC::Run qw();
@@ -34,9 +35,18 @@ class Genome::Cromwell {
                 return $ua;
             },
         },
-    ],
+        ],
 };
 
+sub status {
+    my $class = shift;
+    my $workflow_id = shift;
+
+    my $self = $class->_singleton_object;
+    my $url = $self->_request_url($workflow_id, 'status');
+
+    return $self->_make_json_request('GET', $url);
+}
 
 sub outputs {
     my $class = shift;
@@ -80,6 +90,24 @@ sub timing {
     return $content;
 }
 
+sub submit_workflow {
+    my $class = shift;
+    my ($definition, $inputs, $dependencies, $options) = @_;
+
+    my $self = $class->_singleton_object;
+    my $url = $self->_request_url();
+    my $content = [ workflowSource  => [$definition],
+                    workflowInputs => [$inputs],
+                    workflowDependencies => [$dependencies],
+                    workflowOptions => [$options] ];
+    my $req = POST( $url,
+                    Content_Type => 'multipart/form-data',
+                    Content => $content );
+
+    return from_json($self->_send_request($req));
+}
+
+
 sub _request_url {
     my $class = shift;
     my @parts = @_;
@@ -97,6 +125,26 @@ sub _make_json_request {
 
     my $content = $class->_make_request(@_);
     return from_json($content);
+}
+
+sub _send_request {
+    my $class = shift;
+    my $req = shift;
+
+    my $self = $class->_singleton_object;
+  ATTEMPT: for (1..5) {
+      my $response = $self->user_agent->request($req);
+
+      unless ($response->is_success) {
+          $self->fatal_message('Error querying server: %s', $response->status_line);
+          sleep 5;
+          next ATTEMPT;
+      }
+
+      return $response->decoded_content;
+  }
+
+    $self->fatal_message('Failed to query server after serveral attempts.');
 }
 
 sub _make_request {
@@ -118,21 +166,7 @@ sub _make_request {
     } else {
         push @request_args, \@headers;
     }
-
-    ATTEMPT: for (1..5) {
-        my $req = HTTP::Request->new(@request_args);
-        my $response = $self->user_agent->request($req);
-
-        unless ($response->is_success) {
-            $self->error_message('Error querying server: %s', $response->status_line);
-            sleep 5;
-            next ATTEMPT;
-        }
-
-        return $response->decoded_content;
-    }
-
-    $self->fatal_message('Failed to query server after serveral attempts.');
+    return $self->_send_request(HTTP::Request->new(@request_args));
 }
 
 sub cromwell_jar_cmdline {

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -216,11 +216,12 @@ sub run_cromwell_gcp {
             $yaml,
             "--output=$cloud_yaml"] );
 
-    print "input yaml $yaml\ncloud yaml $cloud_yaml\n";
+    $self->debug_message('input yaml: %s', $yaml);
+    $self->debug_message('cloud yaml: %s', $cloud_yaml);
     my $workflow_id = Genome::Cromwell->submit_workflow(
         $main_workflow_file, $cloud_yaml, $zip_deps, $workflow_options )->{id};
 
-    print "Submitted workflow id=" . $workflow_id . "\n";
+    $self->status_message('Submitted workflow with ID: %s', $workflow_id);
 
     # Poll until done
     my $status;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -6,7 +6,6 @@ use warnings;
 use Cwd;
 use Data::Dumper;
 use File::Spec;
-use File::Basename;
 use Genome;
 use Genome::Utility::File::Mode qw();
 use Genome::Utility::Text qw();
@@ -208,7 +207,7 @@ sub run_cromwell_gcp {
         user_group => $user_group,
         resource_string => 'rusage[mem=512M:internet2_upload_mbps=500]',
         wait_for_completion => 1,
-        log_file => "$logdir/cloudize_workflow.log",
+        log_file => File::Spec->join($logdir, 'cloudize_workflow.log'),
         cmd => [
             "python3",
             "/opt/scripts/cloudize-workflow.py",
@@ -223,7 +222,8 @@ sub run_cromwell_gcp {
     # Zip dependencies
     my $deps_zip = "$data_dir/deps.zip";
     my $prev_dir = getcwd;
-    chdir(dirname($main_workflow_file));
+    my(undef, $deps_dir, undef) = File::Spec->splitpath($main_workflow_file);
+    chdir($deps_dir);
     Genome::Sys->shellcmd(cmd => ['zip', '-r', $deps_zip, '.']);
     chdir($prev_dir);
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -197,7 +197,7 @@ sub run_cromwell_gcp {
     my $poll_interval_seconds = 30;
 
     # Cloudize workflow
-    my $cloud_yaml = $yaml =~ s/.ya?ml/_cloud.yaml/r;
+    my $cloud_yaml = $yaml; $cloud_yaml =~ s/.ya?ml/_cloud.yaml/;
     my $guard = Genome::Config::set_env('lsb_sub_additional', 'docker(jackmaruska/cloudize-workflow:1.0.0)');
     delete local $ENV{BOTO_CONFIG};
 
@@ -257,7 +257,7 @@ sub _fetch_cromwell_log {
     my $logdir = shift;
 
     my $workflow_opts = from_json(Genome::Sys->read_file($workflow_options));
-    my $final_workflow_log_dir = %$workflow_opts{'final_workflow_log_dir'};
+    my $final_workflow_log_dir = $workflow_opts->{final_workflow_log_dir};
 
     Genome::Sys->shellcmd(
         cmd => [

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -186,7 +186,7 @@ sub run_cromwell_gcp {
 
     my $zip_deps = Genome::Config::get('workflow_deps_zip');
     my $workflow_options = Genome::Config::get('cromwell_workflow_options');
-    my $bucket = Genome::Config::get('google_cloud_storage_bucket');
+    my $bucket = Genome::Config::get('cromwell_gcp_bucket');
 
     my $logdir = $self->build->log_directory;
     my $cromwell_url = Genome::Cromwell->server_url;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -243,11 +243,11 @@ sub run_cromwell_gcp {
             ]
             );
         $self->_generate_timing_report($workflow_id);
+        $self->_fetch_cromwell_log($workflow_id, $workflow_options, $logdir);
     } else {
+        $self->_fetch_cromwell_log($workflow_id, $workflow_options, $logdir);
         $self->fatal_message("Workflow $workflow_id has non-succeeded status $status using workflow definition $main_workflow_file. Logs at $logdir");
     }
-
-    $self->_fetch_cromwell_log($workflow_id, $workflow_options, $logdir);
 }
 
 sub _fetch_cromwell_log {

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -220,7 +220,7 @@ sub run_cromwell_gcp {
     $self->debug_message('cloud yaml: %s', $cloud_yaml);
 
     # Zip dependencies
-    my $deps_zip = "$data_dir/deps.zip";
+    my $deps_zip = File::Spec->join($data_dir, 'deps.zip');
     my $prev_dir = getcwd;
     my(undef, $deps_dir, undef) = File::Spec->splitpath($main_workflow_file);
     chdir($deps_dir);
@@ -246,7 +246,7 @@ sub run_cromwell_gcp {
             user_group => $user_group,
             resource_string => 'rusage[mem=512M:internet2_download_mbps=500]',
             wait_for_completion => 1,
-            log_file => "$logdir/pull_outputs.log",
+            log_file => File::Spec->join($logdir, 'pull_outputs.log'),
             cmd => [
                 "python3", "/opt/scripts/pull_outputs.py",
                 $workflow_id, "--output=$results_dir", "--cromwell-url=$cromwell_url"
@@ -273,8 +273,8 @@ sub _fetch_cromwell_log {
         cmd => [
             '/usr/bin/python3',
             '/usr/bin/gsutil/gsutil', 'cp',
-            $final_workflow_log_dir . "/workflow." . $workflow_id . ".log",
-            $logdir . "/" . $workflow_id . ".log"
+            File::Spec->join($final_workflow_log_dir, "workflow." . $workflow_id . ".log"),
+            File::Spec->join($logdir, $workflow_id . ".log")
         ]);
 }
 

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -199,7 +199,7 @@ sub run_cromwell_gcp {
 
     # Cloudize workflow
     my $cloud_yaml = $yaml =~ s/.ya?ml/_cloud.yaml/r;
-    my $guard = Genome::Config::set_env('lsb_sub_additional', 'docker(jackmaruska/cloudize-workflow:latest)');
+    my $guard = Genome::Config::set_env('lsb_sub_additional', 'docker(jackmaruska/cloudize-workflow:1.0.0)');
     delete local $ENV{BOTO_CONFIG};
 
     Genome::Sys::LSF::bsub::bsub(

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -190,7 +190,6 @@ sub run_cromwell_gcp {
 
     my $logdir = $self->build->log_directory;
     my $cromwell_url = Genome::Cromwell->server_url;
-    my $lsb_sub_additional = Genome::Config::get('lsb_sub_additional');
     my $queue = Genome::Config::get('lsf_queue_build_worker');
     my $user_group = Genome::Config::get('lsf_user_group');
     my $main_workflow_file = $self->build->model->main_workflow_file;
@@ -249,8 +248,6 @@ sub run_cromwell_gcp {
     }
 
     $self->_fetch_cromwell_log($workflow_id, $workflow_options, $logdir);
-
-    $guard = Genome::Config::set_env('lsb_sub_additional', $lsb_sub_additional);
 }
 
 sub _fetch_cromwell_log {


### PR DESCRIPTION
Enable GCP workflows by setting `cwl_runner` to `cromwell_gcp`

Additional settings required are:
- `workflow_deps_zip`, path to a .zip file containing WDL dependencies, likely pointing at analysis-wdls repository
- `cromwell_workflow_options`, path to a .json file for Cromwell settings, different for each lab at minimum
- `cromwell_gcp_bucket` which bucket to place Cromwell generated files like outputs and logs

gcloud uses user permissions, so the user must `gcloud auth login` before sending off jobs

