### PR TITLE
Consistently use Genome::Sys to test readability of files.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version1/VariantAnnotator.t
+++ b/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version1/VariantAnnotator.t
@@ -43,7 +43,7 @@ sub get_test_data {
 
     my $test_variants_file = $test_dir . "/variants.tsv";
     ok (-s $test_variants_file, "test variants file exists and has size at $test_variants_file");
-    ok (-r $test_variants_file, "test variants file is readable by the user running this test $test_variants_file");
+    ok (Genome::Sys->validate_file_for_reading($test_variants_file), "test variants file is readable by the user running this test $test_variants_file");
 
     my @variant_headers = variant_headers();
     my $variant_svr = Genome::Utility::IO::SeparatedValueReader->create(

--- a/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version2/BedToAnnotation.t
+++ b/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version2/BedToAnnotation.t
@@ -22,11 +22,11 @@ sub test_snvs{
 
     my $test_bed_file = $test_dir . "/snvs.bed";
     ok (-s $test_bed_file, "snv bed file exists and has size at $test_bed_file");
-    ok (-r $test_bed_file, "snv bed file is readable by the user running this test $test_bed_file");
+    ok (Genome::Sys->validate_file_for_reading($test_bed_file), "snv bed file is readable by the user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/snvs.annotation";
     ok (-s $annotation_file, "snv output file exists and has size at $annotation_file");
-    ok (-r $annotation_file, "snv variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "snv variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(
@@ -47,11 +47,11 @@ sub test_indels{
 
     my $test_bed_file = $test_dir . "/indels.bed";
     ok (-s $test_bed_file, "indel bed file exists and has size at $test_bed_file");
-    ok (-r $test_bed_file, "indel bed file is readable by the user running this test $test_bed_file");
+    ok (Genome::Sys->validate_file_for_reading($test_bed_file), "indel bed file is readable by the user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/indels.annotation";
     ok (-s $annotation_file, "indel output file exists and has size at $annotation_file");
-    ok (-r $annotation_file, "indel variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "indel variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(
@@ -71,11 +71,11 @@ sub test_nonsense {
 
     my $test_bed_file = $test_dir . '/nonsense.bed';
     ok(-s $test_bed_file, "nonsense bed file exists and has size at $test_bed_file");
-    ok(-r $test_bed_file, "nonsense bed file is readable by user running this test $test_bed_file");
+    ok(Genome::Sys->validate_file_for_reading($test_bed_file), "nonsense bed file is readable by user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/nonsense.annotation";
     ok (-z $annotation_file, "nonsense output file exists and has 0 size at $annotation_file");
-    ok (-r $annotation_file, "nonsense variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "nonsense variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(

--- a/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version2/VariantAnnotator.t
+++ b/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version2/VariantAnnotator.t
@@ -43,7 +43,7 @@ sub get_test_data {
 
     my $test_variants_file = $test_dir . "/variants.tsv";
     ok (-s $test_variants_file, "test variants file exists and has size at $test_variants_file");
-    ok (-r $test_variants_file, "test variants file is readable by the user running this test $test_variants_file");
+    ok (Genome::Sys->validate_file_for_reading($test_variants_file), "test variants file is readable by the user running this test $test_variants_file");
 
     my @variant_headers = variant_headers();
     my $variant_svr = Genome::Utility::IO::SeparatedValueReader->create(

--- a/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version3/BedToAnnotation.t
+++ b/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version3/BedToAnnotation.t
@@ -22,11 +22,11 @@ sub test_snvs{
 
     my $test_bed_file = $test_dir . "/snvs.bed";
     ok (-s $test_bed_file, "snv bed file exists and has size at $test_bed_file");
-    ok (-r $test_bed_file, "snv bed file is readable by the user running this test $test_bed_file");
+    ok (Genome::Sys->validate_file_for_reading($test_bed_file), "snv bed file is readable by the user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/snvs.annotation";
     ok (-s $annotation_file, "snv output file exists and has size at $annotation_file");
-    ok (-r $annotation_file, "snv variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "snv variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(
@@ -47,11 +47,11 @@ sub test_indels{
 
     my $test_bed_file = $test_dir . "/indels.bed";
     ok (-s $test_bed_file, "indel bed file exists and has size at $test_bed_file");
-    ok (-r $test_bed_file, "indel bed file is readable by the user running this test $test_bed_file");
+    ok (Genome::Sys->validate_file_for_reading($test_bed_file), "indel bed file is readable by the user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/indels.annotation";
     ok (-s $annotation_file, "indel output file exists and has size at $annotation_file");
-    ok (-r $annotation_file, "indel variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "indel variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(
@@ -73,11 +73,11 @@ sub test_extra_columns{
 
     my $test_bed_file = $test_dir . "/extra_columns.bed";
     ok (-s $test_bed_file, "extra_column bed file exists and has size at $test_bed_file");
-    ok (-r $test_bed_file, "extra_column bed file is readable by the user running this test $test_bed_file");
+    ok (Genome::Sys->validate_file_for_reading($test_bed_file), "extra_column bed file is readable by the user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/extra_columns.annotation";
     ok (-s $annotation_file, "extra_column output file exists and has size at $annotation_file");
-    ok (-r $annotation_file, "extra_column variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "extra_column variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(

--- a/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version3/VariantAnnotator.t
+++ b/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version3/VariantAnnotator.t
@@ -31,7 +31,7 @@ sub get_test_data {
 
     my $test_variants_file = $test_dir . "/variants.tsv";
     ok (-s $test_variants_file, "test variants file exists and has size at $test_variants_file");
-    ok (-r $test_variants_file, "test variants file is readable by the user running this test $test_variants_file");
+    ok (Genome::Sys->validate_file_for_reading($test_variants_file), "test variants file is readable by the user running this test $test_variants_file");
 
     my $none_annotations_file = $test_dir . "/none_annotations.tsv";
     ok (-s $none_annotations_file, "annotations with no filter file exists and has size");

--- a/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version4/BedToAnnotation.t
+++ b/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version4/BedToAnnotation.t
@@ -22,11 +22,11 @@ sub test_snvs{
 
     my $test_bed_file = $test_dir . "/snvs.bed";
     ok (-s $test_bed_file, "snv bed file exists and has size at $test_bed_file");
-    ok (-r $test_bed_file, "snv bed file is readable by the user running this test $test_bed_file");
+    ok (Genome::Sys->validate_file_for_reading($test_bed_file), "snv bed file is readable by the user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/snvs.annotation";
     ok (-s $annotation_file, "snv output file exists and has size at $annotation_file");
-    ok (-r $annotation_file, "snv variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "snv variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(
@@ -47,11 +47,11 @@ sub test_indels{
 
     my $test_bed_file = $test_dir . "/indels.bed";
     ok (-s $test_bed_file, "indel bed file exists and has size at $test_bed_file");
-    ok (-r $test_bed_file, "indel bed file is readable by the user running this test $test_bed_file");
+    ok (Genome::Sys->validate_file_for_reading($test_bed_file), "indel bed file is readable by the user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/indels.annotation";
     ok (-s $annotation_file, "indel output file exists and has size at $annotation_file");
-    ok (-r $annotation_file, "indel variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "indel variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(
@@ -73,11 +73,11 @@ sub test_extra_columns{
 
     my $test_bed_file = $test_dir . "/extra_columns.bed";
     ok (-s $test_bed_file, "extra_column bed file exists and has size at $test_bed_file");
-    ok (-r $test_bed_file, "extra_column bed file is readable by the user running this test $test_bed_file");
+    ok (Genome::Sys->validate_file_for_reading($test_bed_file), "extra_column bed file is readable by the user running this test $test_bed_file");
 
     my $annotation_file = $test_dir. "/extra_columns.annotation";
     ok (-s $annotation_file, "extra_column output file exists and has size at $annotation_file");
-    ok (-r $annotation_file, "extra_column variants file is readable by the user running this test $annotation_file");
+    ok (Genome::Sys->validate_file_for_reading($annotation_file), "extra_column variants file is readable by the user running this test $annotation_file");
 
     my ($output_fh, $output_file) = tempfile(UNLINK => 1);
     my $adaptor = $THIS_VERSION_ADAPTOR_SUBCLASS->create(

--- a/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version4/VariantAnnotator.t
+++ b/lib/perl/Genome/Model/Tools/Annotate/TranscriptVariants/Version4/VariantAnnotator.t
@@ -31,7 +31,7 @@ sub get_test_data {
 
     my $test_variants_file = $test_dir . "/variants.tsv";
     ok (-s $test_variants_file, "test variants file exists and has size at $test_variants_file");
-    ok (-r $test_variants_file, "test variants file is readable by the user running this test $test_variants_file");
+    ok (Genome::Sys->validate_file_for_reading($test_variants_file), "test variants file is readable by the user running this test $test_variants_file");
 
     my $none_annotations_file = $test_dir . "/none_annotations.tsv";
     ok (-s $none_annotations_file, "annotations with no filter file exists and has size");

--- a/lib/perl/Genome/Model/Tools/BioSamtools/AlignmentSummaryV2.pm
+++ b/lib/perl/Genome/Model/Tools/BioSamtools/AlignmentSummaryV2.pm
@@ -485,7 +485,7 @@ sub _verify_target_index {
 sub _open_sorted_bam {
     my $self = shift;
 
-    if (-f $self->bam_file && -r _) {
+    if (Genome::Sys->validate_file_for_reading($self->bam_file)) {
         my $bam_reader = Bio::DB::Bam->open( $self->bam_file );
         my $bam_header = $bam_reader->header;
         if ($bam_header->text =~ m/SO:coordinate/i) {


### PR DESCRIPTION
To handle non-POSIX permissions we need to not rely on the default behavior of -r.