### PR TITLE
Use the Genome::Sys method to get the java executable path.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/WorkFlow/FastqsToBam.pm
@@ -89,7 +89,7 @@ sub _fastqs_to_bam {
 
     my $output_bam_path = $self->output_path;
 
-    my @cmd = (qw(/gapp/x64linux/opt/java/jre/jre1.8.0_31/bin/java -Xmx16g -jar /gscmnt/gc2560/core/software/picard/2.18.25/picard.jar FastqToSam), 'O='. $output_bam_path, 'SM='. $self->library->sample->name, 'LB='. $self->library->name, 'RG='. UR::Object::Type->autogenerate_new_object_id_uuid, 'F1='. $fastqs[0]);
+    my @cmd = (Genome::Sys->java_executable_path('1.8'), qw(-Xmx16g -jar /gscmnt/gc2560/core/software/picard/2.18.25/picard.jar FastqToSam), 'O='. $output_bam_path, 'SM='. $self->library->sample->name, 'LB='. $self->library->name, 'RG='. UR::Object::Type->autogenerate_new_object_id_uuid, 'F1='. $fastqs[0]);
     if ( $fastqs[1] ) {
         $self->debug_message("Fastq 2: $fastqs[1]");
         push @cmd, 'F2='. $fastqs[1];


### PR DESCRIPTION
There is no `/gapp` on the new cluster, so use our config instead since we already have that mechanism for controlling where to look!