### PR TITLE
Fix typo

### DIFF
--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -601,7 +601,7 @@ EOCONFIG
         $config .= <<'EOCONFIG'
         exit-code-timeout-seconds = 600
 
-        filesysytems {
+        filesystems {
           local {
             caching {
               duplication-strategy: [


### PR DESCRIPTION
Instead of silently defaulting to md5 hashing, this should hopefully speed up workflows by actually using `xxh64` instead.