### PR TITLE
Use mgibio image for cloudize-workflows in cromwell_gcp workflows

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -231,7 +231,7 @@ sub run_cromwell_gcp {
     # Cloudize workflow
     #
     my $cloud_yaml = $yaml; $cloud_yaml =~ s/.ya?ml/_cloud.json/;
-    my $lsb_sub_guard = Genome::Config::set_env('lsb_sub_additional', 'docker(jackmaruska/cloudize-workflow:1.3.1)');
+    my $lsb_sub_guard = Genome::Config::set_env('lsb_sub_additional', 'docker(mgibio/cloudize-workflow:1.1.0)');
     delete local $ENV{BOTO_CONFIG};
 
     Genome::Sys::LSF::bsub::bsub(


### PR DESCRIPTION
We're moving cloudize-workflows image from my personal dockerhub to the mgibio dockerhub. The contents are still the same repo here: https://github.com/griffithlab/cloud-workflows/