### PR TITLE
Add config for specifying the queue for interactive jobs.

### DIFF
--- a/etc/genome/spec/lsf_queue_interactive.yaml
+++ b/etc/genome/spec/lsf_queue_interactive.yaml
@@ -1,0 +1,5 @@
+# Specifies the LSF queue to submit interactive jobs to.
+---
+env: XGENOME_LSF_QUEUE_INTERACTIVE
+validators:
+    - LSFQueue

--- a/lib/perl/Genome/Model/Command/Submittable.pm
+++ b/lib/perl/Genome/Model/Command/Submittable.pm
@@ -30,6 +30,7 @@ sub _submit_jobs {
         cmd => $cmd,
         user_group => Genome::Config::get('lsf_user_group'),
         interactive => 1,
+        queue => Genome::Config::get('lsf_queue_interactive'),
     );
 
     return 1;

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -243,6 +243,8 @@ sub _dispatch_process {
 
     my $log_file_base = File::Spec->join($self->log_directory, 'process-%J');
 
+    local $ENV{LSF_DOCKER_NETWORK} = undef;
+
     my $job_id = Genome::Sys->bsub(
         queue => Genome::Config::get('lsf_queue_build_worker'),
         cmd => [qw(genome process run), $self->id],


### PR DESCRIPTION
We were relying on the fact that the default queue is interactive, which is not ideal!