### PR TITLE
slurm support for running cromwell workflows

### DIFF
--- a/etc/genome/spec/job_dispatch_backend.yaml
+++ b/etc/genome/spec/job_dispatch_backend.yaml
@@ -1,0 +1,3 @@
+---
+env: XGENOME_JOB_DISPATCH_BACKEND
+default_value: lsf

--- a/etc/genome/spec/usage_log_db_server.yaml
+++ b/etc/genome/spec/usage_log_db_server.yaml
@@ -1,0 +1,5 @@
+# The 'usage_log_db_server' configuration variable holds database server
+# connection details for the usage_log database.  Its value is used to build the
+# DBI connection string after the DBI driver name.
+--- 
+env: XGENOME_USAGE_LOG_DB_SERVER

--- a/lib/perl/Genome/ConfigValidator/LSFQueue.pm
+++ b/lib/perl/Genome/ConfigValidator/LSFQueue.pm
@@ -9,8 +9,16 @@ with qw(Genome::ConfigValidatorBase);
 
 sub check {
     my ($self, $value) = @_;
-    system(qq(bqueues $value 1> /dev/null 2>&1));
-    return $? == 0;
+    my $jdb = Genome::Config::get('job_dispatch_backend');
+    if ($jdb eq 'lsf') {
+        system(qq(bqueues $value 1> /dev/null 2>&1));
+        return $? == 0;
+    } elsif ($jdb eq 'slurm') {
+        system(qq(scontrol show partition $value 1> /dev/null 2>&1));
+        return $? == 0;
+    } else {
+        die 'unknown job dispatch backend';
+    }
 }
 
 sub message {

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -1257,7 +1257,7 @@ sub _get_job {
     if ($backend eq 'lsf') {
         require Genome::Sys::LSF::JobIterator;
     } elsif ($backend eq 'slurm') {
-        $arg = "--job $job_id";
+        $arg = "--job $job_id,$job_id"; #passing a list prevents squeue from erroring when job not found
         require Genome::Sys::SLURM::JobIterator;
     } else {
         $self->fatal_message('unknown job dispatch backend: %s', $backend);

--- a/lib/perl/Genome/Model/Build.pm
+++ b/lib/perl/Genome/Model/Build.pm
@@ -20,6 +20,7 @@ use Date::Manip;
 use Genome::Sys::LSF::bsub qw();
 use Genome::Utility::Email;
 use Genome::Utility::Vcf;
+use Genome::Utility::List qw();
 
 require Scope::Guard;
 
@@ -1200,9 +1201,14 @@ sub stop {
 sub _kill_job {
     my ($self, $job) = @_;
 
-    Genome::Sys->shellcmd(
-        cmd => 'bkill '.$job->{Job},
-    );
+    my $backend = Genome::Config::get('job_dispatch_backend') || 'lsf';
+    if ($backend eq 'slurm') {
+        Genome::Sys->shellcmd(cmd => ['scancel', $job->{Job}]);
+    } elsif( $backend eq 'lsf') {
+        Genome::Sys->shellcmd(cmd => ['bkill', $job->{Job}]);
+    } else {
+        $self->fatal_message('Unable to resume job for unknown backend: %s', $backend);
+    }
 
     my $i = 0;
     do {
@@ -1215,7 +1221,7 @@ sub _kill_job {
             $self->error_message("Build master job did not die after 60 seconds.");
             return 0;
         }
-    } while ($job && ($job->{Status} ne 'EXIT' && $job->{Status} ne 'DONE'));
+    } while ($job && !Genome::Utility::List::in($job->{Status}, 'EXIT', 'DONE', 'COMPLETED', 'EXITED', 'CANCELLED'));
 
     return 1;
 }
@@ -1235,7 +1241,7 @@ sub _get_running_master_lsf_job {
     my $job = $self->_get_job($job_id);
     return if not defined $job;
 
-    if ( $job->{Status} eq 'EXIT' or $job->{Status} eq 'DONE' ) {
+    if ( Genome::Utility::List::in($job->{Status}, 'EXIT', 'DONE', 'COMPLETED', 'EXITED', 'CANCELLED') ) {
         return;
     }
 
@@ -1243,12 +1249,22 @@ sub _get_running_master_lsf_job {
 }
 
 sub _get_job {
-    use Genome::Sys::LSF::JobIterator;
     my $self = shift;
     my $job_id = shift;
 
+    my $backend = Genome::Config::get('job_dispatch_backend') || 'lsf';
+    my $arg = $job_id;
+    if ($backend eq 'lsf') {
+        require Genome::Sys::LSF::JobIterator;
+    } elsif ($backend eq 'slurm') {
+        $arg = "--job $job_id";
+        require Genome::Sys::SLURM::JobIterator;
+    } else {
+        $self->fatal_message('unknown job dispatch backend: %s', $backend);
+    }
+
     my @jobs = ();
-    my $iter = Job::Iterator->new($job_id);
+    my $iter = Job::Iterator->new($arg);
     while (my $job = $iter->next) {
         push @jobs, $job;
     }

--- a/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
+++ b/lib/perl/Genome/Model/CwlPipeline/Command/Run.pm
@@ -185,6 +185,8 @@ sub run_cromwell {
     #cromwell relies on reading the output from bsub
     delete local $ENV{BSUB_QUIET};
 
+    local $ENV{ENROOT_CACHE_PATH} = File::Spec->join($tmp_dir, '.enroot_cache');
+
     my $config_file = $self->_generate_cromwell_config($tmp_dir, $results_dir);
     my $labels_file = $self->_generate_cromwell_labels;
 
@@ -521,7 +523,23 @@ sub _generate_cromwell_config {
 include required(classpath("application"))
 
 backend {
-  default = "LSF"
+EOCONFIG
+    ;
+
+    my $job_dispatch_backend = Genome::Config::get('job_dispatch_backend');
+    if ($job_dispatch_backend eq 'lsf') {
+        $config .= <<'EOCONFIG';
+    default = "LSF"
+EOCONFIG
+    } elsif ($job_dispatch_backend eq 'slurm') {
+        $config .= <<'EOCONFIG';
+    default = "SLURM"
+EOCONFIG
+    } else {
+        $self->fatal_message('Unknown job dispatch backend: %s', $job_dispatch_backend);
+    }
+
+    $config .= <<'EOCONFIG'
   providers {
     LSF {
       actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
@@ -552,10 +570,13 @@ EOCONFIG
         -cwd ${cwd} \
 EOCONFIG
     ;
+
+    my ($slurm_primary_docker_image) = $primary_docker_image =~ m/docker\(.+\)/;
+
     $config .= <<EOCONFIG
         -o /dev/null \\
         -e $log_dir/cromwell-%J.err \\
-        -a '$primary_docker_image' \\
+        -a '$slurm_primary_docker_image' \\
         -g '$job_group' \\
         -G '$user_group' \\
 EOCONFIG
@@ -609,6 +630,116 @@ EOCONFIG
         job-id-regex = "Job <(\\d+)>.*"
 EOCONFIG
 ;
+    $config .= <<EOCONFIG
+        root = "$tmp_dir/cromwell-executions"
+EOCONFIG
+;
+    if(Genome::Config::get('cromwell_call_caching')) {
+        $config .= <<'EOCONFIG'
+        exit-code-timeout-seconds = 600
+
+        filesystems {
+          local {
+            caching {
+              duplication-strategy: [
+                "hard-link", "soft-link", "copy"
+              ]
+              hashing-strategy: "xxh64"
+              fingerprint-size: 10485760
+              check-sibling-md5: false
+            }
+          }
+        }
+EOCONFIG
+;
+    }
+
+    $config .= <<'EOCONFIG'
+      }
+    }
+
+    SLURM {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+        runtime-attributes = """
+        Int cpu = 1
+        Int memory_mb = 4096
+        String? docker
+EOCONFIG
+    ;
+    $config .= <<EOCONFIG
+        String queue = "${default_queue}"
+EOCONFIG
+    ;
+    $config .= <<'EOCONFIG'
+        """
+        submit = """
+        sbtach \
+        -J ${job_name} \
+        -cwd ${cwd} \
+EOCONFIG
+    ;
+
+
+    $config .= <<EOCONFIG
+        -o /dev/null \\
+        -e $log_dir/cromwell-%J.err \\
+        -A '$user_group' \\
+        --container-image '$primary_docker_image' \\
+EOCONFIG
+        ;
+    if ($docker_volumes) {
+        my $slurm_docker_volumes = $docker_volumes;
+        $slurm_docker_volumes =~ s/ /,/g;
+        $config .= <<EOCONFIG
+        --container-mounts '$slurm_docker_volumes' \\
+EOCONFIG
+        ;
+    }
+    $config .= <<'EOCONFIG'
+        -p '${queue}' \
+        --mem ${memory_mb} \
+        -N 1 \
+        -n 1 \
+        -c ${cpu} \
+        --wrap "/bin/bash ${script}"
+        """
+
+        submit-docker = """
+        unset SLURM_SPANK__SLURM_SPANK_OPTION_pyxis_container_env
+        unset SLURM_SPANK__SLURM_SPANK_OPTION_pyxis_container_image
+        unset PYXIS_CONTAINER_IMAGE
+        sbatch \
+        -J ${job_name} \
+        -D ${cwd} \
+EOCONFIG
+    ;
+
+    my $slurm_vol = $vol;
+    $slurm_vol =~ s/ /,/g;
+
+    $config .= <<ECONFIG
+        -o /dev/null \\
+        -e $log_dir/cromwell-%J.err \\
+        -A '$user_group' \\
+        --container-mounts '$slurm_vol' \\
+ECONFIG
+    ;
+    $config .= <<'EOCONFIG'
+        -p ${queue} \
+        --container-image '${docker}' \
+        -N 1 \
+        -n 1 \
+        -c ${cpu} \
+        --mem ${memory_mb} \
+        --wrap "/bin/bash ${script}"
+        """
+        kill = "scancel ${job_id}"
+        kill-docker = "scancel ${job_id}"
+        check-alive = "squeue -j ${job_id}"
+        job-id-regex = "Submitted batch job (\\d+).*"
+EOCONFIG
+    ;
     $config .= <<EOCONFIG
         root = "$tmp_dir/cromwell-executions"
 EOCONFIG

--- a/lib/perl/Genome/Process.pm
+++ b/lib/perl/Genome/Process.pm
@@ -263,7 +263,14 @@ sub _dispatch_process {
     $self->lsf_job_id($job_id);
     Genome::Sys::CommitAction->create(
         on_commit => sub {
-            Genome::Sys->shellcmd(cmd => ['bresume', $job_id]);
+            my $backend = Genome::Config::get('job_dispatch_backend') || 'lsf';
+            if ($backend eq 'slurm') {
+                Genome::Sys->shellcmd(cmd => ['scontrol', 'release', $job_id]);
+            } elsif( $backend eq 'lsf') {
+                Genome::Sys->shellcmd(cmd => ['bresume', $job_id]);
+            } else {
+                $self->fatal_message('Unable to resume job for unknown backend: %s', $backend);
+            }
         },
     );
 

--- a/lib/perl/Genome/Site.pm
+++ b/lib/perl/Genome/Site.pm
@@ -9,7 +9,7 @@ BEGIN {
 
 use Carp qw(croak);
 use File::Spec qw();
-use Sys::Hostname qw(hostname);
+use Net::Domain qw(hostfqdn);
 use UR::Util qw();
 use Module::Runtime qw(require_module);
 
@@ -44,7 +44,7 @@ sub site_pkg {
 
 sub site_dirs {
     # look for a config module matching all or part of the hostname
-    my $hostname = hostname();
+    my $hostname = hostfqdn();
     my @hwords = map { s/-/_/g; $_ } reverse split(/\./, $hostname);
 }
 

--- a/lib/perl/Genome/Site/TGI/UsageLog.pm
+++ b/lib/perl/Genome/Site/TGI/UsageLog.pm
@@ -60,7 +60,7 @@ sub record_usage {
     }
 }
 
-sub dsn { 'dbi:Pg:dbname=genome_usage;host=gms-postgres.gsc.wustl.edu;sslcert=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.crt;sslkey=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.pem;sslrootcert=/gscmnt/gc2560/core/gms-database-certs/gms-postgres.server.crt' }
+sub dsn { Genome::Config::get('usage_log_db_server') }
 sub db_username { Genome::Config::get('usage_log_db_username') }
 sub db_password { Genome::Config::get('usage_log_db_password') }
 sub db_opts { { AutoCommit => 1, PrintError => 0, RaiseError => 0 } }

--- a/lib/perl/Genome/Site/cluster/cm.pm
+++ b/lib/perl/Genome/Site/cluster/cm.pm
@@ -1,0 +1,17 @@
+package Genome::Site::cluster::cm;
+use Genome::Site::TGI;
+1;
+
+=pod
+
+=head1 NAME
+
+Genome::Config::edu::cluster::cm - WU TGI host configuration (temporary)
+
+=head1 SYNOPSIS
+
+Ensures that Genome::Site::TGI is used by all *.cm.cluster hosts until
+their FQDN is properly updated to ris.wustl.edu.
+
+=cut
+

--- a/lib/perl/Genome/Sys/LSF/bsub.pm
+++ b/lib/perl/Genome/Sys/LSF/bsub.pm
@@ -8,6 +8,7 @@ use Exporter qw(import);
 use Params::Validate qw(:types);
 use List::MoreUtils qw(any);
 use Genome::Sys::LSF::ResourceParser qw();
+use Genome::Sys::SLURM::sbatch qw();
 use File::Spec qw();
 
 our @EXPORT = qw(bsub);
@@ -72,7 +73,14 @@ sub run {
 }
 
 sub bsub {
-    return run('bsub', @_);
+    my $backend = Genome::Config::get('job_dispatch_backend') || 'lsf';
+    if ($backend eq 'slurm') {
+        return Genome::Sys::SLURM::sbatch::sbatch(@_);
+    } elsif ($backend eq 'lsf') {
+        return run('bsub', @_);
+    } else {
+        die "Unknown job dispatch backend: $backend";
+    }
 }
 
 sub args_builder {

--- a/lib/perl/Genome/Sys/SLURM/JobIterator.pm
+++ b/lib/perl/Genome/Sys/SLURM/JobIterator.pm
@@ -1,0 +1,56 @@
+package Genome::Sys::SLURM::JobIterator;
+
+use strict;
+use warnings;
+
+package Job::Iterator;
+
+sub new {
+    my $class = shift;
+    my $opts = shift || '';
+    open my $f, "squeue -O '" . join(":\t,", qw(JOBID PARTITION ACCOUNT USERNAME STATE)) . ":' " . $opts . ' |';
+    my $headers = readline($f);
+    chomp $headers;
+    return bless[ $f, [split "\t", $headers]], $class;
+}
+
+sub next {
+    my $self = shift;
+
+    my $line = readline($self->[0]);
+    return unless defined $line;
+
+    chomp $line;
+    return Job->new($self->[1], $line);
+}
+
+package Job;
+
+sub new {
+    my $class = shift;
+    my $headers = shift;
+    my $line = shift;
+
+    my @fields = split("\t", $line);
+
+    my %data;
+    for my $i (0..(scalar(@fields)-1)) {
+        $data{ $headers->[$i] } = $fields[$i];
+    }
+
+    #for compatibility
+    $data{Job} = $data{JOBID};
+    $data{Status} = $data{STATE};
+
+    return bless \%data, $class;
+}
+
+sub started_on {
+    die('started_on unimplemented for slurm iterator');
+}
+
+sub events {
+    die('events unimplemented for slurm iterator');
+}
+
+1;

--- a/lib/perl/Genome/Sys/SLURM/sbatch.pm
+++ b/lib/perl/Genome/Sys/SLURM/sbatch.pm
@@ -1,0 +1,293 @@
+package Genome::Sys::SLURM::sbatch;
+
+use strict;
+use warnings;
+
+use Genome::Sys;
+use Exporter qw(import);
+use Params::Validate qw(:types);
+
+our @EXPORT = qw(sbatch);
+our @EXPORT_OK = qw(sbatch);
+
+sub run {
+    my $executable = shift;
+    my @args = args_builder(@_);
+
+    my %args = @_;
+
+    if (ref($executable) ne 'ARRAY') {
+        $executable = [$executable];
+    }
+
+    my $docker_image = Genome::Config::get('lsb_sub_additional') || $ENV{LSB_SUB_ADDITIONAL} || $ENV{PYXIS_CONTAINER_IMAGE};
+    if( (my $image_name) = $docker_image =~ /^docker\d?\((.*?)\)/) {
+        $docker_image = $image_name;
+    }
+    local $ENV{LSB_SUB_ADDITIONAL} = $docker_image;
+    local $ENV{PYXIS_CONTAINER_IMAGE} = $docker_image;
+
+    if (!defined $ENV{LSF_DOCKER_PRESERVE_ENVIRONMENT} or $ENV{LSF_DOCKER_PRESERVE_ENVIRONMENT} eq 'true') {
+        unshift @args,
+            '--container-env=PATH'; #most env is getting preserved automatically but this one needs special care
+    }
+
+    my $docker_volumes = $ENV{LSF_DOCKER_VOLUMES} || $ENV{PYXIS_CONTAINER_MOUNTS} || $ENV{APPTAINER_BIND} || '';
+    $docker_volumes =~ s/ /,/g;
+    if (my $config_docker_volumes = Genome::Config::get('docker_volumes')) {
+        $config_docker_volumes =~ s/ /,/g;
+        if ($docker_volumes) {
+            $docker_volumes .= ',' . $config_docker_volumes;
+        } else {
+            $docker_volumes = $config_docker_volumes;
+        }
+    }
+    local $ENV{LSF_DOCKER_VOLUMES} = $docker_volumes if $docker_volumes;
+    local $ENV{PYXIS_CONTAINER_MOUNTS} = $docker_volumes if $docker_volumes;
+
+    if (exists $args{interactive} and $args{interactive}) {
+        if($executable->[0] eq 'sbatch') {
+            $executable->[0] = 'srun';
+        }
+        Genome::Sys->shellcmd(
+            cmd => [@$executable, @args],
+        );
+
+        return -1; #not a valid job ID.
+    } else {
+        my @output = Genome::Sys->capture(@$executable, @args);
+
+        my $job_id = ($output[-1] =~ /^Submitted batch job (\d+)/)[0];
+        unless ($job_id) {
+            die "Could not get job id from sbatch output!";
+        }
+
+        return $job_id;
+    }
+}
+
+sub sbatch {
+    return run('sbatch', @_);
+}
+
+sub args_builder {
+    my %args = _args(@_);
+    my $command = delete $args{cmd};
+    my $resource_string = delete $args{resource_string};
+
+    #remove LSF-specific flags with no equivalent
+    for my $skipped_key ('job_group', 'never_rerunnable') {
+        delete $args{$skipped_key};
+    }
+
+    my @args;
+    for my $flag (_flags()) {
+        if ($args{$flag}) {
+            push @args, _option_mapper($flag, \%args);
+        }
+        delete $args{$flag};
+    }
+    if (keys %args) {
+        push @args, map { _option_mapper($_, \%args), $args{$_} } sort keys %args;
+    }
+
+    if (ref($command) ne 'ARRAY') {
+        $command = [$command];
+    }
+
+    unless ($args{interactive}) {
+        my @propagate_conf;
+        if (defined $ENV{SLURM_CONF}) {
+            push @propagate_conf, 'SLURM_CONF="' . $ENV{SLURM_CONF} . '"';
+        }
+        $command = ['--wrap', join(' ', @propagate_conf, @$command)];
+    }
+
+    if ($resource_string) {
+        my $parsed = _parse_slurm_params($resource_string);
+        if (exists $parsed->{options}{partition}) {
+            push @args, '--partition', $parsed->{options}{partition};
+        }
+        if (exists $parsed->{options}{cpus}) {
+            push @args, '--cpus-per-task', $parsed->{options}{cpus};
+        }
+        if (exists $parsed->{options}{mem}) {
+            push @args, '--mem', $parsed->{options}{mem};
+        }
+    }
+
+    return (@args, @$command);
+}
+
+sub _args {
+    return Params::Validate::validate(@_, _args_spec());
+}
+
+sub _option_mapper {
+    my $arg = shift;
+    my $args_ref = shift;
+    my $spec = _args_spec();
+    if (not exists $spec->{$arg}{option_flag}) {
+        die qq(Could not find option flag for '$arg' in args spec);
+    }
+    my $flag = $spec->{$arg}{option_flag};
+    if (ref($flag) eq 'CODE') {
+        return $flag->($arg, $args_ref);
+    }
+    return $flag;
+}
+
+sub _flags {
+    my $spec = _args_spec();
+    return grep { $spec->{$_}{type} == BOOLEAN } sort keys %{$spec};
+}
+
+sub _args_spec {
+    return {
+        rerunnable => {
+            optional => 1,
+            type => BOOLEAN,
+            option_flag => '--requeue',
+        },
+        never_rerunnable => {
+            optional => 1,
+            type => BOOLEAN,
+            option_flag => sub { return () },
+        },
+        hold_job => {
+            optional => 1,
+            option_flag => '--hold',
+            type => BOOLEAN,
+        },
+        send_job_report => {
+            optional => 1,
+            option_flag => '--mail-type=END',
+            type => BOOLEAN,
+        },
+        queue => {
+            optional => 1,
+            option_flag => '--partition',
+            type => SCALAR,
+            callbacks => {
+                'valid SLURM partition' => \&_valid_slurm_partition,
+            },
+        },
+        project => {
+            optional => 1,
+            option_flag => '--comment',
+            type => SCALAR,
+        },
+        email => {
+            optional => 1,
+            option_flag => '--mail-user',
+            type => SCALAR,
+        },
+        err_file => {
+            optional => 1,
+            option_flag => '--error',
+            type => SCALAR,
+        },
+        log_file => {
+            optional => 1,
+            option_flag => '--output',
+            type => SCALAR,
+        },
+        job_group => {
+            optional => 1,
+            option_flag => sub { return () },
+            type => SCALAR,
+        },
+        user_group => {
+            optional => 1,
+            option_flag => '--account',
+            type => SCALAR,
+        },
+        job_name => {
+            optional => 1,
+            option_flag => '--job-name',
+            type => SCALAR,
+        },
+        depend_on => {
+            optional => 1,
+            option_flag => sub {
+                my ($arg, $args_ref) = @_;
+                my $lsf_dep = $args_ref->{depend_on};
+                my $slurm_dep = _translate_dependency($lsf_dep);
+                return ('--dependency', $slurm_dep);
+            },
+            type => SCALAR,
+        },
+        wait_for_completion => {
+            optional => 1,
+            option_flag => '--wait',
+            type => BOOLEAN,
+        },
+        interactive => {
+            optional => 1,
+            option_flag => '--pty',
+            type => BOOLEAN,
+        },
+        post_exec_cmd => {
+            optional => 1,
+            option_flag => '--epilog',
+            type => SCALAR,
+        },
+        cmd => {
+            type => SCALAR | ARRAYREF,
+        },
+        resource_string => {
+            optional => 1,
+            type => SCALAR,
+        },
+    };
+}
+
+sub _translate_dependency {
+    my $lsf_dep = shift;
+
+    my $slurm_dep = $lsf_dep;
+
+    $slurm_dep =~ s/ended\((\d+)\)/after:$1/g;
+    $slurm_dep =~ s/done\((\d+)\)/afterok:$1/g;
+    $slurm_dep =~ s/started\((\d+)\)/afterany:$1/g;
+    #there are other types of dependency that we're ignoring at the moment.
+
+    if($slurm_dep =~ m/\s*&&\s*/ or $slurm_dep =~ m/\s*\|\|\s*/) {
+        die 'complex LSF dependency translation not supported';
+    }
+
+    return $slurm_dep;
+}
+
+sub _parse_slurm_params {
+    my $resource_string = shift;
+
+    my %result = (options => {});
+
+    #We're going to ignore the '-R' in LSF resource strings here. The short options in the below
+    #match the parts we care about.
+    if ($resource_string =~ /-q\s+(\S+)/) {
+        $result{options}{partition} = $1;
+    }
+    if ($resource_string =~ /-n\s+(\d+)/) {
+        $result{options}{cpus} = $1;
+    }
+    if ($resource_string =~ /-M\s+(\S+)/) {
+        my $val = $1;
+        if ($val =~ /\d$/) {
+            $val .= 'K'; #memlimit in LSF defaulted to KB
+        }
+        $result{options}{mem} = $val;
+    }
+
+    return \%result;
+}
+
+sub _valid_slurm_partition {
+    my $requested_partition = shift;
+
+    system(qq(scontrol show partition $requested_partition 1> /dev/null 2>&1));
+    return $? == 0;
+}
+
+1;

--- a/lib/perl/Genome/Sys/SLURM/sbatch.pm
+++ b/lib/perl/Genome/Sys/SLURM/sbatch.pm
@@ -26,6 +26,8 @@ sub run {
     }
     local $ENV{LSB_SUB_ADDITIONAL} = $docker_image;
     local $ENV{PYXIS_CONTAINER_IMAGE} = $docker_image;
+    unshift @args,
+        '--container-image', $docker_image;
 
     if (!defined $ENV{LSF_DOCKER_PRESERVE_ENVIRONMENT} or $ENV{LSF_DOCKER_PRESERVE_ENVIRONMENT} eq 'true') {
         unshift @args,
@@ -42,8 +44,13 @@ sub run {
             $docker_volumes = $config_docker_volumes;
         }
     }
+
     local $ENV{LSF_DOCKER_VOLUMES} = $docker_volumes if $docker_volumes;
     local $ENV{PYXIS_CONTAINER_MOUNTS} = $docker_volumes if $docker_volumes;
+    if ($docker_volumes) {
+        unshift @args,
+            '--container-mounts', $docker_volumes;
+    }
 
     if (exists $args{interactive} and $args{interactive}) {
         if($executable->[0] eq 'sbatch') {

--- a/lib/perl/Genome/Sys/SLURM/sbatch.t
+++ b/lib/perl/Genome/Sys/SLURM/sbatch.t
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+
+use above 'Test::More';
+use Test::Builder;
+use Test::Fatal qw(exception);
+use Genome::Sys::SLURM::sbatch qw();
+
+if( Genome::Config::get('job_dispatch_backend') ne 'slurm' ) {
+    plan skip_all => 'These tests only work on slurm';
+} else {
+    plan tests => 11;
+}
+
+my $fake_partition = 'fake_partition';
+my @partitions = (map { Genome::Config::get($_) } qw(lsf_queue_build_worker lsf_queue_short));
+
+ok( !Genome::Sys::SLURM::sbatch::_valid_slurm_partition($fake_partition),
+    qq('$fake_partition' is not a valid partition));
+
+ok( Genome::Sys::SLURM::sbatch::_valid_slurm_partition($partitions[0]),
+    qq('$partitions[0]' is a valid partition'));
+
+like( exception { Genome::Sys::SLURM::sbatch::_args(queue => $fake_partition, cmd => 'true') },
+    qr/valid SLURM partition/,
+    qq('$fake_partition' triggered exception));
+
+is( exception { Genome::Sys::SLURM::sbatch::_args(queue => $partitions[0], cmd => 'true') },
+    undef,
+    qq('$partitions[0]' did not trigger exception));
+
+do {
+    my $_option_mapper = \&Genome::Sys::SLURM::sbatch::_option_mapper;
+    no warnings 'redefine';
+    local *Genome::Sys::SLURM::sbatch::_option_mapper = sub {
+        my $option = $_option_mapper->(@_);
+        $option =~ s/^--/-s:/;
+        return $option;
+    };
+    is( Genome::Sys::SLURM::sbatch::_option_mapper('project'),
+        '-s:comment',
+        q('project' arg maps to '-s:comment' option with _option_mapper overridden));
+};
+
+is( Genome::Sys::SLURM::sbatch::_option_mapper('project'),
+    '--comment',
+    q('project' arg maps to '--comment' option));
+
+my @cases = (
+    [
+        [
+            email => 'nnutter@genome.wustl.edu',
+            cmd => 'true',
+        ], [qw(--mail-user nnutter@genome.wustl.edu --wrap true)], 'single option',
+    ],[
+        [
+            email => 'nnutter@genome.wustl.edu',
+            project => 'HighPriority',
+            cmd => 'true',
+        ], [qw(--mail-user nnutter@genome.wustl.edu --comment HighPriority --wrap true)], 'multiple options',
+    ],[
+        [
+            hold_job => 0,
+            cmd => 'true',
+        ], [qw(--wrap true)], 'disabled flag',
+    ],[
+        [
+            hold_job => 1,
+            cmd => 'true',
+        ], [qw(--hold --wrap true)], 'enabled flag',
+    ],
+    [
+        [
+            job_group => '/genome/test',
+            user_group => 'compute-test',
+            cmd => 'true',
+        ], [qw(--account compute-test --wrap true)], 'job group ignored, user group mapped to account',
+    ]
+);
+for my $case (@cases) {
+    my @input = @{$case->[0]};
+    my $expected = $case->[1];
+    my $name = $case->[2];
+    my $got = [Genome::Sys::SLURM::sbatch::args_builder(@input)];
+    is_deeply($got, $expected, $name);
+}


### PR DESCRIPTION
The new compute cluster uses slurm instead of LSF, so we need to be able to submit jobs there instead.