### PR TITLE
Centralize checking for the existence of eligible LSF hosts.

### DIFF
--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwamem.pm
@@ -41,12 +41,6 @@ sub required_rusage {
 
     my $queue = Genome::Config::get('lsf_queue_alignment_default');
 
-    my $host_groups;
-    $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
-    $host_groups =~ s/\/\s+/\ /g;
-    $host_groups =~ s/^HOSTS:\s+//;
-    $host_groups =~ s/\+\d+//g;
-
     my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $tmp_gb] span[hosts=1]";
     my $rusage  = "rusage[mem=$mem_mb, gtmp=$tmp_gb]";
     my $options = "-M $mem_kb -n $cpus -q $queue";
@@ -56,14 +50,13 @@ sub required_rusage {
     #check to see if our resource requests are feasible (This uses "maxmem" to check theoretical availability)
     #factor of four is based on current six jobs per host policy this should be revisited later
     my $select_check = "select[ncpus >= $cpus && maxmem >= " . ($mem_mb * 4) . " && maxgtmp >= $tmp_gb] span[hosts=1]";
-    my $select_cmd = "bhosts -R '$select_check' $host_groups | grep ^HOST";
 
-    my @selected_blades = qx($select_cmd);
+    my $hosts_found = Genome::Sys->eligible_hosts($select_check, $queue);
 
-    if (@selected_blades) {
+    if ($hosts_found) {
         return $required_usage;
     } else {
-        die $class->error_message("Failed to find hosts that meet resource requirements ($required_usage). [Looked with `$select_cmd`]");
+        die $class->error_message("Failed to find hosts that meet resource requirements ($required_usage).");
     }
 }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/BwamemStream.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/BwamemStream.pm
@@ -44,12 +44,6 @@ sub required_rusage {
 
     my $queue = Genome::Config::get('lsf_queue_alignment_default');
 
-    my $host_groups;
-    $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
-    $host_groups =~ s/\/\s+/\ /g;
-    $host_groups =~ s/^HOSTS:\s+//;
-    $host_groups =~ s/\+\d+//g;
-
     my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $tmp_gb] span[hosts=1]";
     my $rusage  = "rusage[mem=$mem_mb, gtmp=$tmp_gb]";
     my $options = "-M $mem_kb -n $cpus -q $queue";
@@ -57,14 +51,13 @@ sub required_rusage {
     my $required_usage = "-R '$select $rusage' $options";
 
     my $select_check = "select[ncpus >= $cpus && maxmem >= $mem_mb && maxgtmp >= $tmp_gb] span[hosts=1]";
-    my $select_cmd = "bhosts -R '$select_check' $host_groups | grep ^HOST";
 
-    my @selected_blades = qx($select_cmd);
+    my $hosts_found = Genome::Sys->eligible_hosts($select_check, $queue);
 
-    if (@selected_blades) {
+    if ($hosts_found) {
         return $required_usage;
     } else {
-        die $class->error_message("Failed to find hosts that meet resource requirements ($required_usage). [Looked with `$select_cmd`]");
+        die $class->error_message("Failed to find hosts that meet resource requirements ($required_usage).");
     }
 }
 

--- a/lib/perl/Genome/InstrumentData/AlignmentResult/Bwasw.pm
+++ b/lib/perl/Genome/InstrumentData/AlignmentResult/Bwasw.pm
@@ -41,12 +41,6 @@ sub required_rusage {
     my $user = getpwuid($<);
     my $queue = Genome::Config::get('lsf_queue_alignment_default');
 
-    my $host_groups;
-    $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
-    $host_groups =~ s/\/\s+/\ /;
-    $host_groups =~ s/^HOSTS:\s+//;
-    $host_groups =~ s/\+\d+//g;
-
     my $select  = "select[ncpus >= $cpus && mem >= $mem_mb && gtmp >= $tmp_gb] span[hosts=1]";
     my $rusage  = "rusage[mem=$mem_mb, gtmp=$tmp_gb]";
     my $options = "-M $mem_kb -n $cpus -q $queue";
@@ -56,14 +50,12 @@ sub required_rusage {
     #check to see if our resource requests are feasible (This uses "maxmem" to check theoretical availability)
     #factor of four is based on current six jobs per host policy this should be revisited later
     my $select_check = "select[ncpus >= $cpus && maxmem >= " . ($mem_mb * 4) . " && maxgtmp >= $tmp_gb] span[hosts=1]";
-    my $select_cmd = "bhosts -R '$select_check' $host_groups | grep ^HOST";
+    my $hosts_found = Genome::Sys->eligible_hosts($select_check, $queue);
 
-    my @selected_blades = qx($select_cmd);
-
-    if (@selected_blades) {
+    if ($hosts_found) {
         return $required_usage;
     } else {
-        die $class->error_message("Failed to find hosts that meet resource requirements ($required_usage). [Looked with `$select_cmd`]");
+        die $class->error_message("Failed to find hosts that meet resource requirements ($required_usage).");
     }
 }
 

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -1950,6 +1950,24 @@ sub touch {
     return 1;
 }
 
+sub eligible_hosts {
+    my ($class, $resource_request, $queue) = @_;
+
+    my $host_groups;
+    $host_groups = qx(bqueues -l $queue | grep ^HOSTS:);
+    return unless $host_groups;
+
+    chomp $host_groups;
+    $host_groups =~ s/\+\d+//g;
+    $host_groups =~ s/\/\s?/\ /g;
+    $host_groups =~ s/^HOSTS:\s+//;
+
+    my $select_cmd = "bhosts -R '$resource_request' $host_groups | grep ^HOST";
+    my @selected_blades = qx($select_cmd);
+
+    return @selected_blades ? 1 : 0;
+}
+
 1;
 
 __END__


### PR DESCRIPTION
There were a few competing implementations around for this; better that we have one that we can fix up when/if issues arise.

(A lot of this seems like a good candidate for outright deprecation and removal at this point... but this PR is a quick change to get tests to pass again for now.)