### PR TITLE
Use fully qualified domain name for database server.

### DIFF
--- a/.test-tracker.conf
+++ b/.test-tracker.conf
@@ -1,8 +1,8 @@
 ---
-db_host: gms-postgres
+db_host: gms-postgres.gsc.wustl.edu
 db_name: test_tracker
 db_schema: test_tracker
-db_dsn: 'dbi:Pg:dbname=test_tracker;host=gms-postgres;sslcert=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.crt;sslkey=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.pem;sslrootcert=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.server.crt'
+db_dsn: 'dbi:Pg:dbname=test_tracker;host=gms-postgres.gsc.wustl.edu;sslcert=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.crt;sslkey=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.pem;sslrootcert=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.server.crt'
 db_password: zIwWhT8qkzrhPm
 db_prefix: 'test_tracker.'
 db_user: test_tracker


### PR DESCRIPTION
Some hosts don't have a friendly search path configured, so this is a little more certain to work as expected.  This should help with some intermittent failures.