### PR TITLE
For test stability, have each build created at a different time.

### DIFF
--- a/lib/perl/Genome/Model/Build/Command/AbandonPriorBuildsWithStatus.t
+++ b/lib/perl/Genome/Model/Build/Command/AbandonPriorBuildsWithStatus.t
@@ -24,6 +24,7 @@ for (('Failed')x3, 'Succeeded', 'Failed', ('Succeeded')x2, 'Scheduled', ('Succee
         model_id => $model->id,
         status => $_,
     );
+    sleep 2; #our build timestamps only have 1s resolution so let's not make them all at the same time
 }
 is(scalar(@{[$model->builds]}), 11, 'created 11 test builds');
 


### PR DESCRIPTION
It is true that some of our commands will fail if multiple builds were
created within the same second.  There's locking in place that prevents
that from happening in practice, so this test was failing for an edge
condition we don't normall encounter.  (If we truly have multiple
simultaneous builds in the same status, picking one arbitrarily to
execute is the "right" behavior here, anyway.)