### PR TITLE
Some straggling test fixes

### DIFF
--- a/lib/perl/Genome/Model/Tools/DetectVariants2/MethRatio.t
+++ b/lib/perl/Genome/Model/Tools/DetectVariants2/MethRatio.t
@@ -17,6 +17,8 @@ use Genome::Test::Factory::SoftwareResult::User;
 
 Genome::Config::set_env('workflow_builder_backend', 'inline');
 
+plan skip_all => 'version 2.6 not available right now.';
+
 my $archos = `uname -a`;
 if ($archos !~ /64/) {
     plan skip_all => "Must run from 64-bit machine";


### PR DESCRIPTION
* Disable DV2 MethRatio test (by popular consensus that it isn't being used).
* FASTQ splitter properly checks it can write to the output directory it will use.