### PR TITLE
Retry postgres connections for up to 90 seconds.

### DIFF
--- a/lib/perl/Genome/Site/TGI.pm
+++ b/lib/perl/Genome/Site/TGI.pm
@@ -48,6 +48,8 @@ use Genome::Site::TGI::LegacyTime;
 use Genome::Sys;
 use Genome::Site::TGI::Extension::Sys;      # extensions to Genome::Sys
 
+use DBIx::RetryConnect Pg => sub { return {total_delay => 90} };
+
 BEGIN {
     unless ($ENV{UR_DBI_NO_COMMIT}) {
         require Genome::Site::TGI::Extension::Logger;


### PR DESCRIPTION
We sometimes get our TCP connection failing trying to connect, so let's try harder to successfully connect.  (This depends on genome/docker_genome_perl_environment#39 to work on our cluster.  Which is to say that after this is merged, any builds that want to take advantage will need to update their docker images.)