### PR TITLE
Skip Memcache.t that depends on production memcache.

### DIFF
--- a/lib/perl/Genome/Memcache.t
+++ b/lib/perl/Genome/Memcache.t
@@ -9,16 +9,20 @@ use Test::More tests => 4;
 
 use_ok('Genome::Memcache');
 
-my $m = Genome::Memcache->server();
-ok($m , 'server object');
+SKIP: {
+    skip "should rewrite test to not depend on production memcached server", 3;
 
-my $key = 'memcache.t';
-    if (my $then = $m->get($key)) {
-        diag('deleteing previous test key from: ' . $then);
-        $m->delete($key);
-    }
+    my $m = Genome::Memcache->server();
+    ok($m , 'server object');
 
-my $now = UR::Context->current->now();
-ok($m->set($key, $now, 10), 'setting cache item');
+    my $key = 'memcache.t';
+        if (my $then = $m->get($key)) {
+            diag('deleteing previous test key from: ' . $then);
+            $m->delete($key);
+        }
 
-cmp_ok($m->get($key), 'eq', $now, "getting cache item $now");
+    my $now = UR::Context->current->now();
+    ok($m->set($key, $now, 10), 'setting cache item');
+
+    cmp_ok($m->get($key), 'eq', $now, "getting cache item $now");
+}


### PR DESCRIPTION
It's also not really safe for concurrent test runs!

Realistically we're more likely to remove this than to fix it, since memcache was used for the perl-generated webviews but we have moved on to genome/spectacle now.