### PR TITLE
Only modify tmp basedir if new location is writable.

### DIFF
--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -617,7 +617,7 @@ sub base_temp_directory {
     my $tmp_location = $ENV{'TMPDIR'} || File::Spec->tmpdir();
     if ($ENV{'LSB_JOBID'}) {
         my $lsf_possible_tempdir = sprintf("%s/%s.tmpdir", $tmp_location, $ENV{'LSB_JOBID'});
-        if (-d $lsf_possible_tempdir) {
+        if (-d -w $lsf_possible_tempdir) {
             $tmp_location = $lsf_possible_tempdir;
         }
     }


### PR DESCRIPTION
For some reason, some servers we're using create a doubly-nested LSF
tmpdir structure, and the inner one is r/w only by root.  In this case
they're already giving us the first level as $ENV{TMPDIR} so we can just
trust it anyway.  This code is still useful on our older cluster,
though, so not just removing it outright yet.

Is this the first instance of using perl 5.10 filetest stacking in our codebase? It might be :smile: