### PR TITLE
Add done_testing so that test-tracker handles skip properly.

### DIFF
--- a/lib/perl/Genome/Memcache.t
+++ b/lib/perl/Genome/Memcache.t
@@ -26,3 +26,5 @@ SKIP: {
 
     cmp_ok($m->get($key), 'eq', $now, "getting cache item $now");
 }
+
+done_testing;


### PR DESCRIPTION
Also seen in #1980.  (As with that one, the individual PR test will work either way so it only affects the merged tests.)