### PR TITLE
Switch cromwell_gcp workflow runner from central Cromwell server to per-run Cromwell VM

### DIFF
--- a/etc/genome/spec/cromwell_gcp_project.yaml
+++ b/etc/genome/spec/cromwell_gcp_project.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_CROMWELL_GCP_PROJECT
+default_value: ""

--- a/etc/genome/spec/cromwell_gcp_server_memory_gb.yaml
+++ b/etc/genome/spec/cromwell_gcp_server_memory_gb.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_CROMWELL_GCP_SERVER_MEMORY_GB
+default_value: "8"

--- a/etc/genome/spec/cromwell_gcp_service_account.yaml
+++ b/etc/genome/spec/cromwell_gcp_service_account.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_CROMWELL_GCP_SERVICE_ACCOUNT
+default_value: ""

--- a/etc/genome/spec/cromwell_workflow_options.yaml
+++ b/etc/genome/spec/cromwell_workflow_options.yaml
@@ -1,8 +1,0 @@
-# The `cromwell_workflow_options` configuration variable is the path
-# to a json file containing the configuration for an individal
-# workflow run in Cromwell.
-#
-# This is required only when cwl_runner=cromwell_gcp
----
-env: XGENOME_CROMWELL_WORKFLOW_OPTIONS
-default: ""

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -41,6 +41,7 @@ sub execute {
         $self->cleanup($tmp_dir);
     } elsif ($cwl_runner eq 'cromwell_gcp') {
         $self->run_cromwell_gcp($yaml, $tmp_dir, $results_dir);
+        $self->cleanup($tmp_dir);
     } elsif ($cwl_runner eq 'toil') {
         $self->run_toil($yaml, $tmp_dir, $results_dir);
         $self->cleanup($tmp_dir, $results_dir);
@@ -186,18 +187,16 @@ sub run_cromwell_gcp {
     my $tmp_dir = shift;
     my $results_dir = shift;
 
-    my $bucket = Genome::Config::get('cromwell_gcp_bucket');
-
     my $logdir = $self->build->log_directory;
-    mkdir $logdir if !(-d $logdir);
     my $data_dir = $self->build->data_directory;
-    my $queue = Genome::Config::get('lsf_queue_build_worker');
-    my $user_group = Genome::Config::get('lsf_user_group');
     my $main_workflow_file = $self->build->model->main_workflow_file;
     my $build_id = $self->build->id;
 
+    my $bucket = Genome::Config::get('cromwell_gcp_bucket');
     my $cromwell_server_memory_gb = Genome::Config::get('cromwell_gcp_server_memory_gb');
     my $cromwell_service_account = Genome::Config::get('cromwell_gcp_service_account');
+    my $queue = Genome::Config::get('lsf_queue_build_worker');
+    my $user_group = Genome::Config::get('lsf_user_group');
 
     my $poll_interval_seconds = 300;
 
@@ -319,7 +318,6 @@ sub run_cromwell_gcp {
                          "Compute instance logs and workflow timing in $data_dir \n" .
                          "Logs for bsubs at $logdir" );
 }
-
 
 sub _fetch_cromwell_log {
     my $self = shift;

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -308,7 +308,8 @@ sub run_cromwell_gcp {
             cmd => [
                 'python3', '/opt/scripts/pull_outputs.py',
                 "--outputs-dir=$results_dir",
-                "--outputs-file=$outputs_json"
+                "--outputs-file=$outputs_json",
+                "--dir-structure=DEEP"
             ] );
     } else {
         $self->fatal_message("Build did not generate output files. See $logdir");

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -639,7 +639,7 @@ EOCONFIG
         #shell out so this is saved immediately for the benefit of `genome model build view` while this build runs.
         Genome::Sys->shellcmd(
             cmd => [qw(genome model build add-note --header-text=hsqldb_server_file), "--body-text=$dbfile_location", $build->id],
-            );
+        );
 
         $config .= <<EOCONFIG
 database {
@@ -667,7 +667,7 @@ EOCONFIG
     }
 
     if (Genome::Config::get('cromwell_call_caching')) {
-        $config .= <<'EOCONFIG'
+        $config .= <<EOCONFIG
 call-caching {
   enabled = true
   invalidate-bad-cache-results = true
@@ -698,8 +698,9 @@ sub _generate_cromwell_labels {
     return $labels_file;
 }
 
-sub _query_workflow_id {
+sub _stage_cromwell_outputs {
     my $self = shift;
+    my $results_dir = shift;
     my $build = $self->build;
 
     my $results = Genome::Cromwell->query( [{ label => 'build:' . $build->id, status => 'Succeeded' }] );
@@ -708,14 +709,6 @@ sub _query_workflow_id {
     }
 
     my $workflow_id = $results->{results}->[0]->{id};
-    return $workflow_id;
-}
-
-sub _stage_cromwell_outputs {
-    my $self = shift;
-    my $results_dir = shift;
-
-    my $workflow_id = $self->_query_workflow_id();
     my $output_result = Genome::Cromwell->outputs($workflow_id);
 
     my $outputs = $output_result->{outputs};

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -598,7 +598,6 @@ workflow-options {
 }
 EOCONFIG
 ;
-
     if ($server =~ /^mysql:/) {
         $config .= <<EOCONFIG
 database {
@@ -699,6 +698,7 @@ sub _generate_cromwell_labels {
 sub _stage_cromwell_outputs {
     my $self = shift;
     my $results_dir = shift;
+
     my $build = $self->build;
 
     my $results = Genome::Cromwell->query( [{ label => 'build:' . $build->id, status => 'Succeeded' }] );


### PR DESCRIPTION
Main goal of the PR: switch from using a central pre-existing Cromwell server to spinning up a Cromwell VM for a submitted run. There are a few benefits to this
1. excluding first-time setup it removes an operational dependency from GMS -- problems with a central server won't sink automated GMS runs
2. it removes auth concerns around creating resources to run a workflow, since auth is done using the calling user's gcloud credentials. I have yet to test how this works in an automated scenario and that will likely have a PR addressing it later. 
3. it's cheaper than a central server for labs/researchers that wouldn't be submitting jobs regularly and frequently

At some point in the future, after spending some time digging in to [Identity Aware Proxy](https://cloud.google.com/iap/docs/concepts-overview) offering from GCP to handle auth issue 2, will likely add an optional central server approach for those who want it. 

Material differences in how this works than previously:
- deps zip file must be uploaded to GCS
- generate files for cromwell.conf and options.json
- start cromwell run via cloud-workflows gms/start.sh script. [Source here](https://github.com/griffithlab/cloud-workflows/blob/main/gms/start.sh)
- poll until that concludes using `gcloud describe` 
- pull artifacts like timing diagram and outputs json using gsutil
- pull outputs by outputs.json not a rest call to server

I have a couple outstanding questions for this but the work is done otherwise. 
- is there an info log level? I'm using debug write now but I'd prefer these actually be visible without full debug logging
- do the steps `preserve_results` and `process_outputs` expect the deeply nested cromwell tree or a flattened version? not entirely sure what's supposed to happen there but pull_outputs.py maintains the Cromwell nested structure so I think it's fine? 