### PR TITLE
Updates to support per-job containers when running with toil.

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Runner/Toil.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Runner/Toil.pm
@@ -1,0 +1,46 @@
+package Genome::Model::CwlPipeline::Runner::Toil;
+
+use strict;
+use warnings;
+
+use File::Spec;
+
+use Genome;
+
+class Genome::Model::CwlPipeline::Runner::Toil {
+    is => 'UR::Singleton',
+};
+
+sub version_exists {
+    my $class = shift;
+    my $version = shift;
+
+    my $allocation = Genome::Disk::Allocation->get(
+        allocation_path => File::Spec->join("toil", $version),
+        status => 'active',
+    );
+
+    return !! $allocation;
+}
+
+sub cwl_runner_wrapper_for_version {
+    my $class = shift;
+    my $version = shift;
+
+    my $allocation = Genome::Disk::Allocation->get(
+        allocation_path => File::Spec->join("toil", $version),
+        status => 'active',
+    );
+    unless ($allocation) {
+        $class->fatal_message('No toil version found for version %s', $version);
+    }
+
+    my $wrapper = File::Spec->join($allocation->absolute_path, 'toil-cwl-runner-wrapper.sh');
+    unless (-e $wrapper) {
+        $class->fatal_message('Wrapper script not found in %s for version %s', $allocation->absolute_path, $version);
+    }
+
+    return $wrapper;
+}
+
+1;


### PR DESCRIPTION
Any container used in the workflow must be capable of running python3 with glibc version of at least 2.16 so that toil's wrapper can run.  (This is similar to how Cromwell requires every image to have a bash shell so its wrapper can run.)  Python doesn't actually need to be installed--we have a copy we mount in the container so long as the shared libraries are compatible.