### PR TITLE
Add multithreading and suppress output

### DIFF
--- a/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.pm
+++ b/lib/perl/Genome/ProcessingProfile/Command/Create/CwlPipeline.pm
@@ -74,7 +74,7 @@ sub execute {
             cmd => [
                 '/usr/bin/python3',
                 '/usr/bin/gsutil/gsutil',
-                'cp', '-r',
+                '-m', '-q', 'cp', '-r',
                 $cwl_directory,
                 Genome::Config::get('gcp_config_bucket') . $pp_dirname,
             ],


### PR DESCRIPTION
Add the `-m` flag to run the upload in parallel and reduce upload time, and add the `-q` flag to prevent listing every uploaded file (currently over 250).