### PR TITLE
Only tie read-only since we don't need to write this file.

### DIFF
--- a/lib/perl/Genome/InstrumentData/Command/Import/Inputs/Factory.pm
+++ b/lib/perl/Genome/InstrumentData/Command/Import/Inputs/Factory.pm
@@ -11,6 +11,7 @@ require List::MoreUtils;
 use Params::Validate qw( :types );
 use Text::CSV;
 use Tie::File;
+use Fcntl;
 
 class Genome::InstrumentData::Command::Import::Inputs::Factory {
     has_optional => {
@@ -136,7 +137,8 @@ sub _load_file {
 
     die $self->error_message('File (%s) is empty!', $file) if not -s $file;
     $self->file($file);
-    tie my @lines, 'Tie::File', $file;
+    tie my @lines, 'Tie::File', $file, mode => O_RDONLY
+        or $self->fatal_message('Failed to load file %s: %s', $file, $!);
     $self->_lines(\@lines);
     $parser->parse($lines[0])
         or $self->fatal_message('Failed to parse header line! %s', $lines[0]);


### PR DESCRIPTION
Also, report the error when the `tie` fails instead of mysteriously failing to parse the header later.

(The test files are mounted read-only now, so the tests that covered this would fail on the `tie` with a `Read-only file system` message.  Users should be able to import instrument data with a read-only input TSV anyway.)