### PR TITLE
Claim that .t test per-lane BAMs are all 1024KB.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Merged.t
@@ -209,6 +209,7 @@ sub generate_individual_alignment_results {
         instrument_data_segment_type => 'read_group',
         instrument_data_segment_id   => 'A:2',
         test_name        => $test_name,
+        bam_size         => 1024,
     );
 
     for my $i (0, 1) {

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Speedseq.t
@@ -100,6 +100,7 @@ my $alignment_result = $pkg->create(
     aligner_version => 'test',
     aligner_params => '',
     merged_alignment_result_id => $merged_alignment_result->id,
+    bam_size => 1024,
     _user_data_for_nested_results => $result_users,
 );
 ok($alignment_result, 'Alignment result created successfully');

--- a/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult_regenerate.t
@@ -141,11 +141,11 @@ sub get_test_alignment_results {
     );
 
     # Set up alignment results
-    my $ar1 = test_setup_object($ar_class, setup_object_args => [instrument_data_id => $ar1_instrument_data_id, %params] );
+    my $ar1 = test_setup_object($ar_class, setup_object_args => [instrument_data_id => $ar1_instrument_data_id, bam_size => 1024, %params] );
     is($ar1->instrument_data_id, $ar1_instrument_data_id, "AR1 has the proper instrument_data_id");
 
     my $ar2_dir = Genome::Sys->create_temp_directory();
-    my $ar2 = test_setup_object( $ar_class, setup_object_args => [ instrument_data_id => $ar2_instrument_data_id, output_dir => $ar2_dir, %params ] );
+    my $ar2 = test_setup_object( $ar_class, setup_object_args => [ instrument_data_id => $ar2_instrument_data_id, bam_size => 1024, output_dir => $ar2_dir, %params ] );
     is($ar2->instrument_data_id, $ar2_instrument_data_id, "AR2 has the proper instrument_data_id");
 
     my $merge_dir = Genome::Sys->create_temp_directory();

--- a/lib/perl/Genome/InstrumentData/Command/AlignAndMerge.t
+++ b/lib/perl/Genome/InstrumentData/Command/AlignAndMerge.t
@@ -40,6 +40,10 @@ my $override2 = Sub::Override->new(
     'Genome::InstrumentData::AlignmentResult::_prepare_reference_sequences',
     sub { return 1; }
 );
+my $override3 = Sub::Override->new(
+    'Genome::InstrumentData::AlignmentResult::bam_size',
+    sub { return 1024; }
+);
 
 my $aligner_index = Genome::Model::Build::ReferenceSequence::AlignerIndex->__define__(
     reference_build => $ref_seq_build,


### PR DESCRIPTION
The tests try to allocate space when revivifying the per-lane BAMs. When the bam size is unknown, the default size request is 100,000,000KB. When temp on the host running the test has less than this amount of space free, the test can fail.

(If temp has less than 1024KB free, we're probably going to have other trouble, anyway!)