### PR TITLE
Add a tiebreaker in the sorting algorithm.

### DIFF
--- a/lib/perl/Genome/Model/Build-multiple-model-inputs.t
+++ b/lib/perl/Genome/Model/Build-multiple-model-inputs.t
@@ -170,5 +170,5 @@ is_deeply(\@input_builds, \@expected_inputs,'user-defined input build was copied
 done_testing;
 
 sub by_date {
-    $a->date_scheduled cmp $b->date_scheduled || $a->date_completed cmp $b->date_completed
+    $a->date_scheduled cmp $b->date_scheduled || $a->date_completed cmp $b->date_completed || $a->id cmp $b->id
 }


### PR DESCRIPTION
If perchance both items have identical timestamps, use ID as a tiebreaker so the ordering is still consistent between them.

This test has been failing intermittently so hopefully this helps with that!