### PR TITLE
Avoid attempting to connect to OLTP database

### DIFF
--- a/lib/perl/Genome/Site/TGI/Project/View/Status/Html.t
+++ b/lib/perl/Genome/Site/TGI/Project/View/Status/Html.t
@@ -5,7 +5,8 @@ use warnings;
 
 use above "Genome";
 
-use Test::More tests => 6;
+use Test::More skip_all => 'requires connection to LIMS db';
+#use Test::More tests => 6;
 
 use_ok('Genome::Site::TGI::Project::View::Status::Html') or die "test cannot continue...";
 

--- a/lib/perl/Genome/Site/TGI/Project/View/Status/Xml.t
+++ b/lib/perl/Genome/Site/TGI/Project/View/Status/Xml.t
@@ -5,7 +5,8 @@ use warnings;
 
 use above "Genome"; 
 
-use Test::More tests => 6;
+use Test::More skip_all => 'requires connection to LIMS db';
+#use Test::More tests => 6;
 use Genome::Site::TGI::Project;
 
 use_ok('Genome::Site::TGI::Project::View::Status::Xml') or die "test cannot continue...";

--- a/lib/perl/Genome/Sys.pm
+++ b/lib/perl/Genome/Sys.pm
@@ -6,6 +6,7 @@ use warnings;
 use Genome;
 use Genome::Carp qw(croakf);
 use Genome::Utility::File::Mode qw(mode);
+use Genome::Utility::List qw();
 
 use autodie qw(chown);
 use Carp;
@@ -1788,10 +1789,12 @@ sub capture {
 sub disconnect_default_handles {
     my $class = shift;
 
-    for my $ds (qw(Genome::DataSource::GMSchema Genome::DataSource::Oltp)) {
-        if($ds->has_default_handle) {
-            $class->debug_message("Disconnecting $ds default handle.");
-            $ds->disconnect_default_dbh();
+    for my $ds (UR::DataSource->is_loaded) {
+        if (Genome::Utility::List::in( $ds->class, (qw(Genome::DataSource::GMSchema Genome::DataSource::Oltp)))) {
+            if ($ds->has_default_handle) {
+                $class->debug_message("Disconnecting $ds default handle.");
+                $ds->disconnect_default_dbh();
+            }
         }
     }
 

--- a/lib/perl/Genome/WorkOrder.t
+++ b/lib/perl/Genome/WorkOrder.t
@@ -6,7 +6,7 @@ use warnings;
 use above 'Genome';
 
 use Data::Dumper 'Dumper';
-use Test::More;
+use Test::More skip_all => 'requires connection to LIMS db';
 
 use_ok('Genome::WorkOrder');
 


### PR DESCRIPTION
This fixes up `Sys.pm` to be more judicious about which database sources it tries to disconnect to avoid inadvertently processing connection info to a datasource that wasn't connected.

This also disables tests that depend on an OLTP connection.  Still holding off on outright removing modules that depend on it in case we need to refer back to the database dump later.