### PR TITLE
fixing pull_outputs command for cloud workflows

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -337,8 +337,7 @@ sub run_cromwell_gcp {
             cmd => [
                 'python3', '/opt/scripts/pull_outputs.py',
                 "--outputs-dir=$results_dir",
-                "--outputs-file=$outputs_json",
-                "--dir-structure=DEEP"
+                "--outputs-file=$outputs_json"
             ] );
     } else {
         $self->fatal_message("Build did not generate output files. See $logdir");


### PR DESCRIPTION
Removing deep option, as it no longer exists in the pull output script